### PR TITLE
ci: unbreak the checks on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,9 @@ jobs:
         with:
           tool: cargo-nextest
       - run: cargo build --workspace --all-targets --locked
-      - run: cargo nextest run --workspace --all-targets --locked
+      # The workspace has no tests yet, and nextest treats that as an error by
+      # default. The flag comes back out with the first real test in B0.
+      - run: cargo nextest run --workspace --all-targets --locked --no-tests=pass
       - run: cargo test --workspace --doc --locked
 
   msrv:
@@ -135,7 +137,7 @@ jobs:
       - uses: taiki-e/install-action@e67fa11c4b9316fa714ddf0abed07a0c3143b95b # v2.87.4
         with:
           tool: cargo-llvm-cov,cargo-nextest
-      - run: cargo llvm-cov nextest --workspace --locked --lcov --output-path lcov.info
+      - run: cargo llvm-cov nextest --workspace --locked --no-tests=pass --lcov --output-path lcov.info
       - run: cargo llvm-cov report --summary-only >> "$GITHUB_STEP_SUMMARY"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -64,6 +64,11 @@ jobs:
           fail-on-severity: moderate
           license-check: true
           allow-licenses: Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause, ISC, Unicode-3.0, Zlib, MPL-2.0, CC0-1.0, BSL-1.0
+          # The licence check is about what ends up in the artifacts we publish. A
+          # GitHub Action runs on a build machine and nothing it contains is linked
+          # into anything we ship, so its licence is not the same question. This
+          # cache action is LGPL-3.0 and that is fine where it sits.
+          allow-dependencies-licenses: pkg:githubactions/Swatinem/rust-cache
 
   codeql:
     name: CodeQL

--- a/deny.toml
+++ b/deny.toml
@@ -31,6 +31,14 @@ allow = [
   "Zlib",
 ]
 
+# webpki-roots is the Mozilla root certificate store. What it ships is data rather
+# than code, and CDLA-Permissive-2.0 is a data licence, which is why it is not in
+# the general allow list. Scoping the exception to the one crate means a future
+# dependency under the same licence still has to be looked at by a person.
+[[licenses.exceptions]]
+name = "webpki-roots"
+allow = ["CDLA-Permissive-2.0"]
+
 # The harness itself must not link anything under a strong copyleft licence.
 # Systems under test are a different matter: they run in their own processes,
 # and a GPL licensed database is perfectly fine to benchmark.


### PR DESCRIPTION
Three failures on main, all from the scaffold.

**nextest treats an empty workspace as an error.** There are no tests yet, so `cargo nextest run` exits 4 with "no tests to run" on every platform. Passing `--no-tests=pass` for now, with a comment saying the flag comes back out with the first real test in B0. Adding a fake test to make the runner happy would have been worse.

**cargo-deny rejected the Mozilla root certificate store.** `webpki-roots` arrives through `ureq`, which the corpus fetcher needs, and it ships under CDLA-Permissive-2.0. That is a data licence rather than a code licence, which is why it is not in the general allow list and should not be.

The exception is scoped to that one crate rather than adding the licence to the allow list. If some other dependency turns up under the same terms later, it still has to be looked at by a person, which is the point.

**Dependency review rejected a GitHub Action.** `Swatinem/rust-cache` is LGPL-3.0. The licence check is about what ends up in the artifacts we publish, and an action runs on a build machine with nothing of it linked into anything we ship, so its licence is not the same question as a crate's. `allow-dependencies-licenses` names that one action rather than switching the check off.

Also worth recording, since it will come up again: the same run warned about two versions of `base64` in the tree. That is a warning rather than an error here on purpose, because a benchmark harness pulls in several client libraries and forcing them onto one version is not a fight worth having.
