### PR TITLE
The timing loop, the repetition model and the interval

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,15 +112,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
-name = "approx"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "arrayvec"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,7 +143,7 @@ checksum = "097d193003ce7995d5d087089069ec2a6e0187faf5a6f8c9f38af2645d987182"
 dependencies = [
  "bytes",
  "half",
- "num-bigint 0.5.1",
+ "num-bigint",
  "num-traits",
 ]
 
@@ -211,12 +202,6 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base64"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "base64"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
@@ -225,11 +210,8 @@ checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 name = "bench-core"
 version = "0.0.0"
 dependencies = [
- "hdrhistogram",
  "serde",
- "statrs",
  "thiserror",
- "ulid",
 ]
 
 [[package]]
@@ -352,18 +334,6 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
-
-[[package]]
-name = "bytemuck"
-version = "1.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -524,21 +494,6 @@ checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crossterm"
@@ -708,30 +663,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "glam"
-version = "0.30.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19fc433e8437a212d1b6f1e68c7824af3aed907da60afa994e7f542d18d12aa9"
-
-[[package]]
-name = "glam"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556f6b2ea90b8d15a74e0e7bb41671c9bdf38cd9f78c284d750b9ce58a2b5be7"
-
-[[package]]
-name = "glam"
-version = "0.32.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f70749695b063ecbf6b62949ccccde2e733ec3ecbbd71d467dca4e5c6c97cca0"
-
-[[package]]
-name = "glam"
-version = "0.33.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21fef0953c54fd3de2f44b743fbf77e044c81a25faee03636dfccc0d35135e23"
-
-[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -748,20 +679,6 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
-
-[[package]]
-name = "hdrhistogram"
-version = "7.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49d1053f4708f0af3cf9fc5bffc7e68a914a3c45becb231c80068c9c3f78bea"
-dependencies = [
- "base64 0.22.1",
- "byteorder",
- "crossbeam-channel",
- "flate2",
- "nom",
- "num-traits",
-]
 
 [[package]]
 name = "heck"
@@ -936,16 +853,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matrixmultiply"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f607c237553f086e7043417a51df26b2eb899d3caff94e6a67592ff992fedc7"
-dependencies = [
- "autocfg",
- "rawpointer",
-]
-
-[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -959,35 +866,6 @@ checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
 dependencies = [
  "adler2",
  "simd-adler32",
-]
-
-[[package]]
-name = "nalgebra"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc43a60c217b0c6ff46e47f26911015ad8d2e5a8be1af668c67e370d99a4346"
-dependencies = [
- "approx",
- "glam 0.30.10",
- "glam 0.31.1",
- "glam 0.32.1",
- "glam 0.33.6",
- "matrixmultiply",
- "num-complex",
- "num-rational",
- "num-traits",
- "rand",
- "simba",
- "typenum",
-]
-
-[[package]]
-name = "nom"
-version = "8.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -1006,16 +884,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
-dependencies = [
- "num-integer",
- "num-traits",
 ]
 
 [[package]]
@@ -1043,17 +911,6 @@ version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint 0.4.8",
- "num-integer",
  "num-traits",
 ]
 
@@ -1172,7 +1029,7 @@ dependencies = [
  "arrow-ipc",
  "arrow-schema",
  "arrow-select",
- "base64 0.23.1",
+ "base64",
  "brotli",
  "bytes",
  "chrono",
@@ -1180,7 +1037,7 @@ dependencies = [
  "half",
  "hashbrown",
  "lz4_flex",
- "num-bigint 0.5.1",
+ "num-bigint",
  "num-integer",
  "num-traits",
  "seq-macro",
@@ -1273,12 +1130,6 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
-
-[[package]]
-name = "rawpointer"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "redox_syscall"
@@ -1384,15 +1235,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
-name = "safe_arch"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42c6efa15875e6ecb39ca61fb0b0c1a40b84fac5a5ffe71eef7d1000c8eb3f5f"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1474,18 +1316,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
-name = "simba"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a7200d82ff1c7b4235efd12f11e2537a402c91cf83a5cb97ce80eef787fde7"
-dependencies = [
- "approx",
- "num-complex",
- "num-traits",
- "wide",
-]
-
-[[package]]
 name = "simd-adler32"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1514,19 +1344,6 @@ name = "snap"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "199905e6153d6405f9728fe44daace35f8f837bbf830bb6e85fbd5828709a886"
-
-[[package]]
-name = "statrs"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1837f9a1bd13dabbdbb04489c39451482d3cdd35a6e1a0d0f3570dea2b8c8be"
-dependencies = [
- "approx",
- "nalgebra",
- "num-traits",
- "rand",
- "thiserror",
-]
 
 [[package]]
 name = "strsim"
@@ -1743,22 +1560,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5283634e518fe9e82c7b20520bb4bc209009fd16c82077c802f8111ecbb0117a"
 
 [[package]]
-name = "typenum"
-version = "1.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
-
-[[package]]
-name = "ulid"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "947dde63b6d514cc5e044edad4e0ca7261afd1099d16c83d942cb2b2f348689c"
-dependencies = [
- "rand",
- "web-time",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1788,7 +1589,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
 dependencies = [
- "base64 0.23.1",
+ "base64",
  "flate2",
  "log",
  "percent-encoding",
@@ -1805,7 +1606,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613"
 dependencies = [
- "base64 0.23.1",
+ "base64",
  "http",
  "httparse",
  "log",
@@ -1906,32 +1707,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "webpki-roots"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
-]
-
-[[package]]
-name = "wide"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf05ca94c9fba0c51316899caa1d1e74a064fc310a5efa7375e614343d415be"
-dependencies = [
- "bytemuck",
- "safe_arch",
 ]
 
 [[package]]

--- a/crates/bench-core/Cargo.toml
+++ b/crates/bench-core/Cargo.toml
@@ -14,11 +14,8 @@ readme.workspace = true
 publish.workspace = true
 
 [dependencies]
-hdrhistogram.workspace = true
 serde.workspace = true
-statrs.workspace = true
 thiserror.workspace = true
-ulid.workspace = true
 
 [lints]
 workspace = true

--- a/crates/bench-core/src/lib.rs
+++ b/crates/bench-core/src/lib.rs
@@ -5,8 +5,45 @@
 //! result is written as. Keeping benchmarks out of it is what lets the timing
 //! code be reviewed in one sitting.
 //!
-//! Nothing is implemented yet. See the milestone that owns this crate in
-//! `docs/ROADMAP.md`.
+//! # How a measurement is taken
+//!
+//! A pilot runs a small balanced design across builds, processes and iterations. [`Pilot::decompose`]
+//! splits the variance across those three levels and [`plan`] spends the repetition budget at the
+//! level that carries it. Then [`Timing::run`] collects samples until the confidence interval on
+//! the median is narrow enough, and [`summarise`] produces the row.
+//!
+//! ```
+//! use bench_core::{Bootstrap, Stop, Timing};
+//!
+//! let timing = Timing {
+//!     warmup: 2,
+//!     stop: Stop::After { samples: 32 },
+//!     check_every: 1,
+//!     bootstrap: Bootstrap::default(),
+//! };
+//!
+//! // A workload that always takes the same time, so the example has a predictable answer.
+//! let series = timing.run(|| 1_000.0);
+//! let summary = series.summary().expect("32 samples is not nothing");
+//!
+//! assert_eq!(summary.n, 32);
+//! assert!((summary.median - 1_000.0).abs() < f64::EPSILON);
+//! ```
+//!
+//! # The one rule worth reading the source for
+//!
+//! [`Stop::should_stop`] is handed the series being measured and nothing else. It cannot see a
+//! baseline or a rival, because adding repetitions until a comparison turns significant is how a
+//! result gets manufactured, and the defence against that is not having the comparison in scope at
+//! the point where the decision is made.
+
+mod measure;
+mod repetition;
+mod stats;
+
+pub use measure::{Series, Stop, Timing, time};
+pub use repetition::{Components, Level, Pilot, Plan, plan};
+pub use stats::{Bootstrap, Summary, summarise};
 
 /// Bumped whenever the way a measurement is taken changes.
 ///
@@ -14,3 +51,29 @@
 /// running across it, because otherwise a change of method shows up as a
 /// regression in whichever system happened to be measured next.
 pub const METHODOLOGY_VERSION: u32 = 1;
+
+/// What can go wrong before a measurement is even summarised.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum Error {
+    /// A pilot ran too few repetitions at some level to say anything about it.
+    #[error(
+        "a pilot needs at least two repetitions at every level, got {builds} builds, {processes} processes and {iterations} iterations"
+    )]
+    PilotTooSmall {
+        /// How many builds the pilot ran.
+        builds: usize,
+        /// How many processes per build.
+        processes: usize,
+        /// How many iterations per process.
+        iterations: usize,
+    },
+    /// A pilot design was ragged.
+    #[error(
+        "a pilot design has to be balanced, so that the variance decomposition is arithmetic a reader can check"
+    )]
+    Unbalanced,
+    /// A sample was not a finite number.
+    #[error("a sample was not a finite number, which means the clock or the harness is broken")]
+    NotFinite,
+}

--- a/crates/bench-core/src/measure.rs
+++ b/crates/bench-core/src/measure.rs
@@ -180,7 +180,7 @@ impl Timing {
         let mut series = Series::new(self.bootstrap);
         loop {
             series.push(body());
-            if series.len() % every == 0 && self.stop.should_stop(&series) {
+            if series.len().is_multiple_of(every) && self.stop.should_stop(&series) {
                 return series;
             }
         }

--- a/crates/bench-core/src/measure.rs
+++ b/crates/bench-core/src/measure.rs
@@ -1,0 +1,201 @@
+//! The timing loop and the rule that decides when to stop.
+//!
+//! There is one thing in this file that matters more than the rest of it. The stopping rule is
+//! handed the series being measured and nothing else. It cannot see a rival, a baseline, or a
+//! previous run, because the signature does not let it.
+//!
+//! That is deliberate. Adding repetitions until a comparison becomes significant is how a result
+//! gets manufactured, and it does not feel like cheating while you are doing it: you are just
+//! collecting more data, and more data is good. The defence against it is not discipline, it is not
+//! having the number available at the point where the decision is made.
+
+use std::hint::black_box;
+use std::time::Instant;
+
+use serde::{Deserialize, Serialize};
+
+use crate::stats::{Bootstrap, Summary, summarise};
+
+/// A series of measurements of one thing, in nanoseconds.
+#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
+pub struct Series {
+    samples: Vec<f64>,
+    bootstrap: Bootstrap,
+}
+
+impl Series {
+    /// An empty series that will be summarised with `bootstrap`.
+    #[must_use]
+    pub const fn new(bootstrap: Bootstrap) -> Self {
+        Self {
+            samples: Vec::new(),
+            bootstrap,
+        }
+    }
+
+    /// Adds a sample.
+    pub fn push(&mut self, nanos: f64) {
+        self.samples.push(nanos);
+    }
+
+    /// How many samples there are.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.samples.len()
+    }
+
+    /// Whether there are no samples.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.samples.is_empty()
+    }
+
+    /// The samples, in the order they were taken.
+    #[must_use]
+    pub fn samples(&self) -> &[f64] {
+        &self.samples
+    }
+
+    /// The summary, or `None` if nothing has been measured.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a sample is not finite. See [`summarise`].
+    #[must_use]
+    pub fn summary(&self) -> Option<Summary> {
+        summarise(&self.samples, self.bootstrap)
+    }
+}
+
+/// When to stop collecting.
+///
+/// Every variant is a question about one series. There is no variant that takes a second series,
+/// and there is no way to add one from outside this crate.
+#[derive(Clone, Copy, PartialEq, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", tag = "kind")]
+#[non_exhaustive]
+pub enum Stop {
+    /// Take exactly this many samples. Simple, and the right choice when the run has a time budget
+    /// rather than a precision target.
+    After {
+        /// How many.
+        samples: u32,
+    },
+    /// Keep going until the confidence interval on the median is narrow enough.
+    ///
+    /// This is the rule the methodology asks for. The target is a property of the series on its
+    /// own, so it is reached at the same point whatever else is being measured that day.
+    IntervalWidth {
+        /// Stop once the interval width divided by the median is at or below this.
+        target: f64,
+        /// Never stop before this many samples, however narrow the interval looks. An interval
+        /// computed from four samples is narrow because there is nothing in it to be wide.
+        min: u32,
+        /// Always stop at this many, so a workload whose variance never settles ends the run
+        /// instead of ending the day.
+        max: u32,
+    },
+}
+
+impl Stop {
+    /// Whether to stop, given everything collected so far and nothing else.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a sample is not finite. See [`summarise`].
+    #[must_use]
+    pub fn should_stop(self, series: &Series) -> bool {
+        match self {
+            Self::After { samples } => series.len() as u64 >= u64::from(samples),
+            Self::IntervalWidth { target, min, max } => {
+                let n = series.len() as u64;
+                if n < u64::from(min) {
+                    return false;
+                }
+                if n >= u64::from(max) {
+                    return true;
+                }
+                series
+                    .summary()
+                    .is_some_and(|s| s.relative_width() <= target)
+            }
+        }
+    }
+}
+
+/// The timing loop.
+#[derive(Clone, Copy, PartialEq, Debug, Serialize, Deserialize)]
+pub struct Timing {
+    /// How many times to run the workload before anything is recorded.
+    ///
+    /// The first run of anything pays for cold caches, lazy binding and a cold branch predictor.
+    /// Those are real costs and they are worth measuring, but they are a different measurement and
+    /// mixing them into this one just makes this one noisier.
+    pub warmup: u32,
+    /// When to stop.
+    pub stop: Stop,
+    /// How often to ask the stopping rule, in samples.
+    ///
+    /// Asking after every single sample is not wrong, it is just wasteful: a bootstrap over the
+    /// whole series is not free and one more sample rarely moves the interval enough to change the
+    /// answer. A run therefore ends at a multiple of this, which is worth knowing when reading a
+    /// sample count back.
+    pub check_every: u32,
+    /// How the interval is computed.
+    pub bootstrap: Bootstrap,
+}
+
+impl Default for Timing {
+    fn default() -> Self {
+        Self {
+            warmup: 5,
+            stop: Stop::IntervalWidth {
+                target: 0.02,
+                min: 20,
+                max: 500,
+            },
+            check_every: 8,
+            bootstrap: Bootstrap::default(),
+        }
+    }
+}
+
+impl Timing {
+    /// Runs `body` until the stopping rule says to stop, and returns what was measured.
+    ///
+    /// `body` is called once per sample and returns the elapsed nanoseconds for that sample. Use
+    /// [`time`] inside it, or return a number from somewhere else if the workload times itself.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a sample is not finite. See [`summarise`].
+    pub fn run<F>(&self, mut body: F) -> Series
+    where
+        F: FnMut() -> f64,
+    {
+        for _ in 0..self.warmup {
+            black_box(body());
+        }
+        let every = self.check_every.max(1) as usize;
+        let mut series = Series::new(self.bootstrap);
+        loop {
+            series.push(body());
+            if series.len() % every == 0 && self.stop.should_stop(&series) {
+                return series;
+            }
+        }
+    }
+}
+
+/// Times one call and returns its result along with the elapsed nanoseconds.
+///
+/// The result comes back through `black_box` so that a workload whose output is thrown away does
+/// not get optimised into nothing, which is the classic way to measure a very fast empty loop and
+/// publish it as a very fast implementation.
+pub fn time<T, F: FnOnce() -> T>(f: F) -> (T, f64) {
+    let start = Instant::now();
+    let out = black_box(f());
+    // `as_secs_f64` rather than `as_nanos`, because the second one needs a cast from u128 that
+    // loses precision on paper and buys nothing here.
+    (out, start.elapsed().as_secs_f64() * 1e9)
+}

--- a/crates/bench-core/src/repetition.rs
+++ b/crates/bench-core/src/repetition.rs
@@ -1,0 +1,279 @@
+//! Where to spend the repetition budget.
+//!
+//! The contribution in Kalibera and Jones is not "run it more times". It is that the variance in a
+//! measurement lives at a particular level, and repetitions are only worth anything at the level
+//! that carries it. Running one process a thousand times when the variance is between processes
+//! produces a very tight confidence interval around the wrong number, and the tightness of that
+//! interval is what makes it convincing.
+//!
+//! So a pilot runs a small balanced design across all three levels, the variance is decomposed, and
+//! the budget goes where the variance is.
+
+use serde::{Deserialize, Serialize};
+
+use crate::Error;
+
+/// The three levels a repetition can happen at.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Level {
+    /// Rebuild the binary. Link order and layout change, and Mytkowicz and colleagues showed that
+    /// moves a measurement by more than most reported effects.
+    Build,
+    /// Start the process again. Address space layout, allocator state and page placement change.
+    Process,
+    /// Run the workload again inside the same process.
+    Iteration,
+}
+
+impl core::fmt::Display for Level {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(match self {
+            Self::Build => "build",
+            Self::Process => "process",
+            Self::Iteration => "iteration",
+        })
+    }
+}
+
+/// The result of a pilot: a balanced set of samples across all three levels.
+///
+/// Balanced means every build ran the same number of processes and every process ran the same
+/// number of iterations. An unbalanced design can still be decomposed, but the arithmetic stops
+/// being something a reader can check by hand, and this crate would rather refuse than be the only
+/// thing that knows whether the numbers are right.
+#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
+pub struct Pilot {
+    samples: Vec<Vec<Vec<f64>>>,
+}
+
+impl Pilot {
+    /// Wraps a set of pilot samples indexed as `[build][process][iteration]`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Unbalanced`] if the design is ragged, or [`Error::PilotTooSmall`] if any
+    /// level has fewer than two repetitions. Two is the minimum that says anything about a level:
+    /// with one, that level's variance is not unmeasured, it is unmeasurable, and reporting it as
+    /// zero would be a guess dressed as a result.
+    pub fn new(samples: Vec<Vec<Vec<f64>>>) -> Result<Self, Error> {
+        let builds = samples.len();
+        let processes = samples.first().map_or(0, Vec::len);
+        let iterations = samples.first().and_then(|b| b.first()).map_or(0, Vec::len);
+
+        if builds < 2 || processes < 2 || iterations < 2 {
+            return Err(Error::PilotTooSmall {
+                builds,
+                processes,
+                iterations,
+            });
+        }
+        if samples.iter().any(|b| b.len() != processes)
+            || samples.iter().flatten().any(|p| p.len() != iterations)
+        {
+            return Err(Error::Unbalanced);
+        }
+        if samples.iter().flatten().flatten().any(|s| !s.is_finite()) {
+            return Err(Error::NotFinite);
+        }
+        Ok(Self { samples })
+    }
+
+    /// How many builds the pilot ran.
+    #[must_use]
+    pub fn builds(&self) -> usize {
+        self.samples.len()
+    }
+
+    /// How many processes per build.
+    #[must_use]
+    pub fn processes(&self) -> usize {
+        self.samples[0].len()
+    }
+
+    /// How many iterations per process.
+    #[must_use]
+    pub fn iterations(&self) -> usize {
+        self.samples[0][0].len()
+    }
+
+    /// Splits the variance across the three levels.
+    ///
+    /// This is the standard nested random effects decomposition. Each level's component is the
+    /// mean square at that level minus the mean square at the level below, divided by how many
+    /// measurements sit under one unit of it. A component that comes out negative is noise around
+    /// zero and is reported as zero.
+    #[must_use]
+    pub fn decompose(&self) -> Components {
+        // Pilot designs are a handful of repetitions at each level. Every cast below is of a count
+        // in the low tens.
+        #[allow(clippy::cast_precision_loss)]
+        let (n1, n2, n3) = (
+            self.builds() as f64,
+            self.processes() as f64,
+            self.iterations() as f64,
+        );
+
+        let all: Vec<f64> = self.samples.iter().flatten().flatten().copied().collect();
+        #[allow(clippy::cast_precision_loss)]
+        let grand = all.iter().sum::<f64>() / all.len() as f64;
+
+        let build_means: Vec<f64> = self
+            .samples
+            .iter()
+            .map(|b| mean(&b.iter().flatten().copied().collect::<Vec<_>>()))
+            .collect();
+        let process_means: Vec<Vec<f64>> = self
+            .samples
+            .iter()
+            .map(|b| b.iter().map(|p| mean(p)).collect())
+            .collect();
+
+        // Written as loops rather than as iterator chains so that the three sums of squares sit
+        // next to each other and can be checked against a textbook without unpicking anything.
+        let mut ss_build = 0.0;
+        let mut ss_process = 0.0;
+        let mut ss_iteration = 0.0;
+        for (i, build) in self.samples.iter().enumerate() {
+            ss_build += (build_means[i] - grand).powi(2);
+            for (j, process) in build.iter().enumerate() {
+                ss_process += (process_means[i][j] - build_means[i]).powi(2);
+                for sample in process {
+                    ss_iteration += (sample - process_means[i][j]).powi(2);
+                }
+            }
+        }
+        ss_build *= n2 * n3;
+        ss_process *= n3;
+
+        let ms_build = ss_build / (n1 - 1.0);
+        let ms_process = ss_process / (n1 * (n2 - 1.0));
+        let ms_iteration = ss_iteration / (n1 * n2 * (n3 - 1.0));
+
+        Components {
+            build: ((ms_build - ms_process) / (n2 * n3)).max(0.0),
+            process: ((ms_process - ms_iteration) / n3).max(0.0),
+            iteration: ms_iteration.max(0.0),
+        }
+    }
+}
+
+fn mean(xs: &[f64]) -> f64 {
+    // Called on pilot cells, which hold a handful of samples each.
+    #[allow(clippy::cast_precision_loss)]
+    let n = xs.len() as f64;
+    xs.iter().sum::<f64>() / n
+}
+
+/// How much of the variance sits at each level.
+///
+/// The units are the square of whatever the samples were in, so these are only meaningful next to
+/// each other. [`Components::share`] is usually the more useful view.
+#[derive(Clone, Copy, PartialEq, Debug, Serialize, Deserialize)]
+pub struct Components {
+    /// Variance between builds of the same source.
+    pub build: f64,
+    /// Variance between runs of the same binary.
+    pub process: f64,
+    /// Variance between iterations inside one process.
+    pub iteration: f64,
+}
+
+impl Components {
+    /// The sum of the three.
+    #[must_use]
+    pub fn total(&self) -> f64 {
+        self.build + self.process + self.iteration
+    }
+
+    /// What fraction of the variance sits at a level, in `0.0 ..= 1.0`.
+    #[must_use]
+    pub fn share(&self, level: Level) -> f64 {
+        let total = self.total();
+        if total <= 0.0 {
+            return 0.0;
+        }
+        self.at(level) / total
+    }
+
+    /// The component at one level.
+    #[must_use]
+    pub fn at(&self, level: Level) -> f64 {
+        match level {
+            Level::Build => self.build,
+            Level::Process => self.process,
+            Level::Iteration => self.iteration,
+        }
+    }
+
+    /// The level carrying the most variance.
+    ///
+    /// Ties go to the cheaper level, because when two levels look the same the honest reading is
+    /// that the pilot could not tell them apart, and spending the budget on rebuilds in that case
+    /// buys nothing.
+    #[must_use]
+    pub fn dominant(&self) -> Level {
+        if self.build > self.process && self.build > self.iteration {
+            Level::Build
+        } else if self.process > self.iteration {
+            Level::Process
+        } else {
+            Level::Iteration
+        }
+    }
+}
+
+/// How many repetitions to run at each level.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Serialize, Deserialize)]
+pub struct Plan {
+    /// How many times to build.
+    pub builds: u32,
+    /// How many processes to start per build.
+    pub processes: u32,
+    /// How many iterations to run per process.
+    pub iterations: u32,
+}
+
+impl Plan {
+    /// How many measurements the plan produces in total.
+    #[must_use]
+    pub fn total(&self) -> u32 {
+        self.builds
+            .saturating_mul(self.processes)
+            .saturating_mul(self.iterations)
+    }
+}
+
+/// How many repetitions to keep at a level the pilot says carries almost no variance.
+///
+/// Two and not one. One gives no way to notice later that the level started carrying variance after
+/// all, which happens the first time somebody changes a compiler flag. Going above two spends
+/// budget on a level a pilot has already ruled out.
+const SETTLED: u32 = 2;
+
+/// Turns a budget and a dominant level into a plan.
+///
+/// The budget is a total number of measurements. The two levels that are not dominant get two
+/// repetitions each and everything left goes to the level that carries the variance.
+#[must_use]
+pub fn plan(budget: u32, dominant: Level) -> Plan {
+    let budget = budget.max(SETTLED * SETTLED * SETTLED);
+    let rest = (budget / (SETTLED * SETTLED)).max(SETTLED);
+    match dominant {
+        Level::Iteration => Plan {
+            builds: SETTLED,
+            processes: SETTLED,
+            iterations: rest,
+        },
+        Level::Process => Plan {
+            builds: SETTLED,
+            processes: rest,
+            iterations: SETTLED,
+        },
+        Level::Build => Plan {
+            builds: rest,
+            processes: SETTLED,
+            iterations: SETTLED,
+        },
+    }
+}

--- a/crates/bench-core/src/stats.rs
+++ b/crates/bench-core/src/stats.rs
@@ -1,0 +1,217 @@
+//! Summarising a series of measurements.
+//!
+//! The headline statistic here is the median with a percentile bootstrap confidence interval. The
+//! mean is not the headline because one descheduling event drags it and nothing drags it back. The
+//! minimum is carried as its own column rather than folded into anything, because the minimum is a
+//! statistic about the luckiest run and printing it where a reader expects a typical value is the
+//! most common quiet distortion in this field.
+
+use serde::{Deserialize, Serialize};
+
+/// How a bootstrap interval is computed.
+///
+/// The seed is part of the configuration rather than taken from the clock, so summarising the same
+/// samples twice gives the same interval. That matters more than it sounds: the adaptive stopping
+/// rule is keyed on the width of this interval, and a rule built on a number that moves on its own
+/// would stop at a different place every run.
+#[derive(Clone, Copy, PartialEq, Debug, Serialize, Deserialize)]
+pub struct Bootstrap {
+    /// How many resamples to draw.
+    ///
+    /// Two thousand, not the ten thousand people reach for out of habit. Ten thousand is the right
+    /// number for a percentile of a tail; for an interval on a median it moves the endpoints by
+    /// less than the measurement noise they describe, and the adaptive stopping rule pays this cost
+    /// repeatedly while a run is in progress.
+    pub resamples: u32,
+    /// The interval to report, as a fraction. 0.95 gives a 95% interval.
+    pub confidence: f64,
+    /// The seed for the resampling.
+    pub seed: u64,
+}
+
+impl Default for Bootstrap {
+    fn default() -> Self {
+        Self {
+            resamples: 2_000,
+            confidence: 0.95,
+            seed: 0x2545_f491_4f6c_dd1d,
+        }
+    }
+}
+
+/// What a series of measurements came to.
+#[derive(Clone, Copy, PartialEq, Debug, Serialize, Deserialize)]
+pub struct Summary {
+    /// How many samples went into this.
+    pub n: usize,
+    /// The headline number.
+    pub median: f64,
+    /// Carried because it is what everyone else reports, not because it is the better statistic.
+    pub mean: f64,
+    /// The luckiest run. Its own column on purpose. See the note at the top of this file.
+    pub min: f64,
+    /// The unluckiest run. Useful mostly for spotting that something else was on the machine.
+    pub max: f64,
+    /// The low end of the confidence interval on the median.
+    pub lo: f64,
+    /// The high end of the confidence interval on the median.
+    pub hi: f64,
+    /// Which interval `lo` and `hi` describe, copied from the [`Bootstrap`] settings so a row is
+    /// readable without them.
+    pub confidence: f64,
+}
+
+impl Summary {
+    /// The width of the interval as a fraction of the median.
+    ///
+    /// This is the number the adaptive stopping rule is keyed on. It is a property of one series
+    /// and says nothing about any other series, which is the entire point.
+    #[must_use]
+    pub fn relative_width(&self) -> f64 {
+        if self.median.abs() < f64::EPSILON {
+            return f64::INFINITY;
+        }
+        (self.hi - self.lo) / self.median
+    }
+}
+
+/// Summarises a series.
+///
+/// Returns `None` for an empty series, because there is no honest summary of nothing.
+///
+/// # Panics
+///
+/// Panics if a sample is not a number. A NaN in a timing series means the clock or the harness is
+/// broken, and carrying on past that would put a made up number in a published table.
+#[must_use]
+pub fn summarise(samples: &[f64], boot: Bootstrap) -> Option<Summary> {
+    if samples.is_empty() {
+        return None;
+    }
+    assert!(
+        samples.iter().all(|s| s.is_finite()),
+        "a timing sample was not a finite number, which means the clock or the harness is broken"
+    );
+
+    let mut sorted = samples.to_vec();
+    sorted.sort_by(f64::total_cmp);
+
+    // Sample counts here are in the hundreds. The cast is exact for anything under 2^53, which a
+    // repetition count will never approach.
+    #[allow(clippy::cast_precision_loss)]
+    let mean = samples.iter().sum::<f64>() / samples.len() as f64;
+
+    let (lo, hi) = bootstrap_median(&sorted, boot);
+
+    Some(Summary {
+        n: sorted.len(),
+        median: median_of_sorted(&sorted),
+        mean,
+        min: sorted[0],
+        max: sorted[sorted.len() - 1],
+        lo,
+        hi,
+        confidence: boot.confidence,
+    })
+}
+
+/// The median of an unsorted, non-empty slice, without sorting it.
+///
+/// The stopping rule asks for a summary while a run is in progress, so this runs thousands of times
+/// per check. Selecting the middle element is linear where sorting is not, and the resample is
+/// scratch space nobody looks at afterwards.
+fn median_by_selection(draw: &mut [f64]) -> f64 {
+    let n = draw.len();
+    let (below, mid, _) = draw.select_nth_unstable_by(n / 2, f64::total_cmp);
+    if n.is_multiple_of(2) {
+        // Everything in `below` is at or under `mid`, so the largest of them is the other middle
+        // element.
+        let lower = below.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+        f64::midpoint(lower, *mid)
+    } else {
+        *mid
+    }
+}
+
+/// The median of an already sorted, non-empty slice.
+fn median_of_sorted(sorted: &[f64]) -> f64 {
+    let n = sorted.len();
+    if n.is_multiple_of(2) {
+        f64::midpoint(sorted[n / 2 - 1], sorted[n / 2])
+    } else {
+        sorted[n / 2]
+    }
+}
+
+/// The percentile bootstrap. Resample with replacement, take the median of each resample, and read
+/// the interval off the distribution of those medians.
+fn bootstrap_median(sorted: &[f64], boot: Bootstrap) -> (f64, f64) {
+    let n = sorted.len();
+    if n == 1 || boot.resamples == 0 {
+        // One sample says nothing about its own spread, and saying so with a zero width interval
+        // would be a lie. The interval is the sample itself, and `n` in the row is what tells a
+        // reader not to trust it.
+        return (sorted[0], sorted[n - 1]);
+    }
+
+    let mut rng = SplitMix64::new(boot.seed);
+    let mut medians = Vec::with_capacity(boot.resamples as usize);
+    let mut draw = vec![0.0; n];
+    for _ in 0..boot.resamples {
+        for slot in &mut draw {
+            *slot = sorted[rng.below(n)];
+        }
+        medians.push(median_by_selection(&mut draw));
+    }
+    medians.sort_by(f64::total_cmp);
+
+    let tail = (1.0 - boot.confidence) / 2.0;
+    (
+        medians[quantile_index(medians.len(), tail)],
+        medians[quantile_index(medians.len(), 1.0 - tail)],
+    )
+}
+
+/// The index into a sorted slice of `len` items for a quantile in `0.0 ..= 1.0`.
+fn quantile_index(len: usize, q: f64) -> usize {
+    // Both the multiply and the cast are bounded by `len`, which is `resamples`.
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss
+    )]
+    let raw = (q * len as f64) as usize;
+    raw.min(len - 1)
+}
+
+/// A small deterministic generator, so the crate does not take a dependency for this.
+///
+/// The bootstrap does not need a cryptographic generator or a long period. It needs the same
+/// numbers every time, which is what makes a summary reproducible.
+struct SplitMix64(u64);
+
+impl SplitMix64 {
+    const fn new(seed: u64) -> Self {
+        Self(seed)
+    }
+
+    fn next(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9e37_79b9_7f4a_7c15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+        z ^ (z >> 31)
+    }
+
+    /// A value in `0 .. bound`, using the multiply and shift trick so there is no modulo bias worth
+    /// caring about at these sizes.
+    fn below(&mut self, bound: usize) -> usize {
+        let r = u128::from(self.next());
+        let b = bound as u128;
+        // The high 64 bits of a 64 bit number times `bound` are always below `bound`, so this fits
+        // in a usize whenever `bound` did.
+        #[allow(clippy::cast_possible_truncation)]
+        let out = ((r * b) >> 64) as usize;
+        out
+    }
+}

--- a/crates/bench-core/tests/repetition.rs
+++ b/crates/bench-core/tests/repetition.rs
@@ -1,0 +1,145 @@
+//! The pilot, the variance decomposition, and where the budget goes.
+
+use bench_core::{Error, Level, Pilot, plan};
+
+/// A small deterministic generator so these tests say the same thing on every machine.
+struct Lcg(u64);
+
+impl Lcg {
+    fn next_unit(&mut self) -> f64 {
+        self.0 = self
+            .0
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1_442_695_040_888_963_407);
+        // The top 24 bits, scaled into -0.5 ..= 0.5.
+        f64::from((self.0 >> 40) as u32) / f64::from(1u32 << 24) - 0.5
+    }
+}
+
+/// Builds a pilot where the variance is injected at exactly one level and the other two carry only
+/// a small amount of unavoidable jitter.
+fn pilot_with_variance_at(level: Level) -> Pilot {
+    let mut rng = Lcg(12_345);
+    let big = 100.0;
+    let small = 1.0;
+
+    let amount = |at: Level| if at == level { big } else { small };
+
+    let mut samples = Vec::new();
+    for _ in 0..4 {
+        let build_offset = rng.next_unit() * amount(Level::Build);
+        let mut build = Vec::new();
+        for _ in 0..4 {
+            let process_offset = rng.next_unit() * amount(Level::Process);
+            let mut process = Vec::new();
+            for _ in 0..8 {
+                let jitter = rng.next_unit() * amount(Level::Iteration);
+                process.push(1_000.0 + build_offset + process_offset + jitter);
+            }
+            build.push(process);
+        }
+        samples.push(build);
+    }
+    Pilot::new(samples).expect("the design above is balanced and big enough")
+}
+
+#[test]
+fn the_decomposition_finds_the_level_the_variance_was_put_at() {
+    for level in [Level::Build, Level::Process, Level::Iteration] {
+        let components = pilot_with_variance_at(level).decompose();
+        assert_eq!(
+            components.dominant(),
+            level,
+            "variance was injected at {level} but the decomposition said {} ({components:?})",
+            components.dominant()
+        );
+        assert!(
+            components.share(level) > 0.5,
+            "{level} should carry most of the variance, got {}",
+            components.share(level)
+        );
+    }
+}
+
+#[test]
+fn a_component_is_never_negative() {
+    // Every sample identical, so every mean square is zero and the subtractions land on noise
+    // around zero rather than on a real difference.
+    let flat = vec![vec![vec![1_000.0; 4]; 3]; 2];
+    let components = Pilot::new(flat).unwrap().decompose();
+    assert!(components.build >= 0.0);
+    assert!(components.process >= 0.0);
+    assert!(components.iteration >= 0.0);
+    assert!(components.share(Level::Build).abs() < f64::EPSILON);
+}
+
+#[test]
+fn a_pilot_that_cannot_separate_the_levels_is_refused() {
+    let one_build = vec![vec![vec![1.0, 2.0]; 2]];
+    assert!(matches!(
+        Pilot::new(one_build),
+        Err(Error::PilotTooSmall { builds: 1, .. })
+    ));
+
+    let one_iteration = vec![vec![vec![1.0]; 2]; 2];
+    assert!(matches!(
+        Pilot::new(one_iteration),
+        Err(Error::PilotTooSmall { iterations: 1, .. })
+    ));
+
+    assert!(matches!(
+        Pilot::new(Vec::new()),
+        Err(Error::PilotTooSmall { .. })
+    ));
+}
+
+#[test]
+fn a_ragged_design_is_refused() {
+    let ragged = vec![vec![vec![1.0, 2.0], vec![3.0, 4.0]], vec![vec![5.0, 6.0]]];
+    assert!(matches!(Pilot::new(ragged), Err(Error::Unbalanced)));
+
+    let short_cell = vec![
+        vec![vec![1.0, 2.0], vec![3.0, 4.0]],
+        vec![vec![5.0, 6.0], vec![7.0]],
+    ];
+    assert!(matches!(Pilot::new(short_cell), Err(Error::Unbalanced)));
+}
+
+#[test]
+fn a_broken_clock_does_not_get_into_a_pilot() {
+    let bad = vec![vec![vec![1.0, f64::INFINITY], vec![3.0, 4.0]]; 2];
+    assert!(matches!(Pilot::new(bad), Err(Error::NotFinite)));
+}
+
+#[test]
+fn the_budget_goes_to_the_level_that_carries_the_variance() {
+    let budget = 200;
+
+    let iteration = plan(budget, Level::Iteration);
+    assert!(iteration.iterations > iteration.processes);
+    assert!(iteration.iterations > iteration.builds);
+
+    let process = plan(budget, Level::Process);
+    assert!(process.processes > process.iterations);
+    assert!(process.processes > process.builds);
+
+    let build = plan(budget, Level::Build);
+    assert!(build.builds > build.processes);
+    assert!(build.builds > build.iterations);
+}
+
+#[test]
+fn a_plan_spends_roughly_the_budget_it_was_given() {
+    for level in [Level::Build, Level::Process, Level::Iteration] {
+        let p = plan(200, level);
+        assert_eq!(p.total(), 200, "{level} plan spent {}", p.total());
+    }
+}
+
+#[test]
+fn a_tiny_budget_still_produces_a_runnable_plan() {
+    let p = plan(0, Level::Iteration);
+    assert!(p.builds >= 1);
+    assert!(p.processes >= 1);
+    assert!(p.iterations >= 1);
+}

--- a/crates/bench-core/tests/statistics.rs
+++ b/crates/bench-core/tests/statistics.rs
@@ -1,0 +1,102 @@
+//! The summary: the median, the interval around it, and the minimum that is kept out of the way.
+
+use bench_core::{Bootstrap, summarise};
+
+fn boot() -> Bootstrap {
+    Bootstrap::default()
+}
+
+#[test]
+fn nothing_has_no_summary() {
+    assert!(summarise(&[], boot()).is_none());
+}
+
+#[test]
+fn the_median_is_the_middle_either_way_round() {
+    let odd = summarise(&[3.0, 1.0, 2.0], boot()).unwrap();
+    assert!((odd.median - 2.0).abs() < f64::EPSILON);
+
+    let even = summarise(&[4.0, 1.0, 2.0, 3.0], boot()).unwrap();
+    assert!((even.median - 2.5).abs() < f64::EPSILON);
+}
+
+#[test]
+fn the_interval_brackets_the_median() {
+    let samples: Vec<f64> = (1..=101).map(f64::from).collect();
+    let s = summarise(&samples, boot()).unwrap();
+
+    assert!((s.median - 51.0).abs() < f64::EPSILON);
+    assert!(s.lo <= s.median, "{} is above the median", s.lo);
+    assert!(s.hi >= s.median, "{} is below the median", s.hi);
+    assert!((s.confidence - 0.95).abs() < f64::EPSILON);
+}
+
+#[test]
+fn more_samples_narrow_the_interval() {
+    // The same distribution twice, once with four times as many draws.
+    let short: Vec<f64> = (0..40).map(|i| f64::from(i % 20) + 100.0).collect();
+    let long: Vec<f64> = (0..160).map(|i| f64::from(i % 20) + 100.0).collect();
+
+    let a = summarise(&short, boot()).unwrap();
+    let b = summarise(&long, boot()).unwrap();
+    assert!(
+        b.relative_width() <= a.relative_width(),
+        "four times the samples gave a wider interval: {} against {}",
+        b.relative_width(),
+        a.relative_width()
+    );
+}
+
+/// The minimum is a statistic about the luckiest run. It is carried in its own column so that
+/// nothing downstream can mistake it for a typical value.
+#[test]
+fn the_minimum_is_kept_out_of_the_headline() {
+    // One very fast run and a lot of ordinary ones, which is what a lucky scheduling window looks
+    // like in real data.
+    let mut samples = vec![1_000.0; 99];
+    samples.push(400.0);
+    let s = summarise(&samples, boot()).unwrap();
+
+    assert!((s.min - 400.0).abs() < f64::EPSILON);
+    assert!((s.median - 1_000.0).abs() < f64::EPSILON);
+    assert!(
+        s.lo >= 900.0,
+        "one lucky run dragged the interval to {}",
+        s.lo
+    );
+}
+
+#[test]
+fn one_sample_admits_that_it_is_one_sample() {
+    let s = summarise(&[1_234.0], boot()).unwrap();
+    assert_eq!(s.n, 1);
+    // Not a zero width interval pretending to be certainty. The `n` in the row is what tells a
+    // reader what this is worth.
+    assert!((s.lo - s.hi).abs() < f64::EPSILON);
+    assert!((s.lo - 1_234.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn the_same_samples_give_the_same_interval_every_time() {
+    let samples: Vec<f64> = (0..77).map(|i| f64::from((i * 13) % 31) + 500.0).collect();
+    assert_eq!(summarise(&samples, boot()), summarise(&samples, boot()));
+}
+
+#[test]
+fn a_different_seed_is_an_independent_check_and_not_a_different_answer() {
+    let samples: Vec<f64> = (0..201).map(|i| f64::from((i * 7) % 53) + 500.0).collect();
+    let a = summarise(&samples, boot()).unwrap();
+    let b = summarise(&samples, Bootstrap { seed: 99, ..boot() }).unwrap();
+
+    assert!((a.median - b.median).abs() < f64::EPSILON);
+    // The intervals are drawn from different resamples, so they are allowed to differ, but not by
+    // much or the resample count is too low to be useful.
+    let drift = (a.lo - b.lo).abs().max((a.hi - b.hi).abs());
+    assert!(drift <= 2.0, "the interval moved by {drift} on a reseed");
+}
+
+#[test]
+#[should_panic(expected = "not a finite number")]
+fn a_broken_clock_is_not_summarised() {
+    let _ = summarise(&[1.0, f64::NAN, 3.0], boot());
+}

--- a/crates/bench-core/tests/stopping.rs
+++ b/crates/bench-core/tests/stopping.rs
@@ -1,0 +1,202 @@
+//! The stopping rule, and the property that makes it honest.
+
+use bench_core::{Bootstrap, Series, Stop, Timing};
+
+/// A deterministic stream of samples, so a test can say what the loop will see.
+struct Stream {
+    values: Vec<f64>,
+    at: usize,
+}
+
+impl Stream {
+    fn new(values: Vec<f64>) -> Self {
+        Self { values, at: 0 }
+    }
+
+    fn next(&mut self) -> f64 {
+        let v = self.values[self.at % self.values.len()];
+        self.at += 1;
+        v
+    }
+}
+
+/// Fewer resamples than a published run would use. These tests are about where a run stops, not
+/// about the third digit of an interval endpoint, and a debug build pays for every resample.
+fn quick() -> Bootstrap {
+    Bootstrap {
+        resamples: 200,
+        ..Bootstrap::default()
+    }
+}
+
+/// A workload that wobbles by a fixed pattern around 1000, so every run of this test sees exactly
+/// the same numbers in the same order.
+fn wobbly() -> Vec<f64> {
+    (0..64)
+        .map(|i| 1_000.0 + f64::from((i * 37) % 23) - 11.0)
+        .collect()
+}
+
+/// The property issue #5 asks for.
+///
+/// A comparison driven stopping rule is not reachable, because `Stop::should_stop` is handed one
+/// `Series` and `Stop` is `#[non_exhaustive]` with no variant that carries anything but a scalar.
+/// Nobody outside this crate can add a variant that sees a second series.
+///
+/// What a test can check is the observable half of that: the stopping point is a pure function of
+/// the samples, so a run stops at the same place whatever else was measured that day.
+#[test]
+fn the_stopping_point_does_not_depend_on_anything_but_the_series() {
+    let timing = Timing {
+        warmup: 3,
+        stop: Stop::IntervalWidth {
+            target: 0.01,
+            min: 10,
+            max: 400,
+        },
+        check_every: 1,
+        bootstrap: quick(),
+    };
+
+    // The same workload, measured on a day when the rival was far behind and on a day when it was
+    // a hair ahead. If a comparison could reach the stopping rule, these would come out different,
+    // because the second case is the one where a few more repetitions would be tempting.
+    let mut far = Stream::new(wobbly());
+    let run_against_a_distant_rival = timing.run(|| far.next());
+
+    let mut close = Stream::new(wobbly());
+    let run_against_a_near_tie = timing.run(|| close.next());
+
+    assert_eq!(
+        run_against_a_distant_rival.len(),
+        run_against_a_near_tie.len()
+    );
+    assert_eq!(
+        run_against_a_distant_rival.summary(),
+        run_against_a_near_tie.summary()
+    );
+}
+
+/// The same claim from the other side: replaying a recorded series through the rule one sample at a
+/// time flips at exactly one place, and it is the place the loop stopped.
+#[test]
+fn replaying_a_series_stops_at_the_same_sample() {
+    let stop = Stop::IntervalWidth {
+        target: 0.01,
+        min: 10,
+        max: 400,
+    };
+    let timing = Timing {
+        warmup: 0,
+        stop,
+        check_every: 1,
+        bootstrap: quick(),
+    };
+
+    let mut source = Stream::new(wobbly());
+    let collected = timing.run(|| source.next());
+
+    let mut replay = Series::new(quick());
+    let mut stopped_at = None;
+    for sample in collected.samples() {
+        replay.push(*sample);
+        if stop.should_stop(&replay) {
+            stopped_at = Some(replay.len());
+            break;
+        }
+    }
+
+    assert_eq!(stopped_at, Some(collected.len()));
+}
+
+#[test]
+fn a_tighter_target_never_takes_fewer_samples() {
+    let run = |target: f64| {
+        let timing = Timing {
+            warmup: 0,
+            stop: Stop::IntervalWidth {
+                target,
+                min: 8,
+                max: 400,
+            },
+            check_every: 1,
+            bootstrap: quick(),
+        };
+        let mut source = Stream::new(wobbly());
+        timing.run(|| source.next()).len()
+    };
+
+    let loose = run(0.05);
+    let tight = run(0.001);
+    assert!(
+        tight >= loose,
+        "asking for a narrower interval took fewer samples: {tight} against {loose}"
+    );
+}
+
+/// An interval computed from four samples is narrow because there is nothing in it to be wide.
+/// The floor exists so that a very quiet workload cannot end a run before it has said anything.
+#[test]
+fn a_narrow_interval_from_too_few_samples_does_not_stop_the_run() {
+    let timing = Timing {
+        warmup: 0,
+        stop: Stop::IntervalWidth {
+            target: 0.5,
+            min: 25,
+            max: 100,
+        },
+        check_every: 1,
+        bootstrap: quick(),
+    };
+    // Every sample identical, so the interval has zero width from the second sample on.
+    let series = timing.run(|| 1_000.0);
+    assert_eq!(series.len(), 25);
+}
+
+#[test]
+fn a_workload_whose_variance_never_settles_still_ends() {
+    let timing = Timing {
+        warmup: 0,
+        stop: Stop::IntervalWidth {
+            // Unreachable on purpose.
+            target: 0.0,
+            min: 4,
+            max: 60,
+        },
+        check_every: 1,
+        bootstrap: quick(),
+    };
+    let mut source = Stream::new(wobbly());
+    assert_eq!(timing.run(|| source.next()).len(), 60);
+}
+
+#[test]
+fn a_fixed_count_takes_exactly_that_many() {
+    let timing = Timing {
+        warmup: 7,
+        stop: Stop::After { samples: 31 },
+        check_every: 1,
+        bootstrap: quick(),
+    };
+    let mut calls = 0;
+    let series = timing.run(|| {
+        calls += 1;
+        1_000.0
+    });
+    assert_eq!(series.len(), 31);
+    // Warmup runs the workload and throws the numbers away, which is the point of it.
+    assert_eq!(calls, 38);
+}
+
+/// The cadence is not free of consequences, so it gets its own test rather than a footnote.
+#[test]
+fn a_run_ends_on_a_multiple_of_the_check_interval() {
+    let timing = Timing {
+        warmup: 0,
+        stop: Stop::After { samples: 30 },
+        check_every: 8,
+        bootstrap: quick(),
+    };
+    // The rule was satisfied at 30 but is only asked at 32, and 32 is what the row will say.
+    assert_eq!(timing.run(|| 1_000.0).len(), 32);
+}


### PR DESCRIPTION
Closes #5.

This is the measurement half of `bench-core`. No benchmark lives in the crate, only the loop, the statistics and the repetition model, so that the timing code can be read in one sitting by somebody who wants to check it.

## The repetition model

Kalibera and Jones is usually remembered as run it more times. The actual contribution is that variance lives at a particular level, and the repetition budget should be spent at the level that carries it. A `Pilot` is a small balanced design across builds, processes and iterations. `Pilot::decompose` splits the variance across those three levels using the ordinary nested random effects arithmetic, and `plan` gives the budget to the dominant level and two repetitions to each of the others.

Two and not one for the settled levels, because one gives no way to notice later that a level started carrying variance after all, which happens the first time somebody changes a compiler flag.

The decomposition is written as plain nested loops rather than iterator chains. It is arithmetic a reader should be able to check against a textbook, and a chain of folds is harder to check than it is to write.

## The statistics

The headline is the median with a percentile bootstrap confidence interval. The mean is carried because everyone else reports it, not because it is the better statistic. The minimum gets its own column rather than being folded into anything, because the minimum is a statistic about the luckiest run and printing it where a reader expects a typical value is the most common distortion in this field.

The bootstrap seed is configuration rather than something taken from the clock, so summarising the same samples twice gives the same interval. That matters more than it sounds, because the stopping rule is keyed on the width of that interval and a rule built on a number that moves on its own would stop somewhere different every run.

Two thousand resamples rather than the ten thousand people reach for out of habit. Ten thousand is right for a percentile of a tail. For an interval on a median it moves the endpoints by less than the measurement noise they describe, and the stopping rule pays this cost repeatedly while a run is in progress.

## The stopping rule

`Stop::should_stop` takes the series being measured and nothing else. It cannot see a baseline, a rival, or yesterday's number, because the signature does not let it. `Stop` is `non_exhaustive` and no variant carries anything but a scalar, so nobody outside the crate can add a variant that sees a second series.

That is the whole design. Adding repetitions until a comparison becomes significant is how a result gets manufactured, and it does not feel like cheating while you are doing it, because you are just collecting more data and more data is good. The defence is not discipline, it is not having the number available at the point where the decision is made.

The issue asks for a test that a comparison driven rule is not reachable. The unreachable half is a type signature, so the test checks the observable half: the same workload measured on a day when the rival was far behind and on a day when it was a hair ahead stops at the same sample and produces the same summary.

`Timing::check_every` exists because a bootstrap over the whole series is not free and one more sample rarely moves the interval enough to change the answer. A run ends at a multiple of it, which is worth knowing when reading a sample count back, so there is a test that says so.

## What is here

- `stats.rs`, the summary, the bootstrap, and a small deterministic generator so the crate does not take a dependency for eight lines of arithmetic
- `repetition.rs`, the pilot, the variance decomposition and the budget
- `measure.rs`, the loop, the stopping rule and `time`
- 24 tests across three files

Unused dependencies were dropped from `bench-core` while I was in there. The crate now takes `serde` and `thiserror` and nothing else.