### PR TITLE
Refuse a run on an unfit machine instead of warning about it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,9 +71,7 @@ jobs:
         with:
           tool: cargo-nextest
       - run: cargo build --workspace --all-targets --locked
-      # The workspace has no tests yet, and nextest treats that as an error by
-      # default. The flag comes back out with the first real test in B0.
-      - run: cargo nextest run --workspace --all-targets --locked --no-tests=pass
+      - run: cargo nextest run --workspace --all-targets --locked
       - run: cargo test --workspace --doc --locked
 
   msrv:
@@ -137,7 +135,7 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-llvm-cov,cargo-nextest
-      - run: cargo llvm-cov nextest --workspace --locked --no-tests=pass --lcov --output-path lcov.info
+      - run: cargo llvm-cov nextest --workspace --locked --lcov --output-path lcov.info
       - run: cargo llvm-cov report --summary-only >> "$GITHUB_STEP_SUMMARY"
       - uses: actions/upload-artifact@v7
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,6 +211,7 @@ name = "bench-core"
 version = "0.0.0"
 dependencies = [
  "serde",
+ "serde_json",
  "thiserror",
 ]
 
@@ -243,8 +244,10 @@ dependencies = [
 name = "bench-env"
 version = "0.0.0"
 dependencies = [
+ "bench-core",
  "blake3",
  "serde",
+ "serde_json",
  "sysinfo",
  "thiserror",
 ]
@@ -1292,6 +1295,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1991,6 +2007,12 @@ name = "zlib-rs"
 version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zstd"

--- a/crates/bench-cli/src/main.rs
+++ b/crates/bench-cli/src/main.rs
@@ -1,8 +1,11 @@
 //! `iris-bench`, the command line tool.
 //!
-//! Nothing is implemented yet. See `docs/ROADMAP.md`.
+//! Only `check` is implemented. See `docs/ROADMAP.md` for the rest.
 
-use clap::{Parser, Subcommand};
+use std::path::PathBuf;
+
+use bench_env::{Capture, Permit};
+use clap::{Parser, Subcommand, ValueEnum};
 
 /// Command line interface for the iris-bench harness.
 #[derive(Debug, Parser)]
@@ -17,7 +20,20 @@ struct Cli {
 #[derive(Debug, Subcommand)]
 enum Command {
     /// Check whether this machine is fit to produce a publishable number.
-    Check,
+    Check {
+        /// What the machine would have to be good enough for.
+        ///
+        /// Exits non zero when it is not, which is what makes this usable as the first step of a
+        /// run rather than as something a person reads and then ignores.
+        #[arg(long, value_enum, default_value_t = Requirement::Durations)]
+        require: Requirement,
+        /// Where to write the environment capture.
+        ///
+        /// The capture is written whether or not the machine passes, because a refused run is
+        /// exactly the case where somebody wants to see what was read.
+        #[arg(long, value_name = "PATH")]
+        out: Option<PathBuf>,
+    },
     /// Fetch or generate a corpus and verify it against its manifest.
     Corpus {
         /// Corpus name, as it appears in the manifest directory.
@@ -37,11 +53,62 @@ enum Command {
     Report,
 }
 
+/// What a caller needs the machine to be good enough for.
+///
+/// The same three levels as [`Permit`], separately declared because a command line argument is a
+/// stable interface and the internal vocabulary is free to move.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, ValueEnum)]
+enum Requirement {
+    /// Absolute durations, which is the only thing comparable across machines.
+    Durations,
+    /// Ratios taken inside one run, where the machine is its own control.
+    Ratios,
+}
+
+impl From<Requirement> for Permit {
+    fn from(requirement: Requirement) -> Self {
+        match requirement {
+            Requirement::Durations => Self::Durations,
+            Requirement::Ratios => Self::Ratios,
+        }
+    }
+}
+
+/// Reads the machine, says what it is good for, and refuses by name when that is not enough.
+fn check(require: Requirement, out: Option<PathBuf>) -> anyhow::Result<()> {
+    let capture = Capture::take();
+
+    println!("{}", capture.class);
+    println!("environment {}", capture.hash);
+    for gate in &capture.gates {
+        let (mark, detail) = match &gate.outcome {
+            bench_env::Outcome::Pass { observed } => ("pass", observed.clone()),
+            bench_env::Outcome::Fail { observed, wanted } => {
+                ("FAIL", format!("{observed}, wanted {wanted}"))
+            }
+        };
+        println!("  {mark}  {:<20} {detail}", gate.name);
+    }
+    println!("this machine is good for {}", capture.permits());
+
+    if let Some(path) = out {
+        std::fs::write(&path, capture.to_json())?;
+        println!("capture written to {}", path.display());
+    }
+
+    // The refusal is returned rather than printed, so that the exit status and the message come from
+    // the same place a library caller would get them from.
+    Ok(capture.require(require.into())?)
+}
+
 fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .init();
 
     let cli = Cli::parse();
-    anyhow::bail!("not implemented yet: {:?}", cli.command)
+    match cli.command {
+        Command::Check { require, out } => check(require, out),
+        other => anyhow::bail!("not implemented yet: {other:?}"),
+    }
 }

--- a/crates/bench-core/Cargo.toml
+++ b/crates/bench-core/Cargo.toml
@@ -17,5 +17,8 @@ publish.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 
+[dev-dependencies]
+serde_json.workspace = true
+
 [lints]
 workspace = true

--- a/crates/bench-core/README.md
+++ b/crates/bench-core/README.md
@@ -2,12 +2,6 @@
 
 Timing, repetition and the result row.
 
-No benchmark lives in this crate. It holds the measurement loop, the
-
-bootstrap confidence interval on the median, and the row schema that every
-
-result is written as. Keeping benchmarks out of it is what lets the timing
-
-code be reviewed in one sitting.
+No benchmark lives in this crate. It holds the measurement loop, the bootstrap confidence interval on the median, and the row schema that every result is written as. Keeping benchmarks out of it is what lets the timing code be reviewed in one sitting.
 
 Part of [iris-bench](https://github.com/tamnd/iris-bench). Licensed under Apache-2.0.

--- a/crates/bench-core/src/environment.rs
+++ b/crates/bench-core/src/environment.rs
@@ -1,0 +1,131 @@
+//! The identity of the conditions a measurement was taken under.
+//!
+//! `bench-env` works out what a machine is and how it is configured and reduces that to one digest.
+//! The digest lives here rather than there because it belongs to the row. Every result carries one,
+//! and two rows with different digests were not taken under the same conditions, so a reader
+//! comparing two numbers checks one field instead of remembering what was true on the day.
+//!
+//! # What is in it and what is not
+//!
+//! Only what the machine is and how it is set up. The processor, how much memory is fitted, the
+//! kernel, the frequency governor, whether turbo is on, whether the run was pinned, and whether
+//! there is a hypervisor underneath.
+//!
+//! Not what the machine was doing at the instant. Free memory and load average move between one
+//! measurement and the next, so hashing them would give every row a digest of its own and the field
+//! would stop being able to group anything. Those observations are what the eligibility gates read,
+//! and a gate that fails stops the run outright, which is a stronger protection than a digest. They
+//! are recorded beside the digest rather than inside it.
+//!
+//! # Why unobservable is not the same as absent
+//!
+//! A setting that cannot be read on a platform is recorded as unreadable rather than skipped, and
+//! that recording is inside the digest. So the same machine measured under two operating systems
+//! produces two different digests, and a row from one cannot be quietly compared against a row from
+//! the other. That is the intended behaviour: the comparison is not wrong because the numbers are
+//! wrong, it is wrong because nobody checked the same things in both cases.
+
+use std::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// A digest of the machine and its configuration, carried by every result row.
+///
+/// Compared with `==` and nothing else. There is no ordering on it and no notion of one environment
+/// being close to another, because two environments are either the same one or they are not.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct EnvironmentHash([u8; 32]);
+
+impl EnvironmentHash {
+    /// Wraps 32 bytes that some hash function has already produced.
+    #[must_use]
+    pub const fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    /// The bytes, for a caller writing them into a binary column.
+    #[must_use]
+    pub const fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+/// Lower case hex, all 64 characters of it.
+///
+/// Not truncated. A short digest reads nicely in a table and collides eventually, and the whole
+/// value of this field is that two rows that share it really were taken under the same conditions.
+impl fmt::Display for EnvironmentHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for byte in self.0 {
+            write!(f, "{byte:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+/// Prints as the hex rather than as a list of numbers, because a digest in a debug log that a reader
+/// cannot compare against a result row by eye is not doing its job.
+impl fmt::Debug for EnvironmentHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "EnvironmentHash({self})")
+    }
+}
+
+/// What is wrong with a string that was supposed to be an environment hash.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum ParseEnvironmentHashError {
+    /// The string was not 64 characters long.
+    #[error("an environment hash is 64 hex characters, this one is {found}")]
+    Length {
+        /// How many characters were there.
+        found: usize,
+    },
+    /// The string was the right length but held something that is not hex.
+    #[error("an environment hash is hex and this one contains {found:?}")]
+    NotHex {
+        /// The first character that is not a hex digit.
+        found: char,
+    },
+}
+
+impl FromStr for EnvironmentHash {
+    type Err = ParseEnvironmentHashError;
+
+    fn from_str(text: &str) -> Result<Self, Self::Err> {
+        if text.len() != 64 {
+            return Err(ParseEnvironmentHashError::Length { found: text.len() });
+        }
+        if let Some(found) = text.chars().find(|c| !c.is_ascii_hexdigit()) {
+            return Err(ParseEnvironmentHashError::NotHex { found });
+        }
+
+        let (pairs, _) = text.as_bytes().as_chunks::<2>();
+        let mut out = [0_u8; 32];
+        for (slot, pair) in out.iter_mut().zip(pairs) {
+            // Both characters passed `is_ascii_hexdigit` above, so neither conversion can fail.
+            let hi = char::from(pair[0]).to_digit(16).unwrap_or(0);
+            let lo = char::from(pair[1]).to_digit(16).unwrap_or(0);
+            *slot = u8::try_from(hi * 16 + lo).unwrap_or(0);
+        }
+        Ok(Self(out))
+    }
+}
+
+/// Serialised as the hex string, not as an array of 32 numbers.
+///
+/// The digest ends up in JSON that a person reads and in a Parquet column that a person queries, and
+/// in both places it has to be the same string they would paste from a result table.
+impl Serialize for EnvironmentHash {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for EnvironmentHash {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let text = String::deserialize(deserializer)?;
+        text.parse().map_err(serde::de::Error::custom)
+    }
+}

--- a/crates/bench-core/src/lib.rs
+++ b/crates/bench-core/src/lib.rs
@@ -37,10 +37,12 @@
 //! result gets manufactured, and the defence against that is not having the comparison in scope at
 //! the point where the decision is made.
 
+mod environment;
 mod measure;
 mod repetition;
 mod stats;
 
+pub use environment::{EnvironmentHash, ParseEnvironmentHashError};
 pub use measure::{Series, Stop, Timing, time};
 pub use repetition::{Components, Level, Pilot, Plan, plan};
 pub use stats::{Bootstrap, Summary, summarise};

--- a/crates/bench-core/tests/environment.rs
+++ b/crates/bench-core/tests/environment.rs
@@ -1,0 +1,64 @@
+//! The environment hash carried by every result row.
+
+use bench_core::{EnvironmentHash, ParseEnvironmentHashError};
+
+/// A digest that is not any real machine, written out so the tests read as text rather than as a
+/// loop that builds the same bytes the code under test would.
+const SAMPLE: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+#[test]
+fn a_hash_prints_as_the_string_it_parsed_from() {
+    let hash: EnvironmentHash = SAMPLE.parse().expect("64 hex characters");
+    assert_eq!(hash.to_string(), SAMPLE);
+}
+
+#[test]
+fn a_hash_prints_every_byte_including_the_leading_zeroes() {
+    // The obvious formatting mistake here loses a leading zero on any byte under sixteen, which
+    // produces a shorter string that still looks like a hash and no longer round trips.
+    let hash = EnvironmentHash::from_bytes([1_u8; 32]);
+    assert_eq!(hash.to_string(), "01".repeat(32));
+}
+
+#[test]
+fn a_hash_serialises_as_a_string_rather_than_as_a_list_of_numbers() {
+    let hash: EnvironmentHash = SAMPLE.parse().expect("64 hex characters");
+    let json = serde_json::to_string(&hash).expect("a hash serialises");
+
+    assert_eq!(json, format!("\"{SAMPLE}\""));
+
+    let back: EnvironmentHash = serde_json::from_str(&json).expect("and comes back");
+    assert_eq!(back, hash);
+}
+
+#[test]
+fn upper_case_hex_parses_and_then_prints_as_lower_case() {
+    let hash: EnvironmentHash = SAMPLE.to_uppercase().parse().expect("64 hex characters");
+    assert_eq!(hash.to_string(), SAMPLE);
+}
+
+#[test]
+fn a_truncated_hash_is_rejected_rather_than_padded() {
+    let error = SAMPLE[..63]
+        .parse::<EnvironmentHash>()
+        .expect_err("63 characters is not a hash");
+    assert_eq!(error, ParseEnvironmentHashError::Length { found: 63 });
+}
+
+#[test]
+fn something_that_is_not_hex_is_rejected_with_the_character_that_was_wrong() {
+    let mut text = SAMPLE.to_owned();
+    text.replace_range(10..11, "z");
+
+    let error = text
+        .parse::<EnvironmentHash>()
+        .expect_err("z is not a hex digit");
+    assert_eq!(error, ParseEnvironmentHashError::NotHex { found: 'z' });
+}
+
+#[test]
+fn two_different_environments_do_not_compare_equal() {
+    let one = EnvironmentHash::from_bytes([0_u8; 32]);
+    let other = EnvironmentHash::from_bytes([1_u8; 32]);
+    assert_ne!(one, other);
+}

--- a/crates/bench-env/Cargo.toml
+++ b/crates/bench-env/Cargo.toml
@@ -14,8 +14,10 @@ readme.workspace = true
 publish.workspace = true
 
 [dependencies]
+bench-core.workspace = true
 blake3.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 sysinfo.workspace = true
 thiserror.workspace = true
 

--- a/crates/bench-env/README.md
+++ b/crates/bench-env/README.md
@@ -1,11 +1,11 @@
 # bench-env
 
-Environment capture and eligibility gates.
+Environment capture and machine eligibility gates.
 
-A machine that fails a gate does not produce a slower number, it produces a
+Before a run takes a single measurement it asks this crate whether the machine is fit to produce the kind of number the run wants. The answer is yes, or it is a refusal naming the gate that failed. There is no third answer and there is no override, because a number with a warning attached is a number that gets copied without the warning and then it is on a slide somewhere.
 
-number that should not be published. So the gates abort the run and name the
+A capture has two halves. The facts are what the machine is: the processor, the memory fitted, the frequency governor, the boost state, whether the run was pinned, whether there is a hypervisor underneath. They are stable until somebody reconfigures the machine, and they are what gets hashed into every result row. The conditions are what the machine is doing: free memory, load average, how many other processes are busy. They move between one measurement and the next, so they are gated and they are not hashed.
 
-gate that failed, and that behaviour is not configurable.
+The rule that does most of the work is not a gate. A gate can only fail on something it can read, and the settings that matter most are the ones some platforms do not expose at all, so a machine whose clock settings cannot be read produces ratios rather than durations. Being unable to see a setting is not evidence that the setting is right.
 
 Part of [iris-bench](https://github.com/tamnd/iris-bench). Licensed under Apache-2.0.

--- a/crates/bench-env/src/class.rs
+++ b/crates/bench-env/src/class.rs
@@ -1,0 +1,79 @@
+//! Which of the hardware classes in `docs/MACHINES.md` this machine is.
+//!
+//! The class is worked out from what the machine reports about itself, never from its name. A
+//! hostname is not a fact about hardware, it does not survive the machine being rebuilt, and it is
+//! the sort of thing that ends up in a public result table by accident. The processor, the presence
+//! of a hypervisor and the operating system are all things a reader can check against the machine
+//! notes, so those are what the classification reads.
+//!
+//! A machine that matches no class is [`Class::Unknown`], and unknown produces nothing publishable.
+//! That is deliberately the safe direction: somebody running the harness on a laptop that nobody has
+//! written a gate set for should get a refusal, not a number.
+
+use serde::{Deserialize, Serialize};
+
+use crate::facts::{Facts, Hypervisor};
+
+/// A hardware class from the machine notes.
+///
+/// The letters are the document's own vocabulary rather than an abbreviation invented here, so that
+/// a class in a result row and a class in `docs/MACHINES.md` are obviously the same thing.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
+pub enum Class {
+    /// Virtualised AMD EPYC servers, shared tenancy.
+    A,
+    /// The Intel Core i9-13900K workstation.
+    B,
+    /// Hosted arm64 Linux.
+    C,
+    /// macOS on Apple silicon, the development machine.
+    D,
+    /// Something nobody has written a gate set for.
+    Unknown,
+}
+
+impl Class {
+    /// The class as the machine notes describe it, for an error a person has to act on.
+    #[must_use]
+    pub const fn description(self) -> &'static str {
+        match self {
+            Self::A => "class A, a virtualised AMD EPYC server on shared tenancy",
+            Self::B => "class B, the Intel Core i9-13900K workstation",
+            Self::C => "class C, a hosted arm64 Linux runner",
+            Self::D => "class D, the macOS development machine",
+            Self::Unknown => "an unclassified machine",
+        }
+    }
+}
+
+impl std::fmt::Display for Class {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.description())
+    }
+}
+
+/// Works out which class a machine belongs to from what it reports about itself.
+///
+/// The order of the checks matters in one place. A class B machine running under WSL2 is still class
+/// B, because it is the same silicon and the machine notes treat WSL2 as a caveat on what its
+/// numbers mean rather than as a different machine. So the processor is examined before the
+/// hypervisor is, and the hypervisor only decides the class for the EPYC guests, where it is the
+/// whole reason they are a separate class.
+#[must_use]
+pub fn classify(facts: &Facts) -> Class {
+    if facts.os == "macos" && facts.arch == "aarch64" {
+        return Class::D;
+    }
+    if facts.cpu.contains("i9-13900K") {
+        return Class::B;
+    }
+    if facts.cpu.contains("EPYC") && facts.hypervisor != Hypervisor::None {
+        return Class::A;
+    }
+    if facts.os == "linux" && facts.arch == "aarch64" {
+        return Class::C;
+    }
+    Class::Unknown
+}

--- a/crates/bench-env/src/conditions.rs
+++ b/crates/bench-env/src/conditions.rs
@@ -1,0 +1,69 @@
+//! What a machine is doing at the moment the capture is taken.
+//!
+//! Kept apart from [`crate::Facts`] because none of it is hashed. Free memory and load average move
+//! between one measurement and the next, so a hash over them would be unique per row and could not
+//! group anything, which is the one job the environment hash has.
+//!
+//! What protects a measurement from a busy machine is not the hash. It is that these readings feed
+//! gates, and a gate that fails stops the run.
+
+use serde::{Deserialize, Serialize};
+
+/// How much CPU a process has to be using before it counts as competition.
+///
+/// Five percent of one processor. Below that is the background of any desktop or server: a handful
+/// of daemons waking up on a timer, none of which will evict a working set. Above it is something
+/// doing work, and something doing work while a measurement is taken is exactly what a gate is for.
+const BUSY_PERCENT: f32 = 5.0;
+
+/// What the machine is doing right now.
+#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
+pub struct Conditions {
+    /// Memory available without swapping, in bytes.
+    pub available_memory_bytes: u64,
+    /// The one minute load average, where the platform keeps one.
+    ///
+    /// Windows does not, and this is `None` there rather than zero, because zero is a reading and
+    /// what is true is that there is nothing to read.
+    pub load_average: Option<f64>,
+    /// How many other processes are using a noticeable share of a processor.
+    pub busy_processes: usize,
+}
+
+impl Conditions {
+    /// Observes the machine, which takes a moment on purpose.
+    ///
+    /// Per process CPU usage is a rate, so it needs two readings with a gap between them. The gap is
+    /// the shortest the platform will give a meaningful answer over. A capture that skipped it would
+    /// report every process at zero and the busy process gate would pass on a machine compiling
+    /// something.
+    #[must_use]
+    pub fn observe() -> Self {
+        let mut system = sysinfo::System::new_all();
+        std::thread::sleep(sysinfo::MINIMUM_CPU_UPDATE_INTERVAL);
+        system.refresh_all();
+
+        let ours = sysinfo::get_current_pid().ok();
+        let busy_processes = system
+            .processes()
+            .iter()
+            .filter(|(pid, process)| Some(**pid) != ours && process.cpu_usage() >= BUSY_PERCENT)
+            .count();
+
+        Self {
+            available_memory_bytes: system.available_memory(),
+            load_average: load_average(),
+            busy_processes,
+        }
+    }
+}
+
+/// The one minute load average, or nothing on a platform that does not have the idea.
+fn load_average() -> Option<f64> {
+    if cfg!(target_os = "windows") {
+        return None;
+    }
+    Some(sysinfo::System::load_average().one)
+}

--- a/crates/bench-env/src/facts.rs
+++ b/crates/bench-env/src/facts.rs
@@ -1,0 +1,310 @@
+//! What a machine is, and how it is configured.
+//!
+//! Everything here is stable for as long as the machine is not reconfigured, which is what makes it
+//! safe to hash. Anything that moves while a run is in progress belongs in [`crate::Conditions`]
+//! instead.
+//!
+//! # Readings that are not available
+//!
+//! Every setting is a [`Setting`], which is either a reading or a note saying why there is not one.
+//! The note is not a placeholder to be tidied up later. It is the record that nobody checked, it
+//! goes into the environment hash, and it is what stops a row from a platform where the governor is
+//! readable being compared against a row from a platform where it is not.
+
+use std::fs;
+#[cfg(target_os = "windows")]
+use std::process::Command;
+
+use serde::{Deserialize, Serialize};
+
+/// A setting that some platforms report and others do not.
+#[derive(Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", tag = "kind", content = "detail")]
+#[non_exhaustive]
+pub enum Setting {
+    /// What the machine said.
+    Reading(String),
+    /// Why there is no reading, phrased so that a person can tell a missing feature from a missing
+    /// permission.
+    Unreadable(String),
+}
+
+impl Setting {
+    /// The reading, if there is one.
+    #[must_use]
+    pub fn reading(&self) -> Option<&str> {
+        match self {
+            Self::Reading(text) => Some(text),
+            Self::Unreadable(_) => None,
+        }
+    }
+
+    /// How to say this inside a sentence about a gate.
+    #[must_use]
+    pub fn describe(&self) -> String {
+        match self {
+            Self::Reading(text) => text.clone(),
+            Self::Unreadable(why) => format!("no reading, because {why}"),
+        }
+    }
+}
+
+/// Whether there is a hypervisor underneath, and which sort.
+#[derive(Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", tag = "kind", content = "detail")]
+#[non_exhaustive]
+pub enum Hypervisor {
+    /// Nothing detected. On a platform where detection works, this means bare metal.
+    None,
+    /// The Windows Subsystem for Linux, which is a hypervisor with memory ballooning under it.
+    Wsl,
+    /// A guest of the named virtual machine monitor.
+    Guest(String),
+    /// This platform is not probed for one.
+    Unknown,
+}
+
+/// What a machine is, in the form that gets hashed into every result row.
+///
+/// The field order is the serialisation order and the serialisation is what gets hashed, so
+/// reordering these fields changes every environment hash ever produced. That is not a reason never
+/// to do it, it is a reason to bump [`bench_core::METHODOLOGY_VERSION`] when it happens.
+#[derive(Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
+pub struct Facts {
+    /// The target architecture this binary was built for.
+    pub arch: String,
+    /// The operating system this binary was built for.
+    pub os: String,
+    /// The operating system version, as the system reports it.
+    pub os_version: Setting,
+    /// The kernel version, as the system reports it.
+    pub kernel: Setting,
+    /// The processor brand string.
+    pub cpu: String,
+    /// How many logical processors there are.
+    pub logical_cpus: usize,
+    /// How many physical cores there are, where the platform will say.
+    pub physical_cores: Option<usize>,
+    /// Total memory fitted, in bytes.
+    pub memory_bytes: u64,
+    /// Whether there is a hypervisor underneath.
+    pub hypervisor: Hypervisor,
+    /// The frequency governor on Linux, or the active power scheme on Windows.
+    pub governor: Setting,
+    /// Whether opportunistic boost is enabled.
+    pub turbo: Setting,
+    /// Which logical processors this process is allowed to run on.
+    pub affinity: Setting,
+}
+
+impl Facts {
+    /// Reads everything this platform will say about itself.
+    ///
+    /// Nothing here fails. A reading that cannot be taken becomes a [`Setting::Unreadable`] with the
+    /// reason in it, because a capture that refuses to be taken tells a person less than a capture
+    /// that says what it could not see.
+    #[must_use]
+    pub fn read() -> Self {
+        let system = sysinfo::System::new_all();
+        let cpus = system.cpus();
+
+        Self {
+            arch: std::env::consts::ARCH.to_owned(),
+            os: std::env::consts::OS.to_owned(),
+            os_version: from_option(
+                sysinfo::System::os_version(),
+                "the system did not report an operating system version",
+            ),
+            kernel: from_option(
+                sysinfo::System::kernel_version(),
+                "the system did not report a kernel version",
+            ),
+            cpu: cpus
+                .first()
+                .map_or_else(|| "unknown".to_owned(), |cpu| cpu.brand().trim().to_owned()),
+            logical_cpus: cpus.len(),
+            physical_cores: sysinfo::System::physical_core_count(),
+            memory_bytes: system.total_memory(),
+            hypervisor: hypervisor(),
+            governor: governor(),
+            turbo: turbo(),
+            affinity: affinity(),
+        }
+    }
+}
+
+/// Turns an optional reading into a [`Setting`] with a stated reason when it is missing.
+fn from_option(value: Option<String>, why: &str) -> Setting {
+    value.map_or_else(
+        || Setting::Unreadable(why.to_owned()),
+        |text| Setting::Reading(text.trim().to_owned()),
+    )
+}
+
+/// Reads a sysfs file, trimming the trailing newline every one of them has.
+fn sysfs(path: &str) -> Option<String> {
+    fs::read_to_string(path)
+        .ok()
+        .map(|text| text.trim().to_owned())
+        .filter(|text| !text.is_empty())
+}
+
+/// Detects a hypervisor on Linux and does not guess anywhere else.
+///
+/// The order matters. WSL is reported as WSL rather than as a Hyper-V guest, because the machine
+/// notes have a specific caveat about it that a generic guest does not carry.
+fn hypervisor() -> Hypervisor {
+    if cfg!(not(target_os = "linux")) {
+        return Hypervisor::Unknown;
+    }
+
+    if let Some(release) = sysfs("/proc/sys/kernel/osrelease") {
+        let lowered = release.to_lowercase();
+        if lowered.contains("microsoft") || lowered.contains("wsl") {
+            return Hypervisor::Wsl;
+        }
+    }
+    if let Some(kind) = sysfs("/sys/hypervisor/type") {
+        return Hypervisor::Guest(kind);
+    }
+    // The board vendor is what a virtual machine monitor puts its own name in. On real hardware this
+    // is the name of whoever made the motherboard, which is not a hypervisor and not a machine
+    // identity either.
+    if let Some(vendor) = sysfs("/sys/class/dmi/id/sys_vendor") {
+        const MONITORS: &[&str] = &[
+            "QEMU",
+            "Xen",
+            "VMware",
+            "Microsoft Corporation",
+            "innotek",
+            "Parallels",
+            "Amazon EC2",
+            "Google",
+            "Alibaba",
+            "OpenStack",
+        ];
+        if MONITORS.iter().any(|monitor| vendor.contains(monitor)) {
+            return Hypervisor::Guest(vendor);
+        }
+    }
+    Hypervisor::None
+}
+
+/// The frequency governor on Linux, the active power scheme on Windows, nothing on macOS.
+///
+/// These are not the same thing and the capture does not pretend they are. They occupy one field
+/// because they are the same question, which is whether the operating system has been told to keep
+/// the clock steady, and the reading itself says which one was asked.
+fn governor() -> Setting {
+    #[cfg(target_os = "linux")]
+    {
+        return sysfs("/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor").map_or_else(
+            || {
+                Setting::Unreadable(
+                    "this kernel exposes no cpufreq governor for the first processor".to_owned(),
+                )
+            },
+            Setting::Reading,
+        );
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        return active_power_scheme();
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+    {
+        Setting::Unreadable(format!(
+            "{} exposes no frequency governor",
+            std::env::consts::OS
+        ))
+    }
+}
+
+/// The name of the active Windows power scheme, from `powercfg`.
+///
+/// `powercfg /getactivescheme` prints one line holding a GUID and then the scheme name in brackets.
+/// The name is what a person recognises and the GUID is what varies between Windows installations
+/// for the same scheme, so the name is what is kept.
+#[cfg(target_os = "windows")]
+fn active_power_scheme() -> Setting {
+    let output = match Command::new("powercfg").arg("/getactivescheme").output() {
+        Ok(output) if output.status.success() => output,
+        Ok(output) => {
+            return Setting::Unreadable(format!("powercfg exited with {}", output.status));
+        }
+        Err(error) => return Setting::Unreadable(format!("powercfg could not be run: {error}")),
+    };
+
+    let text = String::from_utf8_lossy(&output.stdout);
+    match (text.find('('), text.rfind(')')) {
+        (Some(open), Some(close)) if open < close => {
+            Setting::Reading(text[open + 1..close].trim().to_owned())
+        }
+        _ => Setting::Unreadable("powercfg printed no scheme name in brackets".to_owned()),
+    }
+}
+
+/// Whether opportunistic boost is on.
+///
+/// Two different files depending on the driver, and neither exists on a machine whose kernel does
+/// not let the setting be changed at all, which is itself the answer for a virtual machine.
+fn turbo() -> Setting {
+    #[cfg(target_os = "linux")]
+    {
+        if let Some(no_turbo) = sysfs("/sys/devices/system/cpu/intel_pstate/no_turbo") {
+            return Setting::Reading(if no_turbo == "1" { "off" } else { "on" }.to_owned());
+        }
+        if let Some(boost) = sysfs("/sys/devices/system/cpu/cpufreq/boost") {
+            return Setting::Reading(if boost == "1" { "on" } else { "off" }.to_owned());
+        }
+        return Setting::Unreadable(
+            "this kernel exposes neither the intel_pstate turbo switch nor the cpufreq boost switch"
+                .to_owned(),
+        );
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        Setting::Unreadable(format!(
+            "{} does not expose the boost state to an unprivileged process",
+            std::env::consts::OS
+        ))
+    }
+}
+
+/// Which logical processors this process may run on.
+///
+/// Read rather than assumed, which is the whole point on a hybrid part. A run that is free to move
+/// between a performance core and an efficiency core produces a distribution with two modes, and a
+/// confidence interval over two modes describes neither of them.
+fn affinity() -> Setting {
+    #[cfg(target_os = "linux")]
+    {
+        let Some(status) = sysfs("/proc/self/status") else {
+            return Setting::Unreadable("this process has no status file".to_owned());
+        };
+        return status
+            .lines()
+            .find_map(|line| line.strip_prefix("Cpus_allowed_list:"))
+            .map_or_else(
+                || {
+                    Setting::Unreadable(
+                        "the process status file lists no allowed processors".to_owned(),
+                    )
+                },
+                |list| Setting::Reading(list.trim().to_owned()),
+            );
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        Setting::Unreadable(format!(
+            "reading the processor affinity of a running process is not implemented for {}",
+            std::env::consts::OS
+        ))
+    }
+}

--- a/crates/bench-env/src/facts.rs
+++ b/crates/bench-env/src/facts.rs
@@ -200,19 +200,19 @@ fn hypervisor() -> Hypervisor {
 fn governor() -> Setting {
     #[cfg(target_os = "linux")]
     {
-        return sysfs("/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor").map_or_else(
+        sysfs("/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor").map_or_else(
             || {
                 Setting::Unreadable(
                     "this kernel exposes no cpufreq governor for the first processor".to_owned(),
                 )
             },
             Setting::Reading,
-        );
+        )
     }
 
     #[cfg(target_os = "windows")]
     {
-        return active_power_scheme();
+        active_power_scheme()
     }
 
     #[cfg(not(any(target_os = "linux", target_os = "windows")))]
@@ -261,10 +261,10 @@ fn turbo() -> Setting {
         if let Some(boost) = sysfs("/sys/devices/system/cpu/cpufreq/boost") {
             return Setting::Reading(if boost == "1" { "on" } else { "off" }.to_owned());
         }
-        return Setting::Unreadable(
+        Setting::Unreadable(
             "this kernel exposes neither the intel_pstate turbo switch nor the cpufreq boost switch"
                 .to_owned(),
-        );
+        )
     }
 
     #[cfg(not(target_os = "linux"))]
@@ -287,7 +287,7 @@ fn affinity() -> Setting {
         let Some(status) = sysfs("/proc/self/status") else {
             return Setting::Unreadable("this process has no status file".to_owned());
         };
-        return status
+        status
             .lines()
             .find_map(|line| line.strip_prefix("Cpus_allowed_list:"))
             .map_or_else(
@@ -297,7 +297,7 @@ fn affinity() -> Setting {
                     )
                 },
                 |list| Setting::Reading(list.trim().to_owned()),
-            );
+            )
     }
 
     #[cfg(not(target_os = "linux"))]

--- a/crates/bench-env/src/gate.rs
+++ b/crates/bench-env/src/gate.rs
@@ -1,0 +1,207 @@
+//! Gates, and what a machine is allowed to produce once they have been evaluated.
+//!
+//! # A gate either aborts or it is not a gate
+//!
+//! There is no warning here and there is no override. A number produced on a machine that failed a
+//! gate is a number with a caveat attached, and a caveat attached to a number does not survive being
+//! copied into a slide. The only way to make the caveat stick is to not produce the number.
+//!
+//! # A gate exists only where it can be evaluated
+//!
+//! The frequency governor is readable on Linux and is not readable on macOS. The tempting move is a
+//! third outcome, something like unknown, that sits between passing and failing. That turns out to
+//! be the worst option available: a caller has to decide what unknown means, every caller decides
+//! differently, and the decision is made far away from the person who knew why the reading was
+//! missing.
+//!
+//! So a gate set is per class and per platform, and a class only carries the gates its platform can
+//! answer. What happens to the unreadable setting is that it is recorded as unreadable in the
+//! environment capture, and the capture is hashed into every result row. Two rows where different
+//! things were checkable end up with different environment hashes and cannot be silently compared.
+//! The protection moves from a runtime decision nobody sees to a field in the data everybody sees.
+
+use serde::{Deserialize, Serialize};
+
+use crate::class::Class;
+
+/// What a machine may be used to produce.
+///
+/// Ordered, weakest first, so a caller can ask whether what a machine permits is at least what a run
+/// needs.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
+pub enum Permit {
+    /// Nothing that gets published. Correctness work and digests, which do not have a clock in them.
+    Nothing,
+    /// Ratios taken inside one run, where the machine is its own control.
+    Ratios,
+    /// Absolute durations, which is the only thing that can be compared across machines.
+    Durations,
+}
+
+impl Permit {
+    /// How to say this in a sentence about a refusal.
+    #[must_use]
+    pub const fn description(self) -> &'static str {
+        match self {
+            Self::Nothing => "no published measurement",
+            Self::Ratios => "within run ratios only",
+            Self::Durations => "absolute durations",
+        }
+    }
+}
+
+impl std::fmt::Display for Permit {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.description())
+    }
+}
+
+/// The result of evaluating one gate.
+///
+/// Deliberately not marked as open to further variants. The doctrine at the top of this file is that
+/// there is no third outcome, and leaving room for one invites a caller to write the wildcard arm
+/// that quietly treats a future unknown as a pass. Adding a variant here should break every match
+/// that reads one, because every one of them would need rethinking.
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", tag = "outcome")]
+pub enum Outcome {
+    /// The machine is in the state the gate wanted.
+    Pass {
+        /// What was read, so that a passing capture is still a record of what was true.
+        observed: String,
+    },
+    /// It is not, and the run stops.
+    Fail {
+        /// What was read.
+        observed: String,
+        /// What would have passed, phrased so a person can go and change it.
+        wanted: String,
+    },
+}
+
+impl Outcome {
+    /// Whether this outcome lets a run continue.
+    #[must_use]
+    pub const fn passed(&self) -> bool {
+        matches!(self, Self::Pass { .. })
+    }
+}
+
+/// One named check against the machine.
+///
+/// The name is what appears in the refusal, so it is written as the thing being checked rather than
+/// as a sentence about the check. A person reading `frequency-governor` in an aborted run knows
+/// where to go.
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+pub struct Gate {
+    /// The identifier used in the refusal message and in the capture.
+    pub name: String,
+    /// What happened when it was evaluated.
+    pub outcome: Outcome,
+}
+
+impl Gate {
+    /// A gate that passed, recording what was seen.
+    #[must_use]
+    pub fn pass(name: impl Into<String>, observed: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            outcome: Outcome::Pass {
+                observed: observed.into(),
+            },
+        }
+    }
+
+    /// A gate that failed, recording what was seen and what would have passed.
+    #[must_use]
+    pub fn fail(
+        name: impl Into<String>,
+        observed: impl Into<String>,
+        wanted: impl Into<String>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            outcome: Outcome::Fail {
+                observed: observed.into(),
+                wanted: wanted.into(),
+            },
+        }
+    }
+
+    /// Builds a pass or a fail from a condition, which is how nearly every gate here is written.
+    #[must_use]
+    pub fn check(
+        name: impl Into<String>,
+        ok: bool,
+        observed: impl Into<String>,
+        wanted: impl Into<String>,
+    ) -> Self {
+        if ok {
+            Self::pass(name, observed)
+        } else {
+            Self::fail(name, observed, wanted)
+        }
+    }
+}
+
+/// The most a machine can produce, and why it is capped there.
+///
+/// The reason is carried rather than recomputed for a message, because it is the half a person acts
+/// on. Knowing that a machine produces ratios is not useful. Knowing that it produces ratios because
+/// the boost state cannot be read is a thing somebody can go and fix.
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct Ceiling {
+    /// The most this machine can produce.
+    pub permit: Permit,
+    /// Why it is capped there, as a clause that reads after the word because.
+    pub because: String,
+}
+
+impl Ceiling {
+    /// Names a ceiling and the reason for it.
+    #[must_use]
+    pub fn new(permit: Permit, because: impl Into<String>) -> Self {
+        Self {
+            permit,
+            because: because.into(),
+        }
+    }
+}
+
+/// Why a run is not allowed to produce what it asked for.
+///
+/// Both variants name something specific. A refusal that says the machine is unsuitable and stops
+/// there is one a person works around by disabling the check.
+#[derive(Clone, PartialEq, Eq, Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum Refusal {
+    /// A gate failed.
+    #[error("the {gate} gate failed: this machine reports {observed}, and {asked} needs {wanted}")]
+    Gate {
+        /// Which gate.
+        gate: String,
+        /// What it read.
+        observed: String,
+        /// What would have passed.
+        wanted: String,
+        /// What the run had asked to produce.
+        asked: Permit,
+    },
+    /// Every gate passed, but this machine does not produce what was asked for.
+    #[error(
+        "{asked} were asked for, and this is {class}, which produces {permits} because {because}"
+    )]
+    Ceiling {
+        /// The class it was identified as.
+        class: Class,
+        /// The most it can produce.
+        permits: Permit,
+        /// Why it is capped there.
+        because: String,
+        /// What the run had asked to produce.
+        asked: Permit,
+    },
+}

--- a/crates/bench-env/src/lib.rs
+++ b/crates/bench-env/src/lib.rs
@@ -1,11 +1,441 @@
-//! Environment capture and eligibility gates.
+//! Environment capture and machine eligibility gates.
 //!
-//! A machine that fails a gate does not produce a slower number, it produces a
-//! number that should not be published. So the gates abort the run and name the
-//! gate that failed, and that behaviour is not configurable.
+//! Before a run takes a single measurement it asks this crate whether the machine is fit to produce
+//! the kind of number the run wants. The answer is yes, or it is a refusal naming the gate that
+//! failed. There is no third answer and there is no override, because a number with a warning
+//! attached is a number that gets copied without the warning and then it is on a slide somewhere.
 //!
-//! Nothing is implemented yet. See the milestone that owns this crate in
-//! `docs/ROADMAP.md`.
+//! ```no_run
+//! use bench_env::{Capture, Permit};
+//!
+//! let capture = Capture::take();
+//! capture.require(Permit::Durations)?;
+//! # Ok::<(), bench_env::Refusal>(())
+//! ```
+//!
+//! # The two halves of a capture
+//!
+//! [`Facts`] is what the machine is: the processor, the memory fitted, the governor, the boost
+//! state, whether a run was pinned, whether there is a hypervisor underneath. It is stable until
+//! somebody reconfigures the machine, and it is what gets hashed into every result row.
+//!
+//! [`Conditions`] is what the machine is doing: free memory, load average, how many other processes
+//! are busy. It moves between one measurement and the next, so it is recorded and gated and it is
+//! not hashed. Hashing it would give every row a hash of its own, and grouping rows is the only
+//! thing the hash is for.
+//!
+//! # Where the strictness actually is
+//!
+//! Not in the gates. A gate can only fail on something it can read, and the settings that matter
+//! most are the ones some platforms do not expose at all. So the rule that does the work is in
+//! [`policy::ceiling`]: a machine whose clock settings cannot be read produces ratios rather than
+//! durations, on the grounds that being unable to see a setting is not evidence that the setting is
+//! right. That is why the workstation running Windows is capped below the same workstation running
+//! Linux, and why the cap shows up as a ceiling with a reason rather than as a gate that quietly
+//! passed.
 
-/// The version of this crate, as reported by build metadata.
+mod class;
+mod conditions;
+mod facts;
+mod gate;
+pub mod policy;
+
+pub use class::{Class, classify};
+pub use conditions::Conditions;
+pub use facts::{Facts, Hypervisor, Setting};
+pub use gate::{Ceiling, Gate, Outcome, Permit, Refusal};
+
+use bench_core::{EnvironmentHash, METHODOLOGY_VERSION};
+use serde::{Deserialize, Serialize};
+
+/// The version of this crate, recorded so a capture says which code produced it.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Everything known about the machine a measurement was taken on.
+///
+/// This is what gets written to `environment.json` beside a set of results, and [`Capture::hash`] is
+/// what goes into every row of them.
+#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
+pub struct Capture {
+    /// The methodology version the measurement was taken under.
+    pub methodology: u32,
+    /// Which hardware class this machine was identified as.
+    pub class: Class,
+    /// The most this machine can produce, and why.
+    pub ceiling: Ceiling,
+    /// What the machine is.
+    pub facts: Facts,
+    /// What the machine was doing when the capture was taken.
+    pub conditions: Conditions,
+    /// Every gate that could be evaluated here, and what it said.
+    pub gates: Vec<Gate>,
+    /// The digest of [`Capture::facts`], which every result row carries.
+    pub hash: EnvironmentHash,
+}
+
+impl Capture {
+    /// Reads the machine and evaluates its gate set.
+    ///
+    /// Takes a moment, because per process CPU usage is a rate and a rate needs two readings with a
+    /// gap between them.
+    #[must_use]
+    pub fn take() -> Self {
+        Self::of(Facts::read(), Conditions::observe())
+    }
+
+    /// Classifies and gates a machine that has already been read.
+    ///
+    /// Private because a capture is supposed to describe a machine somebody measured on, and a
+    /// constructor that takes the facts as an argument is a constructor for a machine that does not
+    /// exist. The tests want exactly that, which is the one legitimate use.
+    fn of(facts: Facts, conditions: Conditions) -> Self {
+        let class = classify(&facts);
+
+        Self {
+            methodology: METHODOLOGY_VERSION,
+            hash: hash(class, &facts),
+            ceiling: policy::ceiling(class, &facts),
+            gates: policy::gates(class, &facts, &conditions),
+            class,
+            facts,
+            conditions,
+        }
+    }
+
+    /// The first gate that failed, if one did.
+    #[must_use]
+    pub fn failed(&self) -> Option<&Gate> {
+        self.gates.iter().find(|gate| !gate.outcome.passed())
+    }
+
+    /// What this machine may be used to produce as things stand.
+    ///
+    /// A failed gate takes it to nothing rather than down one step. A machine with something else
+    /// running on it is not a machine whose ratios are trustworthy either, because the interference
+    /// does not have to land evenly on the two sides of a ratio.
+    #[must_use]
+    pub fn permits(&self) -> Permit {
+        if self.failed().is_some() {
+            Permit::Nothing
+        } else {
+            self.ceiling.permit
+        }
+    }
+
+    /// Says whether the run may go ahead, and refuses by name when it may not.
+    ///
+    /// # Errors
+    ///
+    /// [`Refusal::Gate`] when a gate failed, naming it and saying what would have passed.
+    /// [`Refusal::Ceiling`] when every gate passed and this machine still does not produce what was
+    /// asked for.
+    pub fn require(&self, asked: Permit) -> Result<(), Refusal> {
+        // Gates first. A failing gate is something a person can go and change, and a ceiling is
+        // usually not, so reporting the ceiling on a machine that also has something running on it
+        // would send them off to argue with the machine notes about the wrong problem.
+        if let Some(gate) = self.failed() {
+            let Outcome::Fail { observed, wanted } = &gate.outcome else {
+                unreachable!("failed() only returns a gate whose outcome is a failure")
+            };
+            return Err(Refusal::Gate {
+                gate: gate.name.clone(),
+                observed: observed.clone(),
+                wanted: wanted.clone(),
+                asked,
+            });
+        }
+
+        if self.ceiling.permit < asked {
+            return Err(Refusal::Ceiling {
+                class: self.class,
+                permits: self.ceiling.permit,
+                because: self.ceiling.because.clone(),
+                asked,
+            });
+        }
+
+        Ok(())
+    }
+
+    /// The capture as the JSON that gets written beside a set of results.
+    ///
+    /// # Panics
+    ///
+    /// If the capture cannot be serialised, which would mean a field was added that serde cannot
+    /// represent. There is no such field and there is no recovery from one.
+    #[must_use]
+    pub fn to_json(&self) -> String {
+        serde_json::to_string_pretty(self).expect("a capture is made only of serialisable fields")
+    }
+}
+
+/// Hashes what the machine is, and nothing about what it was doing.
+///
+/// The class is in the hash as well as the facts it was derived from. It is redundant today, and it
+/// stops a change to the classification rules from silently producing the same hash for a machine
+/// that is now understood differently.
+fn hash(class: Class, facts: &Facts) -> EnvironmentHash {
+    #[derive(Serialize)]
+    struct Hashed<'a> {
+        methodology: u32,
+        class: Class,
+        facts: &'a Facts,
+    }
+
+    let canonical = serde_json::to_vec(&Hashed {
+        methodology: METHODOLOGY_VERSION,
+        class,
+        facts,
+    })
+    .expect("the facts are made only of serialisable fields");
+
+    EnvironmentHash::from_bytes(*blake3::hash(&canonical).as_bytes())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Capture, Ceiling, Class, Conditions, Facts, Hypervisor, Permit, Refusal, Setting};
+
+    /// The workstation, configured the way a timing run wants it.
+    fn workstation() -> Facts {
+        Facts {
+            arch: "x86_64".to_owned(),
+            os: "linux".to_owned(),
+            os_version: Setting::Reading("24.04".to_owned()),
+            kernel: Setting::Reading("6.8.0-51-generic".to_owned()),
+            cpu: "13th Gen Intel(R) Core(TM) i9-13900K".to_owned(),
+            logical_cpus: 32,
+            physical_cores: Some(24),
+            memory_bytes: 64 * 1024 * 1024 * 1024,
+            hypervisor: Hypervisor::None,
+            governor: Setting::Reading("performance".to_owned()),
+            turbo: Setting::Reading("off".to_owned()),
+            affinity: Setting::Reading("0-15".to_owned()),
+        }
+    }
+
+    /// One of the shared tenancy servers.
+    fn epyc_guest() -> Facts {
+        Facts {
+            cpu: "AMD EPYC 7002 series".to_owned(),
+            logical_cpus: 8,
+            physical_cores: Some(8),
+            memory_bytes: 24 * 1024 * 1024 * 1024,
+            hypervisor: Hypervisor::Guest("QEMU".to_owned()),
+            governor: Setting::Unreadable("the guest exposes no cpufreq governor".to_owned()),
+            turbo: Setting::Unreadable("the guest exposes no boost switch".to_owned()),
+            affinity: Setting::Reading("0-3".to_owned()),
+            ..workstation()
+        }
+    }
+
+    /// A machine with nothing else happening on it.
+    fn idle(facts: &Facts) -> Conditions {
+        Conditions {
+            available_memory_bytes: facts.memory_bytes / 2,
+            load_average: Some(0.1),
+            busy_processes: 0,
+        }
+    }
+
+    #[test]
+    fn a_gate_that_fails_names_itself_in_the_refusal() {
+        let facts = workstation();
+        let conditions = Conditions {
+            available_memory_bytes: 1024 * 1024 * 1024,
+            ..idle(&facts)
+        };
+
+        let refusal = Capture::of(facts, conditions)
+            .require(Permit::Durations)
+            .expect_err("a machine with one gigabyte free is not fit to measure on");
+
+        let Refusal::Gate { gate, wanted, .. } = refusal else {
+            panic!("a failing gate has to refuse as a gate, not as a ceiling: {refusal:?}")
+        };
+        assert_eq!(gate, "memory-headroom");
+        assert!(wanted.contains("16.0 GiB"), "wanted {wanted}");
+    }
+
+    #[test]
+    fn a_failing_gate_is_reported_before_the_ceiling_is() {
+        // Both are wrong with this machine: it is a guest, which caps it at nothing, and it also has
+        // something running on it. The gate is the half a person can go and fix, so it comes first.
+        let facts = epyc_guest();
+        let conditions = Conditions {
+            busy_processes: 3,
+            ..idle(&facts)
+        };
+
+        let refusal = Capture::of(facts, conditions)
+            .require(Permit::Ratios)
+            .expect_err("three busy processes is not an idle machine");
+
+        assert!(
+            matches!(refusal, Refusal::Gate { ref gate, .. } if gate == "busy-processes"),
+            "{refusal:?}"
+        );
+    }
+
+    #[test]
+    fn a_shared_tenancy_guest_is_refused_however_idle_it_looks() {
+        let facts = epyc_guest();
+        let conditions = idle(&facts);
+        let capture = Capture::of(facts, conditions);
+
+        assert_eq!(capture.class, Class::A);
+        assert!(capture.failed().is_none(), "{:?}", capture.gates);
+        assert_eq!(capture.permits(), Permit::Nothing);
+
+        let refusal = capture
+            .require(Permit::Ratios)
+            .expect_err("a guest does not produce a ratio either");
+        assert!(matches!(refusal, Refusal::Ceiling { .. }), "{refusal:?}");
+    }
+
+    #[test]
+    fn the_workstation_produces_durations_when_its_clock_settings_can_be_read() {
+        let facts = workstation();
+        let conditions = idle(&facts);
+        let capture = Capture::of(facts, conditions);
+
+        assert_eq!(capture.class, Class::B);
+        assert_eq!(capture.permits(), Permit::Durations);
+        capture
+            .require(Permit::Durations)
+            .expect("a pinned workstation with boost off and the performance governor");
+    }
+
+    #[test]
+    fn the_workstation_drops_to_ratios_when_they_cannot_be_read() {
+        // This is the machine under Windows. Every gate that can be evaluated passes, because the
+        // ones that would have caught a drifting clock cannot be evaluated at all. Being unable to
+        // see a setting is not evidence that the setting is right, so the ceiling falls.
+        let facts = Facts {
+            os: "windows".to_owned(),
+            turbo: Setting::Unreadable("windows does not expose the boost state".to_owned()),
+            affinity: Setting::Unreadable("not implemented for windows".to_owned()),
+            governor: Setting::Reading("High performance".to_owned()),
+            ..workstation()
+        };
+        let conditions = idle(&facts);
+        let capture = Capture::of(facts, conditions);
+
+        assert_eq!(capture.class, Class::B);
+        assert!(capture.failed().is_none(), "{:?}", capture.gates);
+        assert_eq!(capture.permits(), Permit::Ratios);
+
+        let refusal = capture
+            .require(Permit::Durations)
+            .expect_err("nothing checked whether the clock was steady");
+        let Refusal::Ceiling { because, .. } = refusal else {
+            panic!("expected a ceiling: {refusal:?}")
+        };
+        assert!(because.contains("the boost state"), "because {because}");
+        assert!(
+            because.contains("the processor affinity"),
+            "because {because}"
+        );
+    }
+
+    #[test]
+    fn a_run_that_is_free_to_move_across_every_processor_fails_the_pinning_gate() {
+        let facts = Facts {
+            affinity: Setting::Reading("0-31".to_owned()),
+            ..workstation()
+        };
+        let conditions = idle(&facts);
+
+        let refusal = Capture::of(facts, conditions)
+            .require(Permit::Durations)
+            .expect_err("an unpinned run on a hybrid part has two modes in it");
+
+        assert!(
+            matches!(refusal, Refusal::Gate { ref gate, .. } if gate == "core-pinning"),
+            "{refusal:?}"
+        );
+    }
+
+    #[test]
+    fn the_workstation_under_a_hypervisor_is_still_the_workstation() {
+        let facts = Facts {
+            hypervisor: Hypervisor::Wsl,
+            ..workstation()
+        };
+        let conditions = idle(&facts);
+        let capture = Capture::of(facts, conditions);
+
+        assert_eq!(capture.class, Class::B, "the silicon has not changed");
+        assert_eq!(capture.permits(), Permit::Ratios, "what it can say has");
+    }
+
+    #[test]
+    fn the_environment_hash_ignores_what_the_machine_was_doing() {
+        let facts = workstation();
+        let busy = Conditions {
+            available_memory_bytes: facts.memory_bytes / 3,
+            load_average: Some(9.0),
+            busy_processes: 4,
+            ..idle(&facts)
+        };
+
+        let quiet = Capture::of(facts.clone(), idle(&facts));
+        let loud = Capture::of(facts, busy);
+
+        assert_eq!(
+            quiet.hash, loud.hash,
+            "a hash that moved with the load average could not group anything"
+        );
+        assert_ne!(
+            quiet.permits(),
+            loud.permits(),
+            "the load average is supposed to be caught by a gate instead"
+        );
+    }
+
+    #[test]
+    fn the_environment_hash_changes_when_a_setting_stops_being_readable() {
+        let readable = workstation();
+        let unreadable = Facts {
+            turbo: Setting::Unreadable("windows does not expose the boost state".to_owned()),
+            ..readable.clone()
+        };
+
+        let before = Capture::of(readable.clone(), idle(&readable));
+        let after = Capture::of(unreadable.clone(), idle(&unreadable));
+
+        assert_ne!(
+            before.hash, after.hash,
+            "two rows where different things were checked must not look interchangeable"
+        );
+    }
+
+    #[test]
+    fn a_machine_nobody_has_written_a_gate_set_for_produces_nothing() {
+        let facts = Facts {
+            os: "freebsd".to_owned(),
+            arch: "riscv64".to_owned(),
+            cpu: "something nobody has measured on".to_owned(),
+            hypervisor: Hypervisor::None,
+            ..workstation()
+        };
+        let conditions = idle(&facts);
+        let capture = Capture::of(facts, conditions);
+
+        assert_eq!(capture.class, Class::Unknown);
+        assert_eq!(capture.permits(), Permit::Nothing);
+    }
+
+    #[test]
+    fn every_class_has_a_ceiling_with_a_reason_on_it() {
+        // The reason is what a person acts on, so an empty one is a bug even though nothing would
+        // fail without this test.
+        let facts = workstation();
+        for class in [Class::A, Class::B, Class::C, Class::D, Class::Unknown] {
+            let Ceiling { because, .. } = crate::policy::ceiling(class, &facts);
+            assert!(!because.is_empty(), "{class} has no reason on its ceiling");
+        }
+    }
+}

--- a/crates/bench-env/src/policy.rs
+++ b/crates/bench-env/src/policy.rs
@@ -1,0 +1,260 @@
+//! The gate set for each hardware class, and the most each class can ever produce.
+//!
+//! This is the file to read to find out why a machine was refused, and the file to change if the
+//! answer is wrong. Everything else in the crate reads a machine or reports a decision. The decision
+//! itself is here.
+//!
+//! The four classes are the ones in `docs/MACHINES.md` and the reasoning is that document's rather
+//! than this one's. Where a rule here looks arbitrary, the machine notes say why it is not.
+
+use crate::class::Class;
+use crate::conditions::Conditions;
+use crate::facts::{Facts, Hypervisor};
+use crate::gate::{Ceiling, Gate, Permit};
+
+/// How much of the fitted memory has to still be available.
+///
+/// A quarter. Not because a measurement needs a quarter of the machine's memory, but because a
+/// machine with less than that free has something substantial resident in it, and whatever that is
+/// has a working set competing for the same cache.
+const MEMORY_HEADROOM: f64 = 0.25;
+
+/// The floor under that fraction, in bytes.
+///
+/// A quarter of a small machine is not much, and the corpora here are measured in gigabytes.
+const MEMORY_FLOOR: u64 = 2 * 1024 * 1024 * 1024;
+
+/// The most load per logical processor that still counts as an idle machine.
+///
+/// A fifth. A completely idle Linux box sits near zero and the housekeeping that wakes up on a timer
+/// does not reach this. One busy thread on an eight processor machine does.
+const LOAD_PER_CPU: f64 = 0.2;
+
+/// What the class can produce at best, and why it is capped there.
+///
+/// Two classes are capped by what they are: a shared tenancy guest cannot produce a duration however
+/// idle it looks, and the development machine is not a measurement machine. The workstation is
+/// capped by how much of it can be read, which is the rule that matters most here. Where the
+/// governor, the boost state and the processor affinity cannot be read, they have not been checked,
+/// and a machine nobody checked produces ratios rather than durations. Being unable to see a setting
+/// is not evidence that the setting is right.
+#[must_use]
+pub fn ceiling(class: Class, facts: &Facts) -> Ceiling {
+    match class {
+        Class::A => Ceiling::new(
+            Permit::Nothing,
+            "the guest cannot set the governor, cannot disable boost, cannot pin to a physical core \
+             and cannot see what a neighbouring tenant is doing",
+        ),
+        Class::B => workstation_ceiling(facts),
+        Class::C => Ceiling::new(
+            Permit::Ratios,
+            "a shared hosted runner has a run to run spread of five to fifteen percent, which is \
+             larger than most effects worth reporting",
+        ),
+        Class::D => Ceiling::new(
+            Permit::Nothing,
+            "this is the development machine, which exists to check that the harness builds and \
+             runs",
+        ),
+        Class::Unknown => Ceiling::new(
+            Permit::Nothing,
+            "nobody has written a gate set for this machine, so nothing about it has been checked",
+        ),
+    }
+}
+
+/// The workstation is the one class whose ceiling depends on what can be read rather than on what it
+/// is.
+fn workstation_ceiling(facts: &Facts) -> Ceiling {
+    if facts.hypervisor == Hypervisor::Wsl {
+        return Ceiling::new(
+            Permit::Ratios,
+            "there is a hypervisor with memory ballooning underneath, which is fine for a ratio \
+             taken inside one run and is a known unknown for an absolute number",
+        );
+    }
+
+    let unreadable: Vec<&str> = [
+        ("the frequency governor", &facts.governor),
+        ("the boost state", &facts.turbo),
+        ("the processor affinity", &facts.affinity),
+    ]
+    .into_iter()
+    .filter(|(_, setting)| setting.reading().is_none())
+    .map(|(name, _)| name)
+    .collect();
+
+    if unreadable.is_empty() {
+        Ceiling::new(
+            Permit::Durations,
+            "everything that keeps the clock steady on this machine can be read and has been checked",
+        )
+    } else {
+        Ceiling::new(
+            Permit::Ratios,
+            format!(
+                "{} cannot be read here, so nothing has checked whether the clock is steady",
+                unreadable.join(", ")
+            ),
+        )
+    }
+}
+
+/// Every gate that can be evaluated on this machine, in the order they are worth reading.
+///
+/// A setting that could not be read produces no gate at all rather than a third kind of outcome. The
+/// reason is in [`crate::gate`]: an outcome between passing and failing has to be interpreted by
+/// every caller, and they will not all interpret it the same way. What the unreadable setting does
+/// instead is lower the ceiling and change the environment hash.
+#[must_use]
+pub fn gates(class: Class, facts: &Facts, conditions: &Conditions) -> Vec<Gate> {
+    let mut gates = vec![
+        memory_headroom(facts, conditions),
+        busy_processes(conditions),
+    ];
+
+    if let Some(load) = conditions.load_average {
+        gates.push(load_average(facts, load));
+    }
+
+    if class == Class::B {
+        gates.extend(workstation_gates(facts));
+    }
+
+    gates
+}
+
+/// The gates that only apply to the workstation, and only where the setting is readable.
+fn workstation_gates(facts: &Facts) -> Vec<Gate> {
+    let mut gates = Vec::new();
+
+    if let Some(governor) = facts.governor.reading() {
+        // Two different settings under one name, because they answer the same question. The Linux
+        // reading is a cpufreq governor and the Windows reading is a power scheme, and the wanted
+        // string says which one is being asked for so that the refusal is actionable on the machine
+        // it came from.
+        //
+        // Which one it is comes from the facts and not from the target this binary was built for.
+        // In a live run those are the same thing, so the distinction costs nothing and buys the
+        // property that a capture means the same whoever reads it back.
+        if facts.os == "windows" {
+            let steady = governor.contains("High performance") || governor.contains("Ultimate");
+            gates.push(Gate::check(
+                "power-scheme",
+                steady,
+                format!("the {governor} power scheme"),
+                "the High performance or Ultimate Performance scheme, so that the clock does not \
+                 drop between samples",
+            ));
+        } else {
+            gates.push(Gate::check(
+                "frequency-governor",
+                governor == "performance",
+                format!("the {governor} governor"),
+                "the performance governor, so that the clock does not drop between samples",
+            ));
+        }
+    }
+
+    if let Some(turbo) = facts.turbo.reading() {
+        gates.push(Gate::check(
+            "turbo",
+            turbo == "off",
+            format!("boost {turbo}"),
+            "boost off, so that the clock does not fall away as the part warms up",
+        ));
+    }
+
+    if let Some(affinity) = facts.affinity.reading() {
+        // This is a hybrid part. What is being checked is that somebody restricted the run at all,
+        // because a run free to move between a performance core and an efficiency core produces a
+        // distribution with two modes, and a confidence interval over two modes describes neither.
+        // Which processors are the performance ones is not something this can work out portably, so
+        // the gate checks that a choice was made and the capture records which choice it was.
+        let everything = format!("0-{}", facts.logical_cpus.saturating_sub(1));
+        gates.push(Gate::check(
+            "core-pinning",
+            affinity != everything && !affinity.is_empty(),
+            format!("this run may use processors {affinity}"),
+            "a run pinned to the performance cores rather than free to move across all of them",
+        ));
+    }
+
+    gates
+}
+
+/// Enough memory left that nothing substantial is resident alongside the measurement.
+fn memory_headroom(facts: &Facts, conditions: &Conditions) -> Gate {
+    let available = conditions.available_memory_bytes;
+    let wanted = fraction_of(facts.memory_bytes, MEMORY_HEADROOM).max(MEMORY_FLOOR);
+
+    Gate::check(
+        "memory-headroom",
+        available >= wanted,
+        format!("{} available", gibibytes(available)),
+        format!("at least {} available", gibibytes(wanted)),
+    )
+}
+
+/// Nothing else on the machine is doing real work.
+fn busy_processes(conditions: &Conditions) -> Gate {
+    Gate::check(
+        "busy-processes",
+        conditions.busy_processes == 0,
+        format!(
+            "{} other processes using a processor",
+            conditions.busy_processes
+        ),
+        "nothing else running",
+    )
+}
+
+/// The same question as the busy process gate, asked of the kernel's own summary.
+///
+/// Both are kept. The process walk sees a single busy process on an otherwise idle machine that the
+/// load average has not caught up with yet, and the load average sees a machine that is thrashing in
+/// a way no single process accounts for.
+fn load_average(facts: &Facts, load: f64) -> Gate {
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "a processor count large enough to lose precision in an f64 does not exist"
+    )]
+    let wanted = LOAD_PER_CPU * facts.logical_cpus as f64;
+
+    Gate::check(
+        "load-average",
+        load <= wanted,
+        format!("a one minute load average of {load:.2}"),
+        format!("a one minute load average no higher than {wanted:.2}"),
+    )
+}
+
+/// A fraction of a byte count, without going through a lossy conversion in the common direction.
+fn fraction_of(bytes: u64, fraction: f64) -> u64 {
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "a memory size large enough to lose precision in an f64 does not exist"
+    )]
+    let scaled = bytes as f64 * fraction;
+
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "a fraction between zero and one of a u64 is in range and not negative"
+    )]
+    let rounded = scaled as u64;
+
+    rounded
+}
+
+/// Byte counts as a person would say them out loud.
+fn gibibytes(bytes: u64) -> String {
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "a memory size large enough to lose precision in an f64 does not exist"
+    )]
+    let gib = bytes as f64 / (1024.0 * 1024.0 * 1024.0);
+
+    format!("{gib:.1} GiB")
+}

--- a/crates/bench-env/src/policy.rs
+++ b/crates/bench-env/src/policy.rs
@@ -104,7 +104,7 @@ fn workstation_ceiling(facts: &Facts) -> Ceiling {
 /// Every gate that can be evaluated on this machine, in the order they are worth reading.
 ///
 /// A setting that could not be read produces no gate at all rather than a third kind of outcome. The
-/// reason is in [`crate::gate`]: an outcome between passing and failing has to be interpreted by
+/// reason is on [`crate::Outcome`]: an outcome between passing and failing has to be interpreted by
 /// every caller, and they will not all interpret it the same way. What the unreadable setting does
 /// instead is lower the ceiling and change the environment hash.
 #[must_use]

--- a/docs/MACHINES.md
+++ b/docs/MACHINES.md
@@ -52,6 +52,29 @@ This is a real limitation and it is worth being blunt about it, because the arm6
 
 The development machine. Used for portability checking and for making sure the harness builds and runs, and for nothing that gets published.
 
+## The gate sets
+
+Every class above has a gate set, and `iris-bench check` evaluates it before a run takes a measurement. A gate that fails aborts and names itself. There is no warning and no override, because a number with a caveat attached is a number that gets copied without the caveat.
+
+Three gates apply everywhere they can be evaluated. `memory-headroom` wants a quarter of the fitted memory still available, and never less than 2 GiB, because a machine with less than that free has something substantial resident in it and whatever that is has a working set competing for the same cache. `busy-processes` wants nothing else above five percent of a processor. `load-average` wants no more than a fifth of a load unit per logical processor, and exists only where the platform keeps a load average, which is everywhere except Windows.
+
+Class B carries three more. `frequency-governor` wants the performance governor on Linux, and its Windows counterpart `power-scheme` wants the High performance or Ultimate Performance scheme. `turbo` wants boost off, so the clock does not fall away as the part warms up. `core-pinning` wants the run restricted to a subset of the processors rather than free to move across all of them, because a run that can migrate between a performance core and an efficiency core produces a distribution with two modes and a confidence interval over two modes describes neither of them.
+
+### What a class can produce at best
+
+| Class | At best | Why it is capped there |
+| --- | --- | --- |
+| A, virtualised EPYC | nothing published | the guest cannot set the governor, cannot disable boost, cannot pin to a physical core and cannot see what a neighbour is doing |
+| B, the i9-13900K | durations, or ratios | durations when the governor, the boost state and the affinity can all be read, ratios when they cannot, and ratios under WSL2 whatever else is readable |
+| C, hosted arm64 | ratios | a shared hosted runner has a run to run spread of five to fifteen percent |
+| D, macOS | nothing published | the development machine, which exists to check that the harness builds and runs |
+
+The class B row is the one worth reading twice, because it is the rule that does most of the work and it is not a gate. A gate can only fail on something it can read, and the settings that matter most are exactly the ones some platforms do not expose. Under Windows the boost state and the processor affinity cannot be read by an unprivileged process, so nothing has checked whether the clock is steady, so that machine produces ratios. Being unable to see a setting is not evidence that the setting is right.
+
+That is not a hypothetical. The M0 probe in iris ran on this machine under Windows and produced a windowed overhead anywhere between minus eight and plus eighteen percent across twenty four runs in one sitting, on a gate set at three, with the flat scan alone moving by a third across an hour. The ceiling rule predicted that before the measurement was taken, which is the argument for keeping it.
+
+A setting that cannot be read is recorded as unreadable rather than skipped, and that recording goes into the environment hash. So the same machine measured under two operating systems produces two different hashes and a row from one cannot be quietly compared against a row from the other.
+
 ## The AVX-512 problem
 
 There is no AVX-512 anywhere in this fleet. The EPYC virtual machines expose AVX2 as their ceiling, and Raptor Lake has the unit fused off. This is not a configuration choice and it cannot be worked around by trying harder.


### PR DESCRIPTION
Closes #2.

A capture asks the machine two different kinds of question, and the split between them is what the rest of this follows from.

The facts are what the machine is: the processor, the memory fitted, the frequency governor, the boost state, whether the run was pinned, whether there is a hypervisor underneath. They are stable until somebody reconfigures the box, and they are hashed into every result row. The conditions are what the machine is doing right now: available memory, load average, how many other processes are using a processor. They move between one measurement and the next, so they are gated and they are not hashed. Hashing them would give every row its own hash, which destroys the one property the hash is there for, namely that two rows carrying different hashes must not be compared.

## The rule that does most of the work is not a gate

A gate can only fail on something it can read, and the settings that matter most are the ones some platforms do not expose at all. The tempting move is a third outcome next to pass and fail, something like unknown, and it is the wrong move because every caller would interpret it differently and most of them would interpret it as fine.

So an unreadable setting does two other things instead. It lowers the class ceiling, so the machine is capped at ratios rather than absolute durations. And it goes into the environment hash, so rows where different things were checkable cannot be silently compared with each other. Being unable to see a setting is not evidence that the setting is right.

The workstation under Windows is the case this was built for. It cannot report its boost state and it cannot report its processor affinity, so it is capped at ratios. That was written before the M0 window sweep in the other repo measured the same machine drifting by a third on a flat scan across an hour of idle time, which is about as direct a confirmation as a rule of this kind gets.

## What is here

`bench_core::EnvironmentHash` is a 32 byte digest that prints, parses and serialises as 64 lower case hex characters. It lives in bench-core rather than bench-env because it belongs to the row, not to the crate that computes it, and a consumer reading result rows back should not have to depend on the environment crate to understand one.

`bench-env` gets five new modules. `class` puts a machine into one of the four hardware classes from the machine notes. `facts` and `conditions` are the two halves of the capture described above. `gate` is the vocabulary: a permit ordered weakest first, an outcome that is a pass or a fail and deliberately nothing else, and a refusal that names either the gate that failed or the ceiling that was too low. `policy` is where the actual thresholds live, in one place, as named constants.

`Capture::require` checks gates before it checks the ceiling. That order is on purpose: a failing gate is something a person can go and fix, and a ceiling is not, so the more useful message is the one that comes out first.

`iris-bench check` is now implemented. It prints the class, the hash, a table of every gate with what was observed, and what the machine is good for, then exits non zero with the refusal if the machine cannot produce what was asked for. Exit status and message come from the same place, so they cannot disagree.

Here it is on the development machine, which is a laptop with a browser open, and the output is what it should be:

```
class D, the macOS development machine
environment 85107ce39b7c0758258a486acc48b8c1a173e6b4d1bd917f41ac3c2452e9a731
  pass  memory-headroom      16.9 GiB available
  FAIL  busy-processes       7 other processes using a processor, wanted nothing else running
  FAIL  load-average         a one minute load average of 12.84, wanted a one minute load average no higher than 2.00
this machine is good for no published measurement
Error: the busy-processes gate failed: this machine reports 7 other processes using a processor, and absolute durations needs nothing else running
```

## One bug worth calling out

`workstation_gates` originally branched on `cfg!(target_os = "windows")`, which is the build target rather than the machine the facts describe. A test reading back a Windows capture on macOS caught it, because the Windows facts were being judged by the Linux governor rule. It now branches on `facts.os`. In a live run the two coincide, so the change costs nothing, and it buys the property that a capture means the same thing whoever reads it back and wherever they read it.

## Also in here

`--no-tests=pass` comes out of both nextest invocations in CI, along with the comment saying it goes when the first real test lands. There are 42 tests now.

The bench-env and bench-core READMEs are reflowed to one unwrapped line per paragraph. They had a blank line between every sentence, which is not the house style.

## Left out

Six other crate READMEs still carry that same blank line between sentences problem: bench-cli, bench-corpus, bench-driver, bench-report, bench-run and bench-store. They are untouched here because fixing them has nothing to do with gates and would bury the part of this that needs reading.
