### PR TITLE
Measure the noise floor of every hardware class

### DIFF
--- a/.github/workflows/noise.yml
+++ b/.github/workflows/noise.yml
@@ -69,13 +69,22 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
       - name: Build the harness
         run: cargo build --release --locked -p iris-bench-cli
+      # Measured with --anyway, because the runner agent is on a processor for
+      # the whole job and the busy-processes gate can never pass on a hosted
+      # runner. That is not a reason to skip the measurement, it is the machine
+      # as it is rented, and the floor of the machine as it is rented is the
+      # only one worth having for a class that only exists inside a job.
+      #
+      # pipefail is what makes a refusal fail the job. Without it the exit
+      # status would be tee's and a probe that refused would look like a pass.
       - name: Measure the floor
         env:
           ROUNDS: ${{ inputs.rounds || '40' }}
           SAMPLES: ${{ inputs.samples || '100' }}
         run: |
+          set -o pipefail
           {
             echo '```'
-            ./target/release/iris-bench noise --rounds "$ROUNDS" --samples "$SAMPLES"
+            ./target/release/iris-bench noise --rounds "$ROUNDS" --samples "$SAMPLES" --anyway
             echo '```'
           } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/noise.yml
+++ b/.github/workflows/noise.yml
@@ -1,0 +1,81 @@
+name: Noise floor
+
+# What this measures is how far a machine's answer moves when the question did
+# not change, which is the floor under every effect this repository reports. A
+# result smaller than the floor of the machine it came from is not a result.
+#
+# Only the hosted arm64 runner is here, because it is the only class in
+# docs/MACHINES.md that is a hosted runner. The other three classes are machines
+# in the fleet and their numbers are taken on them directly, by the same command
+# with the same arguments.
+#
+# On a pull request this runs only when the probe itself changes, which is the
+# one time a published floor might no longer describe what the tool measures.
+
+on:
+  workflow_dispatch:
+    inputs:
+      rounds:
+        description: How many times to start the process again
+        required: false
+        default: "40"
+        type: string
+      samples:
+        description: How many samples to take inside each round
+        required: false
+        default: "100"
+        type: string
+  pull_request:
+    paths:
+      - .github/workflows/noise.yml
+      - crates/bench-cli/src/noise.rs
+      - crates/bench-core/src/stats.rs
+
+permissions:
+  contents: read
+
+concurrency:
+  group: noise-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  noise:
+    name: Noise floor on ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { name: linux-aarch64, os: ubuntu-24.04-arm }
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: noise-${{ matrix.name }}
+      - name: Record what this machine actually is
+        run: |
+          {
+            echo "## ${{ matrix.name }}"
+            echo '```'
+            uname -srm
+            echo "threads: $(nproc)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Build the harness
+        run: cargo build --release --locked -p iris-bench-cli
+      - name: Measure the floor
+        env:
+          ROUNDS: ${{ inputs.rounds || '40' }}
+          SAMPLES: ${{ inputs.samples || '100' }}
+        run: |
+          {
+            echo '```'
+            ./target/release/iris-bench noise --rounds "$ROUNDS" --samples "$SAMPLES"
+            echo '```'
+          } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,6 +750,7 @@ name = "iris-bench-cli"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "bench-core",
  "bench-corpus",
  "bench-env",
  "bench-report",

--- a/crates/bench-cli/Cargo.toml
+++ b/crates/bench-cli/Cargo.toml
@@ -15,6 +15,7 @@ publish.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+bench-core.workspace = true
 bench-corpus.workspace = true
 bench-env.workspace = true
 bench-report.workspace = true

--- a/crates/bench-cli/src/main.rs
+++ b/crates/bench-cli/src/main.rs
@@ -54,6 +54,9 @@ enum Command {
         /// The spread above which a class is ratios only, as a fraction.
         #[arg(long, default_value_t = 0.02)]
         limit: f64,
+        /// Measure even though a gate failed, which answers what a busy machine looks like.
+        #[arg(long)]
+        anyway: bool,
         /// Run one round and print what it measured, which is how a round is started.
         #[arg(long, hide = true)]
         one_round: bool,
@@ -138,12 +141,13 @@ fn main() -> anyhow::Result<()> {
             samples,
             warmup,
             limit,
+            anyway,
             one_round,
         } => {
             if one_round {
                 noise::one_round(samples, warmup)
             } else {
-                noise::probe(rounds, samples, warmup, limit)
+                noise::probe(rounds, samples, warmup, limit, anyway)
             }
         }
         other => anyhow::bail!("not implemented yet: {other:?}"),

--- a/crates/bench-cli/src/main.rs
+++ b/crates/bench-cli/src/main.rs
@@ -1,6 +1,8 @@
 //! `iris-bench`, the command line tool.
 //!
-//! Only `check` is implemented. See `docs/ROADMAP.md` for the rest.
+//! Only `check` and `noise` are implemented. See `docs/ROADMAP.md` for the rest.
+
+mod noise;
 
 use std::path::PathBuf;
 
@@ -33,6 +35,28 @@ enum Command {
         /// exactly the case where somebody wants to see what was read.
         #[arg(long, value_name = "PATH")]
         out: Option<PathBuf>,
+    },
+    /// Measure how far this machine's answer moves between runs of one fixed workload.
+    ///
+    /// The number this prints is the floor under every effect measured here afterwards, so it is
+    /// the first thing to run on a machine nobody has measured before and the first thing to run
+    /// again when a result looks too good.
+    Noise {
+        /// How many times to start the process again.
+        #[arg(long, default_value_t = 20)]
+        rounds: u32,
+        /// How many samples to take inside each round.
+        #[arg(long, default_value_t = 50)]
+        samples: u32,
+        /// How many passes to run before a round starts recording.
+        #[arg(long, default_value_t = 5)]
+        warmup: u32,
+        /// The spread above which a class is ratios only, as a fraction.
+        #[arg(long, default_value_t = 0.02)]
+        limit: f64,
+        /// Run one round and print what it measured, which is how a round is started.
+        #[arg(long, hide = true)]
+        one_round: bool,
     },
     /// Fetch or generate a corpus and verify it against its manifest.
     Corpus {
@@ -109,6 +133,19 @@ fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     match cli.command {
         Command::Check { require, out } => check(require, out),
+        Command::Noise {
+            rounds,
+            samples,
+            warmup,
+            limit,
+            one_round,
+        } => {
+            if one_round {
+                noise::one_round(samples, warmup)
+            } else {
+                noise::probe(rounds, samples, warmup, limit)
+            }
+        }
         other => anyhow::bail!("not implemented yet: {other:?}"),
     }
 }

--- a/crates/bench-cli/src/noise.rs
+++ b/crates/bench-cli/src/noise.rs
@@ -36,7 +36,7 @@ use std::process::Command;
 
 use anyhow::{Context as _, bail};
 use bench_core::{Bootstrap, Stop, Timing, coefficient_of_variation, summarise, time};
-use bench_env::Capture;
+use bench_env::{Capture, Outcome};
 
 /// How many 64 bit words the probe walks. Four mebibytes of them.
 const WORDS: usize = 4 * 1024 * 1024 / 8;
@@ -136,20 +136,43 @@ fn measure(samples: u32, warmup: u32) -> anyhow::Result<Round> {
 
 /// Runs the probe: `rounds` fresh processes, and the spread across what they answered.
 ///
-/// This exits zero whether or not the machine is quiet enough, and that is deliberate. The
-/// virtualised class is expected to be over the bar and knowing by how much is the point of running
-/// this at all, so a non zero exit would turn the expected result into a failure and the number
-/// nobody would ever see. `check` is the command that refuses; this one measures.
+/// The machine is read before the rounds and again after them, and a gate that failed at either end
+/// stops this without printing a floor. A floor measured on a machine with something else running
+/// on it is a measurement of the something else, and it is worse than no floor at all, because it
+/// looks like a fact about the hardware and gets quoted as one. Reading the machine again at the
+/// end is what catches the build that finished, the browser that woke up, and the backup that
+/// started while the probe was running.
+///
+/// `anyway` measures regardless and says on every line of the report that it did. That exists
+/// because what a busy machine looks like is a real question, and because somebody will want the
+/// number for a machine that can never pass, which is better answered than worked around.
+///
+/// Being over the bar is not a failure and does not change the exit status. The virtualised class
+/// is expected to be over it and finding out by how much is the reason to run this at all, so a non
+/// zero exit there would turn the expected answer into an error nobody reads. `check` is the
+/// command that refuses on the machine; this one refuses on the conditions and then measures.
 ///
 /// # Errors
 ///
-/// If a round cannot be started, ends badly, or prints something that is not two numbers.
-pub(crate) fn probe(rounds: u32, samples: u32, warmup: u32, limit: f64) -> anyhow::Result<()> {
+/// If a gate failed and `anyway` was not asked for, or if a round cannot be started, ends badly, or
+/// prints something that is not two numbers.
+pub(crate) fn probe(
+    rounds: u32,
+    samples: u32,
+    warmup: u32,
+    limit: f64,
+    anyway: bool,
+) -> anyhow::Result<()> {
     let capture = Capture::take();
+    unfit(&capture, anyway, "before the probe started")?;
+
     let mut measured = Vec::with_capacity(rounds as usize);
     for _ in 0..rounds {
         measured.push(spawn_round(samples, warmup)?);
     }
+
+    let after = Capture::take();
+    unfit(&after, anyway, "by the time the probe finished")?;
 
     let medians: Vec<f64> = measured.iter().map(|round| round.median).collect();
     let withins: Vec<f64> = measured.iter().map(|round| round.within).collect();
@@ -197,8 +220,35 @@ pub(crate) fn probe(rounds: u32, samples: u32, warmup: u32, limit: f64) -> anyho
         "the class ceiling is unchanged by this: {}",
         capture.permits()
     );
+    if anyway {
+        println!(
+            "this floor was taken with a gate failing, so it describes today on this machine and \
+             not the machine"
+        );
+    }
 
     Ok(())
+}
+
+/// Stops the probe when the machine is not fit to be measured.
+fn unfit(capture: &Capture, anyway: bool, when: &str) -> anyhow::Result<()> {
+    let Some(gate) = capture.failed() else {
+        return Ok(());
+    };
+    if anyway {
+        return Ok(());
+    }
+
+    let detail = match &gate.outcome {
+        Outcome::Pass { observed } => observed.clone(),
+        Outcome::Fail { observed, wanted } => format!("{observed}, wanted {wanted}"),
+    };
+    bail!(
+        "the {} gate failed {when}: {detail}. A floor measured on a machine with something else \
+         running on it is a measurement of the something else. Wait for the machine to settle, or \
+         ask for --anyway if what a busy machine looks like is the question",
+        gate.name
+    );
 }
 
 /// Starts one round in a new process and reads back what it measured.

--- a/crates/bench-cli/src/noise.rs
+++ b/crates/bench-cli/src/noise.rs
@@ -1,0 +1,266 @@
+//! The noise floor probe: how much a machine's answer moves when the question did not change.
+//!
+//! Every other number this harness produces is a difference between two measurements, and a
+//! difference is only worth reporting when it is bigger than the spread of the thing it came from.
+//! This measures that spread. It runs one fixed workload, restarts the process, runs it again, and
+//! reports the coefficient of variation across those rounds.
+//!
+//! The result belongs in `docs/MACHINES.md` next to the class it was taken on, because it is a fact
+//! about the machine rather than about anything being benchmarked, and because a reader looking at
+//! a two percent effect needs to know what the floor under it was.
+//!
+//! # Why a round is a whole process
+//!
+//! Running the same workload a thousand times inside one process measures how steady the machine is
+//! over the next few milliseconds, which is not the question. Address space layout, page placement
+//! and allocator state are fixed for the life of a process and all three of them move a
+//! measurement, so a probe that never restarts reports a floor far below the one a real comparison
+//! stands on. A round here is therefore a process, which is [`bench_core::Level::Process`], and the
+//! headline number is the spread across rounds.
+//!
+//! Rebuilding the binary between rounds is the level above that and this does not do it. That level
+//! is real, it is what [`bench_core::Pilot`] exists to split out, and a rebuild takes longer than
+//! everything else here put together. The floor reported by this probe is a floor under one build,
+//! and a comparison across builds sits on a higher one.
+//!
+//! # The workload
+//!
+//! Four independent multiply and add chains over a four mebibyte buffer. It is not a decoder and it
+//! is not trying to be one. What is wanted is a workload with no input, no allocation and no system
+//! call inside the timed region, so that whatever moves between rounds is the machine and not the
+//! work. Four mebibytes is larger than the level two cache on every machine in the fleet and
+//! smaller than the level three cache on all of them, so the probe watches the core clock and the
+//! path to the last level cache together, which is where a neighbouring tenant shows up first.
+
+use std::process::Command;
+
+use anyhow::{Context as _, bail};
+use bench_core::{Bootstrap, Stop, Timing, coefficient_of_variation, summarise, time};
+use bench_env::Capture;
+
+/// How many 64 bit words the probe walks. Four mebibytes of them.
+const WORDS: usize = 4 * 1024 * 1024 / 8;
+
+/// How many chains run at once.
+///
+/// One chain measures the latency of a multiply and nothing else, because every step waits for the
+/// one before it. Four of them keep the multiplier fed and let the loop run at the speed the bytes
+/// arrive, which is the part worth watching for movement.
+const CHAINS: usize = 4;
+
+/// An odd multiplier with its bits spread out, so no chain settles into a short cycle.
+const MULTIPLIER: u64 = 6_364_136_223_846_793_005;
+
+/// One pass over the buffer, which is one sample.
+///
+/// The accumulators are folded together and returned so that nothing here is dead code to a
+/// compiler that can see the whole function. [`bench_core::time`] puts the result through a black
+/// box, and between the two of them the loop survives to be measured.
+fn pass(buffer: &[u64]) -> u64 {
+    let mut chains = [1u64; CHAINS];
+    // The buffer is a whole number of steps long, so the remainder here is empty. It is dropped
+    // rather than folded in, because a probe that walks a different number of words on a different
+    // machine is measuring two things at once.
+    let (steps, _) = buffer.as_chunks::<CHAINS>();
+    for step in steps {
+        for (chain, &word) in chains.iter_mut().zip(step) {
+            *chain = chain.wrapping_mul(MULTIPLIER).wrapping_add(word);
+        }
+    }
+    chains.iter().fold(0, |folded, chain| folded ^ chain)
+}
+
+/// The buffer, filled without a cast so the fill is the same arithmetic on every target.
+fn buffer() -> Vec<u64> {
+    let mut words = Vec::with_capacity(WORDS);
+    let mut word = MULTIPLIER;
+    for _ in 0..WORDS {
+        word = word.wrapping_mul(MULTIPLIER).wrapping_add(1);
+        words.push(word);
+    }
+    words
+}
+
+/// What one round came to.
+#[derive(Clone, Copy, Debug)]
+struct Round {
+    /// The median sample in this round, in nanoseconds.
+    median: f64,
+    /// The spread within this round, as a fraction.
+    within: f64,
+}
+
+/// Runs one round in this process and prints it for the parent to read.
+///
+/// Two numbers on one line, whitespace separated, in nanoseconds and then as a fraction. A format
+/// with nothing to parse wrong is worth more here than a format that could be extended later, and
+/// the parent and the child are the same binary so there is no version skew to design around.
+///
+/// # Errors
+///
+/// If the round produced no samples, or samples with no spread and no mean, which means the clock
+/// did not move and there is nothing to report.
+pub(crate) fn one_round(samples: u32, warmup: u32) -> anyhow::Result<()> {
+    let round = measure(samples, warmup)?;
+    println!("{} {}", round.median, round.within);
+    Ok(())
+}
+
+/// Times the workload in this process.
+fn measure(samples: u32, warmup: u32) -> anyhow::Result<Round> {
+    let buffer = buffer();
+    let timing = Timing {
+        warmup,
+        stop: Stop::After { samples },
+        // `Stop::After` does not look at the series, so asking it after every sample costs a
+        // comparison rather than a bootstrap.
+        check_every: 1,
+        bootstrap: Bootstrap::default(),
+    };
+
+    let series = timing.run(|| time(|| pass(&buffer)).1);
+    let Some(summary) = series.summary() else {
+        bail!("a round with no samples in it, which means the sample count was zero");
+    };
+    let Some(within) = coefficient_of_variation(series.samples()) else {
+        bail!(
+            "a round whose samples have no spread and no mean, which means the clock did not move"
+        );
+    };
+
+    Ok(Round {
+        median: summary.median,
+        within,
+    })
+}
+
+/// Runs the probe: `rounds` fresh processes, and the spread across what they answered.
+///
+/// This exits zero whether or not the machine is quiet enough, and that is deliberate. The
+/// virtualised class is expected to be over the bar and knowing by how much is the point of running
+/// this at all, so a non zero exit would turn the expected result into a failure and the number
+/// nobody would ever see. `check` is the command that refuses; this one measures.
+///
+/// # Errors
+///
+/// If a round cannot be started, ends badly, or prints something that is not two numbers.
+pub(crate) fn probe(rounds: u32, samples: u32, warmup: u32, limit: f64) -> anyhow::Result<()> {
+    let capture = Capture::take();
+    let mut measured = Vec::with_capacity(rounds as usize);
+    for _ in 0..rounds {
+        measured.push(spawn_round(samples, warmup)?);
+    }
+
+    let medians: Vec<f64> = measured.iter().map(|round| round.median).collect();
+    let withins: Vec<f64> = measured.iter().map(|round| round.within).collect();
+
+    let Some(across) = coefficient_of_variation(&medians) else {
+        bail!("{rounds} rounds is not enough to have a spread, try at least two");
+    };
+    let summary = summarise(&medians, Bootstrap::default()).expect("there is at least one round");
+    let typical = summarise(&withins, Bootstrap::default()).expect("one per round");
+
+    println!("{}", capture.class);
+    println!("environment {}", capture.hash);
+    println!(
+        "{rounds} rounds of {samples} samples over {} MiB, {warmup} passes of warmup per round",
+        WORDS * 8 / (1024 * 1024)
+    );
+    println!();
+    println!("  round to round      {:>8.2}%", across * 100.0);
+    println!(
+        "  within one round    {:>8.2}%   median of the rounds",
+        typical.median * 100.0
+    );
+    println!("  median round        {:>8.3} ms", summary.median / 1e6);
+    println!("  fastest round       {:>8.3} ms", summary.min / 1e6);
+    println!("  slowest round       {:>8.3} ms", summary.max / 1e6);
+    println!();
+
+    if across > limit {
+        println!(
+            "a round to round spread of {:.2}% is over the {:.2}% bar, so this class is ratios only",
+            across * 100.0,
+            limit * 100.0
+        );
+    } else {
+        println!(
+            "a round to round spread of {:.2}% is under the {:.2}% bar, so nothing this probe can \
+             see rules this class out for durations",
+            across * 100.0,
+            limit * 100.0
+        );
+    }
+    // Being quiet is necessary and not sufficient. The ceiling comes from what can be read about
+    // the machine, and a machine nobody could check is capped whatever this probe measured.
+    println!(
+        "the class ceiling is unchanged by this: {}",
+        capture.permits()
+    );
+
+    Ok(())
+}
+
+/// Starts one round in a new process and reads back what it measured.
+fn spawn_round(samples: u32, warmup: u32) -> anyhow::Result<Round> {
+    let binary = std::env::current_exe().context("finding this binary to start it again")?;
+    let output = Command::new(&binary)
+        .arg("noise")
+        .arg("--one-round")
+        .args(["--samples", &samples.to_string()])
+        .args(["--warmup", &warmup.to_string()])
+        .output()
+        .with_context(|| format!("starting a round with {}", binary.display()))?;
+
+    if !output.status.success() {
+        bail!(
+            "a round exited with {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+
+    let text =
+        String::from_utf8(output.stdout).context("a round printed something that is not text")?;
+    let mut numbers = text.split_whitespace();
+    let median = number(numbers.next(), &text)?;
+    let within = number(numbers.next(), &text)?;
+    Ok(Round { median, within })
+}
+
+/// One number out of what a round printed.
+fn number(field: Option<&str>, whole: &str) -> anyhow::Result<f64> {
+    let field =
+        field.with_context(|| format!("a round printed {:?}, wanted two numbers", whole.trim()))?;
+    field
+        .parse()
+        .with_context(|| format!("a round printed {field:?}, which is not a number"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_workload_does_the_same_thing_every_time() {
+        // A probe whose answer moves between rounds is measuring itself. This is the check that the
+        // work is fixed, so that a spread in the timings is a fact about the machine.
+        let words = buffer();
+        assert_eq!(pass(&words), pass(&words));
+        assert_eq!(buffer(), words);
+    }
+
+    #[test]
+    fn the_buffer_is_the_size_it_says_it_is() {
+        assert_eq!(buffer().len() * 8, 4 * 1024 * 1024);
+    }
+
+    #[test]
+    fn a_round_reports_a_median_and_a_spread() {
+        // Two samples and no warmup, because what is being checked is that the round comes back
+        // with numbers, and a real round takes long enough to be worth keeping out of the suite.
+        let round = measure(2, 0).expect("two samples is a round");
+        assert!(round.median > 0.0, "a pass took no measurable time");
+        assert!(round.within >= 0.0);
+    }
+}

--- a/crates/bench-core/src/lib.rs
+++ b/crates/bench-core/src/lib.rs
@@ -45,7 +45,7 @@ mod stats;
 pub use environment::{EnvironmentHash, ParseEnvironmentHashError};
 pub use measure::{Series, Stop, Timing, time};
 pub use repetition::{Components, Level, Pilot, Plan, plan};
-pub use stats::{Bootstrap, Summary, summarise};
+pub use stats::{Bootstrap, Summary, coefficient_of_variation, summarise};
 
 /// Bumped whenever the way a measurement is taken changes.
 ///

--- a/crates/bench-core/src/stats.rs
+++ b/crates/bench-core/src/stats.rs
@@ -115,6 +115,50 @@ pub fn summarise(samples: &[f64], boot: Bootstrap) -> Option<Summary> {
     })
 }
 
+/// The coefficient of variation of a series: the standard deviation over the mean.
+///
+/// Unitless, which is the whole reason for it. One machine's spread in nanoseconds says nothing
+/// next to another machine's, and the same spread as a fraction of the answer is directly
+/// comparable, which is what the noise floor table in `docs/MACHINES.md` is made of.
+///
+/// Mean based rather than median based, because that is what the coefficient of variation is and
+/// this number gets compared against figures published for other harnesses. Everywhere else here
+/// the median is the headline, for the reason at the top of this file, and the difference is not an
+/// inconsistency: a result wants the statistic that shrugs off one descheduling event, and a noise
+/// floor wants the one that counts it.
+///
+/// `None` for fewer than two samples, because one sample has no spread, and for a mean at zero,
+/// because dividing by that would report a machine as infinitely noisy when what actually happened
+/// is that the clock did not move.
+///
+/// # Panics
+///
+/// Panics if a sample is not finite, for the same reason [`summarise`] does.
+#[must_use]
+pub fn coefficient_of_variation(samples: &[f64]) -> Option<f64> {
+    if samples.len() < 2 {
+        return None;
+    }
+    assert!(
+        samples.iter().all(|s| s.is_finite()),
+        "a timing sample was not a finite number, which means the clock or the harness is broken"
+    );
+
+    // Series lengths here are in the tens or hundreds.
+    #[allow(clippy::cast_precision_loss)]
+    let n = samples.len() as f64;
+
+    let mean = samples.iter().sum::<f64>() / n;
+    if mean.abs() < f64::EPSILON {
+        return None;
+    }
+
+    // The n minus one divisor, because these are samples of how a machine behaves and not the whole
+    // of it.
+    let variance = samples.iter().map(|s| (s - mean).powi(2)).sum::<f64>() / (n - 1.0);
+    Some(variance.sqrt() / mean)
+}
+
 /// The median of an unsorted, non-empty slice, without sorting it.
 ///
 /// The stopping rule asks for a summary while a run is in progress, so this runs thousands of times

--- a/crates/bench-core/tests/statistics.rs
+++ b/crates/bench-core/tests/statistics.rs
@@ -1,6 +1,6 @@
 //! The summary: the median, the interval around it, and the minimum that is kept out of the way.
 
-use bench_core::{Bootstrap, summarise};
+use bench_core::{Bootstrap, coefficient_of_variation, summarise};
 
 fn boot() -> Bootstrap {
     Bootstrap::default()
@@ -99,4 +99,45 @@ fn a_different_seed_is_an_independent_check_and_not_a_different_answer() {
 #[should_panic(expected = "not a finite number")]
 fn a_broken_clock_is_not_summarised() {
     let _ = summarise(&[1.0, f64::NAN, 3.0], boot());
+}
+
+#[test]
+fn a_machine_that_always_answers_the_same_has_no_spread() {
+    let cv = coefficient_of_variation(&[1_000.0; 16]).unwrap();
+    assert!(cv.abs() < f64::EPSILON, "a flat series came out at {cv}");
+}
+
+#[test]
+fn the_spread_is_a_fraction_of_the_answer_and_not_a_duration() {
+    // The same shape twice, one a thousand times slower than the other. A machine that is slower
+    // and no less steady has the same noise floor, and a statistic that said otherwise would put
+    // every fast machine at the top of the table for the wrong reason.
+    let quick: Vec<f64> = (0..40).map(|i| 100.0 + f64::from(i % 4)).collect();
+    let slow: Vec<f64> = quick.iter().map(|s| s * 1_000.0).collect();
+
+    let a = coefficient_of_variation(&quick).unwrap();
+    let b = coefficient_of_variation(&slow).unwrap();
+    assert!((a - b).abs() < 1e-12, "{a} against {b}");
+}
+
+#[test]
+fn a_known_series_gives_the_textbook_answer() {
+    // Two, four and six. The mean is four and the sample standard deviation is two, so the
+    // coefficient of variation is a half. Worth having one case a reader can check by hand rather
+    // than only against the implementation that produced it.
+    let cv = coefficient_of_variation(&[2.0, 4.0, 6.0]).unwrap();
+    assert!((cv - 0.5).abs() < 1e-12, "{cv}");
+}
+
+#[test]
+fn one_sample_has_no_spread_to_report() {
+    assert!(coefficient_of_variation(&[1_234.0]).is_none());
+    assert!(coefficient_of_variation(&[]).is_none());
+}
+
+#[test]
+fn a_clock_that_did_not_move_is_not_infinitely_noisy() {
+    // Dividing by a mean of zero would report this as the noisiest machine ever measured, when what
+    // it means is that the workload took no time the clock could see.
+    assert!(coefficient_of_variation(&[0.0, 0.0, 0.0]).is_none());
 }

--- a/docs/MACHINES.md
+++ b/docs/MACHINES.md
@@ -18,7 +18,7 @@ Three virtual machines on KVM and QEMU, all running Ubuntu 24.04 LTS on the 6.8 
 
 Instruction set as exposed to the guest tops out at AVX2. There is no AVX-512.
 
-These are shared tenancy virtual machines. The guest cannot set the CPU frequency governor, cannot disable turbo, cannot pin to a physical core with any confidence that it is exclusive, and cannot see what a neighbouring tenant is doing. That rules them out for any published timing.
+These are shared tenancy virtual machines. The guest cannot set the CPU frequency governor, cannot disable turbo, cannot pin to a physical core with any confidence that it is exclusive, and cannot see what a neighbouring tenant is doing. That rules them out for any published timing. The noise floor section below puts a measured number on it: between 3.89% and 39.68% round to round on an identical workload, against a two percent bar.
 
 **Used for:** hosting the object storage endpoints for the storage tier study, including MinIO with injected network latency; mirroring corpora; running generation jobs, digest verification and other work whose output is a file rather than a duration; long running jobs where wall clock is not the measurement.
 
@@ -44,7 +44,9 @@ Windows numbers come from the same machine natively, which makes the Windows aga
 
 GitHub Actions `ubuntu-24.04-arm`. There is no arm64 Linux machine in the fleet, so this is the only arm64 Linux available.
 
-A shared hosted runner has a run to run spread in the range of five to fifteen percent, which is larger than most of the effects worth detecting. So arm64 results are within-run ratios only: WebAssembly against native on the same machine at the same moment, or guarded against unguarded. Absolute arm64 timings are not published, and a cross machine comparison against a Class B absolute number is prohibited rather than discouraged.
+A shared hosted runner has a job to job spread in the range of five to fifteen percent, which is larger than most of the effects worth detecting, because a job lands on whatever physical host is free and next to whatever neighbours are on it. So arm64 results are within-run ratios only: WebAssembly against native on the same machine at the same moment, or guarded against unguarded. Absolute arm64 timings are not published, and a cross machine comparison against a Class B absolute number is prohibited rather than discouraged.
+
+Inside a single job the runner is quiet, and measurably so: the noise floor section below records 0.10% and 0.23% round to round within a job. That is the reason a within-run ratio taken there is worth having, and it is not a reason to relax the paragraph above, because the two numbers are about different things.
 
 This is a real limitation and it is worth being blunt about it, because the arm64 study is the part of this work most likely to produce a new result. A ratio measured on a noisy machine is still a ratio, but it is a weaker instrument than the same ratio on dedicated hardware.
 
@@ -62,18 +64,63 @@ Class B carries three more. `frequency-governor` wants the performance governor 
 
 ### What a class can produce at best
 
-| Class | At best | Why it is capped there |
-| --- | --- | --- |
-| A, virtualised EPYC | nothing published | the guest cannot set the governor, cannot disable boost, cannot pin to a physical core and cannot see what a neighbour is doing |
-| B, the i9-13900K | durations, or ratios | durations when the governor, the boost state and the affinity can all be read, ratios when they cannot, and ratios under WSL2 whatever else is readable |
-| C, hosted arm64 | ratios | a shared hosted runner has a run to run spread of five to fifteen percent |
-| D, macOS | nothing published | the development machine, which exists to check that the harness builds and runs |
+| Class | At best | Measured floor | Why it is capped there |
+| --- | --- | --- | --- |
+| A, virtualised EPYC | nothing published | 3.89% to 39.68% | the guest cannot set the governor, cannot disable boost, cannot pin to a physical core and cannot see what a neighbour is doing |
+| B, the i9-13900K under Linux | durations, or ratios | 1.05% | durations when the governor, the boost state and the affinity can all be read, ratios when they cannot, and ratios under WSL2 whatever else is readable |
+| B, the i9-13900K under Windows | ratios only | 18.54% | the boost state and the processor affinity cannot be read there by an unprivileged process, and the measured floor is over the two percent bar |
+| C, hosted arm64 | ratios only | 0.23% inside a job, not measured between jobs | a shared hosted runner has a run to run spread of five to fifteen percent |
+| D, macOS | nothing published | 7.83% | the development machine, which exists to check that the harness builds and runs |
 
-The class B row is the one worth reading twice, because it is the rule that does most of the work and it is not a gate. A gate can only fail on something it can read, and the settings that matter most are exactly the ones some platforms do not expose. Under Windows the boost state and the processor affinity cannot be read by an unprivileged process, so nothing has checked whether the clock is steady, so that machine produces ratios. Being unable to see a setting is not evidence that the setting is right.
+The measured floor column is the round to round spread from `iris-bench noise`, and the section below says how it was taken and what it does not cover.
+
+The class B rows are the ones worth reading twice, because they are the rule that does most of the work and it is not a gate. A gate can only fail on something it can read, and the settings that matter most are exactly the ones some platforms do not expose. Under Windows the boost state and the processor affinity cannot be read by an unprivileged process, so nothing has checked whether the clock is steady, so that machine produces ratios. Being unable to see a setting is not evidence that the setting is right.
 
 That is not a hypothetical. The M0 probe in iris ran on this machine under Windows and produced a windowed overhead anywhere between minus eight and plus eighteen percent across twenty four runs in one sitting, on a gate set at three, with the flat scan alone moving by a third across an hour. The ceiling rule predicted that before the measurement was taken, which is the argument for keeping it.
 
 A setting that cannot be read is recorded as unreadable rather than skipped, and that recording goes into the environment hash. So the same machine measured under two operating systems produces two different hashes and a row from one cannot be quietly compared against a row from the other.
+
+## The noise floor
+
+Every effect this repository reports sits on top of how far a machine's answer moves when the question did not change. A difference smaller than that is not a difference, it is the machine. `iris-bench noise` measures it, and the table below is what the fleet actually did rather than what it was expected to do.
+
+The probe walks four mebibytes of memory in four independent dependency chains. No I/O, no allocation inside the timed region, and a working set larger than any level of cache on any machine here, so what it exercises is the memory path and the scheduler rather than a library. Each round is a whole fresh process, because restarting re-rolls address space layout, page placement and allocator state, and a floor measured inside one long lived process comes out well below the floor a real comparison has to stand on. Every reading below is forty rounds of a hundred samples with five warmup passes per round.
+
+Two numbers come out of it and they answer different questions. Round to round is the spread of the round medians, and that is the floor, because it is what a second run of a benchmark has to clear. Within one round is the spread of the individual samples inside a round, and it is a diagnostic rather than a limit, because a median over a hundred samples absorbs a descheduling event that a single sample does not. A machine can be steady between rounds and wild inside them, or the reverse, and both of those happened here.
+
+| What was measured | Round to round | Within one round | Median round | Gates at the time |
+| --- | --- | --- | --- | --- |
+| A1, the 4 vCPU guest | 5.09% and 6.16% | 39% and 114% | 0.156 ms and 0.169 ms | busy processes and load average both failing |
+| A2, the 6 vCPU guest | 9.98% and 39.68% | 160% and 149% | 0.201 ms and 0.223 ms | busy processes and load average both failing |
+| A3, the 8 vCPU guest | 3.89% and 6.45% | 36% and 41% | 0.198 ms and 0.202 ms | busy processes failing |
+| B, Linux under WSL2, pinned to the performance cores | 1.05% | 11.87% | 0.090 ms | every gate passing |
+| B, Windows, pinned to the same sixteen processors | 18.54% | 4.22% | 0.096 ms | busy processes failing, at one process |
+| C, hosted arm64 | 0.10% and 0.23% | 3.0% and 2.4% | 0.155 ms | busy processes failing, the runner agent |
+| D, macOS | 7.83% | 26.80% | 0.261 ms | busy processes and load average both failing |
+
+Where there are two figures they are two separate sittings, and both are printed because the difference between them is part of the result.
+
+The bar is two percent. Class A is over it on every machine and in every reading, which is the answer this measurement existed to get. The three guests were already ruled out for published durations, but that was an argument from what the hardware exposes to a guest. Now there is a number attached to it, and the number is worse than the argument suggested. The 6 vCPU guest moved by 39.68% between rounds of an identical workload in one sitting, with its slowest round more than three times its fastest. Any effect smaller than that measured on that machine is the neighbouring tenants.
+
+Class A is also not stable between sittings, and that matters more than any single figure in the row. The 8 vCPU guest gave 3.89% at a load average of 6.05 and then 6.45% an hour later at a load average of 1.42, so the quieter reading was the worse one. A floor that moves in the wrong direction when the machine calms down is not a property of the machine, and a class whose floor cannot be pinned down is a class that cannot carry a duration.
+
+Class B under WSL2, pinned to the performance cores with every gate in its set passing, came in at 1.05%. It is the only row here taken on a machine that satisfied its own gate set, and it is the only row under the bar for a reason about the machine rather than about the moment. On this evidence the durations ceiling for the Linux side stays where it is.
+
+Class B under Windows on the same physical machine, pinned to the same sixteen processors, came in at 18.54%, and the shape of that number is unlike anything else in the table. The samples inside a round are the steadiest of any machine here at 4.22%, and the median round is 0.096 ms, within seven percent of the Linux side on the same silicon. What moves is whole rounds: the slowest is 0.163 ms against a fastest of 0.095 ms. So the Windows floor is not a slow machine, it is a machine that now and then hands a whole process to something else for a while. The ceiling rule had already put Windows at ratios because the boost state and the affinity cannot be read there. The measurement agrees with the rule, and the rule got there first, which is the argument for keeping rules that do not depend on a measurement being taken.
+
+Class C measured 0.10% and 0.23% in two jobs, and three jobs in a row produced a median round of 0.155 ms. That does not lift the arm64 ceiling and it should not be read as evidence for lifting it. What the probe sees is one job on one rented machine over about ten seconds. The reason a hosted runner is ratios only is the spread between jobs, which is a question about which physical host a job lands on and how loaded its neighbours are, and three jobs is not a sample of that. The useful reading of this row is narrower and still worth having: the runner is quiet while it is running, so a ratio taken inside one job there is measuring what it claims to measure.
+
+Class D sits at 7.83%, taken on the development machine at a load average of 30.90 while it was doing everything a development machine does. That class publishes nothing, so the row is a check that the probe reports something sane on a busy machine rather than a limit on anything.
+
+### What the floor does not cover
+
+Three gaps, written down so the table does not get read as more than it is.
+
+It covers one sitting and one build. Drift across an hour and drift across a rebuild are both real, both larger than anything here on some machines, and both out of scope for this probe. The M0 work in iris watched a flat scan move by a third across an hour on the class B machine, which is more than fifteen times the round to round floor measured on it.
+
+Every row except the pinned WSL2 one was taken with a gate failing, through `--anyway`, and the report prints that fact on its own output. Those rows describe a machine on a day and not the machine. That is not carelessness about the conditions, it is what the fleet is: the class A guests host the object storage endpoints and the generation jobs this page says they are for, so they are never idle by design, and a hosted runner has the runner agent on a processor for the whole job.
+
+`busy-processes` wants nothing else above five percent of a processor and no machine here meets it reliably. The workstation reported one busy process at its quietest and thirty three a few minutes later without anything being started in between. That gate is tracked as its own issue with these readings as the evidence. It was deliberately not loosened to let these measurements through, because widening a bar until your own number gets past it is the same mistake as adding repetitions until a comparison turns significant.
 
 ## The AVX-512 problem
 


### PR DESCRIPTION
Closes #3.

A difference between two measurements is only worth reporting when it is larger than the spread of the thing it was taken from. Nothing here knew what that spread was, so no number this repository produced could be read against it. This adds the probe that measures it, and the next commit on this branch puts the measured numbers into `docs/MACHINES.md`.

`iris-bench noise` runs one fixed workload, restarts the process, runs it again, and reports the coefficient of variation across those rounds. A round is a whole process on purpose. Running one workload a thousand times inside a single process measures how steady the machine is over the next few milliseconds, and address space layout, page placement and allocator state are all fixed for the life of a process, so a probe that never restarts reports a floor well below the one a real comparison stands on. Rebuilding the binary between rounds is the level above that and this deliberately does not go there, which means the number is a floor under one build and a comparison across builds sits on a higher one.

The workload is four independent multiply and add chains over a four mebibyte buffer. It is not a decoder and is not trying to be one. What is wanted is no input, no allocation and no system call inside the timed region, so that whatever moves between rounds is the machine and not the work. Four mebibytes is larger than the level two cache on every machine in the fleet and smaller than the level three cache on all of them, so the probe watches the core clock and the path to the last level cache together, which is where a neighbouring tenant shows up first.

The probe exits zero whether or not the machine is quiet. The virtualised class is expected to be over the bar and finding out by how much is the whole reason to run this, so a non zero exit would turn the expected answer into a failure that nobody reads. `check` is the command that refuses, this one measures.

`bench-core` gains `coefficient_of_variation`. It is mean based, because that is what the coefficient of variation is and because the number gets compared against figures published for other harnesses. The median stays the headline everywhere else for the reason at the top of `stats.rs`, and the difference is not an inconsistency: a result wants the statistic that shrugs off one descheduling event, and a noise floor wants the one that counts it.

The new workflow measures the hosted arm64 runner, which is the only class in the machine notes that is a hosted runner. The other three classes are machines in the fleet and their numbers come from running the same command with the same arguments on them. On a pull request the workflow runs only when the probe itself changes, which is the one time a published floor stops describing what the tool measures.
