### PR TITLE
Measure what the timing loop adds to a sample

### DIFF
--- a/crates/bench-cli/src/main.rs
+++ b/crates/bench-cli/src/main.rs
@@ -1,8 +1,10 @@
 //! `iris-bench`, the command line tool.
 //!
-//! Only `check`, `noise` and `resident` are implemented. See `docs/ROADMAP.md` for the rest.
+//! Only `check`, `noise`, `overhead` and `resident` are implemented. See `docs/ROADMAP.md` for the
+//! rest.
 
 mod noise;
+mod overhead;
 mod resident;
 
 use std::path::PathBuf;
@@ -96,6 +98,35 @@ enum Command {
         /// this machine has to be read next to.
         #[arg(long)]
         control: bool,
+    },
+    /// Measure what the timing loop adds to a sample, and the workload length that makes it small.
+    ///
+    /// The B0 gate. There is no single overhead percentage, because the harness adds a roughly
+    /// fixed number of nanoseconds and the share that takes depends on how long the workload runs.
+    /// What this reports is the fixed cost and the duration at which it falls under the bar.
+    Overhead {
+        /// How many pairs of measurements to take at each duration.
+        #[arg(long, default_value_t = 40)]
+        pairs: u32,
+        /// How many iterations of the workload each side of a pair runs.
+        #[arg(long, default_value_t = 64)]
+        batch: u32,
+        /// How many pairs to run at each duration before recording anything.
+        #[arg(long, default_value_t = 3)]
+        warmup: u32,
+        /// The share of a workload the harness may take, as a fraction.
+        #[arg(long, default_value_t = 0.01)]
+        bar: f64,
+        /// The shortest workload this fleet intends to time, in microseconds.
+        ///
+        /// The gate is whether the harness is under the bar at this duration. It is an input
+        /// because it is a decision about what gets benchmarked rather than a fact about the
+        /// machine, and burying a decision like that in a constant makes it look like a fact.
+        #[arg(long, default_value_t = 10)]
+        floor: u32,
+        /// Measure even though a gate failed, which produces a working note rather than a result.
+        #[arg(long)]
+        anyway: bool,
     },
     /// Fetch or generate a corpus and verify it against its manifest.
     Corpus {
@@ -208,6 +239,21 @@ fn main() -> anyhow::Result<()> {
                 control,
             )
         }
+        Command::Overhead {
+            pairs,
+            batch,
+            warmup,
+            bar,
+            floor,
+            anyway,
+        } => overhead::gate(
+            pairs,
+            batch,
+            warmup,
+            bar,
+            f64::from(floor) * 1_000.0,
+            anyway,
+        ),
         other => anyhow::bail!("not implemented yet: {other:?}"),
     }
 }

--- a/crates/bench-cli/src/overhead.rs
+++ b/crates/bench-cli/src/overhead.rs
@@ -1,0 +1,407 @@
+//! What the harness adds to a measurement of something that does nothing.
+//!
+//! Every duration this repository publishes is the workload plus whatever the timing loop costs to
+//! wrap around it. That cost does not cancel out of a ratio when the two sides run different
+//! numbers of samples, it does not shrink when the machine is idle, and it is the one source of
+//! error here that is a property of the code rather than of the hardware. So it gets measured
+//! rather than assumed, and the number goes next to the noise floor in `docs/MACHINES.md`.
+//!
+//! # What overhead means when the answer depends on the workload
+//!
+//! There is no single percentage. The harness adds a roughly fixed number of nanoseconds per
+//! sample, so the share it takes is large for a short workload and negligible for a long one, and
+//! quoting one figure without the duration it was taken at says nothing. What this reports instead
+//! is the fixed cost and the duration at which it falls under the bar, which is the form a reader
+//! can apply to a workload that has not been written yet.
+//!
+//! # How the fixed cost is separated from the work
+//!
+//! Both sides of a pair run the same number of iterations of the same workload. One side reads the
+//! clock once around the whole batch, the other reads it once per iteration. Dividing each by the
+//! iteration count gives the cost of one iteration measured two ways, and the difference between
+//! them is every clock read but one. Nothing else about the two sides differs, which is what makes
+//! the subtraction mean something.
+//!
+//! This is the reason the comparison is not against a workload of nothing at all. A pair of clock
+//! reads around an empty body does measure the clock, and it is reported below because it is worth
+//! knowing, but it does not measure what the clock reads cost when there is real work between them
+//! competing for the same out of order window.
+//!
+//! # The workload
+//!
+//! A dependent chain of multiply and add in registers, with the iteration count set by calibration
+//! to hit each target duration. No memory, no allocation and no system call, so the sweep varies
+//! duration and nothing else. The noise probe deliberately walks a buffer because it is watching
+//! for a neighbouring tenant on the path to memory. This is watching for the clock, and a workload
+//! that touches memory would put cache behaviour into a number that is supposed to be about two
+//! calls to [`std::time::Instant::now`].
+
+use anyhow::bail;
+use bench_core::{Bootstrap, Ratio, paired_ratio, summarise, time};
+use bench_env::{Capture, Outcome};
+use std::hint::black_box;
+
+/// An odd multiplier with its bits spread out, so the chain does not settle into a short cycle.
+const MULTIPLIER: u64 = 6_364_136_223_846_793_005;
+
+/// The durations the sweep visits, in nanoseconds.
+///
+/// Four decades, because the crossing point is expected to sit in the middle of them and a sweep
+/// that only brackets it from one side cannot show that it was found rather than assumed.
+const TARGETS: [f64; 5] = [100.0, 1_000.0, 10_000.0, 100_000.0, 1_000_000.0];
+
+/// One duration's worth of results.
+struct Row {
+    /// How many chain steps this row ran per iteration.
+    rounds: u64,
+    /// One iteration, timed once around the whole batch.
+    batched: f64,
+    /// One iteration, timed on its own.
+    separate: f64,
+    /// What the harness adds to a reported sample, in nanoseconds.
+    bias: f64,
+    /// The second divided by the first.
+    ratio: Ratio,
+}
+
+/// A dependent chain of multiply and add, `rounds` steps long.
+///
+/// Each step needs the result of the one before it, so the loop runs at the latency of a multiply
+/// rather than at its throughput. That is what makes the duration proportional to `rounds` and
+/// predictable enough to calibrate against.
+fn spin(rounds: u64) -> u64 {
+    let mut value = MULTIPLIER;
+    for _ in 0..rounds {
+        value = value.wrapping_mul(MULTIPLIER).wrapping_add(1);
+    }
+    value
+}
+
+/// Runs the chain with both the argument and the result hidden from the optimiser.
+///
+/// Hiding the result stops the call being deleted. Hiding the argument stops it being computed once
+/// and reused, which is the failure that turns a batch of a hundred iterations into one iteration
+/// and reports the harness as free.
+fn opaque(rounds: u64) -> u64 {
+    black_box(spin(black_box(rounds)))
+}
+
+/// How many chain steps take about `target` nanoseconds on this machine.
+fn calibrate(target: f64) -> u64 {
+    const PROBE: u32 = 1_000_000;
+    // Three goes and the shortest wins. Calibration runs before the measurement and a single
+    // descheduled probe would set every row's iteration count from one bad reading.
+    let per_round = (0..3)
+        .map(|_| time(|| opaque(u64::from(PROBE))).1 / f64::from(PROBE))
+        .fold(f64::INFINITY, f64::min);
+    if per_round <= 0.0 {
+        return 1;
+    }
+    // The step count is a workload size rather than a measurement, so losing the fractional part
+    // is the intent, and the clamp is what makes the conversion defined rather than the cast.
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let steps = (target / per_round).round().clamp(1.0, 1e15) as u64;
+    steps
+}
+
+/// Runs the gate.
+///
+/// # Errors
+///
+/// If the machine is not fit to measure and `anyway` was not asked for, or if the shortest workload
+/// the harness can time within `bar` is longer than `floor`.
+pub(crate) fn gate(
+    pairs: u32,
+    batch: u32,
+    warmup: u32,
+    bar: f64,
+    floor: f64,
+    anyway: bool,
+) -> anyhow::Result<()> {
+    if batch < 2 {
+        bail!(
+            "a batch of {batch} leaves no clock reads to count, since the difference between the \
+             two sides is every read but one"
+        );
+    }
+
+    let capture = Capture::take();
+    unfit(&capture, anyway, "before the measurement started")?;
+
+    let empty = empty_clock_pair(pairs, warmup);
+    let rows = TARGETS
+        .into_iter()
+        .map(|target| measure(target, pairs, batch, warmup))
+        .collect::<anyhow::Result<Vec<_>>>()?;
+
+    let after = Capture::take();
+    unfit(&after, anyway, "by the time the measurement finished")?;
+
+    // The bias is read off the shortest row. It is the same number of nanoseconds in every row, so
+    // every row is an estimate of it, and the shortest is the one where it is the largest share of
+    // what was measured and therefore the one where the machine's own noise buries it last. The
+    // other rows are printed so that a reader can see whether it really is constant, which is the
+    // assumption the whole table rests on.
+    let shortest = rows.first().expect("the sweep is not empty");
+    let crossing = shortest.bias / bar;
+
+    report(&capture, &rows, empty, batch, crossing, bar, floor);
+
+    if anyway {
+        println!();
+        println!(
+            "this was measured with a gate failing, so it describes today on this machine and not \
+             the machine"
+        );
+    }
+
+    if shortest.ratio.lo <= 1.0 {
+        // A bias that cannot be shown to be positive is not a bias that has been measured, and
+        // reporting a crossing point derived from it would put a number on noise. This fails rather
+        // than passing, for the same reason `Ratio::within` asks the interval and not the midpoint.
+        bail!(
+            "the shortest row puts the instrumented side at {:.2}% of the clean one, interval \
+             {:.2}% to {:.2}%, which includes parity, so this run cannot say what the harness adds. \
+             That is a statement about the machine rather than about the timing loop, and the noise \
+             floor in docs/MACHINES.md says whether this machine was ever going to resolve it",
+            shortest.ratio.ratio * 100.0,
+            shortest.ratio.lo * 100.0,
+            shortest.ratio.hi * 100.0
+        )
+    } else if crossing <= floor {
+        Ok(())
+    } else {
+        bail!(
+            "the harness adds {:.1} ns to every sample it reports, so it is under {:.2}% only for \
+             workloads longer than {}, and the shortest workload this fleet intends to time is {}. \
+             Either the timing loop reads the clock more than it needs to or this machine's clock \
+             is slow, and the {:.1} ns a pair of reads costs in wall clock says which",
+            shortest.bias,
+            bar * 100.0,
+            duration(crossing),
+            duration(floor),
+            empty
+        )
+    }
+}
+
+/// What a pair of clock reads around an empty body costs, as a median in nanoseconds.
+fn empty_clock_pair(pairs: u32, warmup: u32) -> f64 {
+    for _ in 0..warmup {
+        black_box(time(|| ()).1);
+    }
+    let samples: Vec<f64> = (0..pairs.max(1)).map(|_| time(|| ()).1).collect();
+    summarise(&samples, Bootstrap::default()).map_or(0.0, |summary| summary.median)
+}
+
+/// Measures one target duration both ways.
+fn measure(target: f64, pairs: u32, batch: u32, warmup: u32) -> anyhow::Result<Row> {
+    let rounds = calibrate(target);
+    let count = f64::from(batch);
+
+    let mut batched_side = Vec::with_capacity(pairs as usize);
+    let mut separate_side = Vec::with_capacity(pairs as usize);
+
+    for pair in 0..pairs + warmup {
+        // Both sides run `batch` iterations of the same chain. The only difference is how often the
+        // clock is read, so the order is alternated for the same reason it is anywhere else: so
+        // that whichever side goes first does not keep the advantage of going first.
+        let (batched, separate) = if pair.is_multiple_of(2) {
+            let batched = batched_pass(rounds, batch);
+            let separate = separate_pass(rounds, batch);
+            (batched, separate)
+        } else {
+            let separate = separate_pass(rounds, batch);
+            let batched = batched_pass(rounds, batch);
+            (batched, separate)
+        };
+        if pair >= warmup {
+            batched_side.push(batched / count);
+            separate_side.push(separate / count);
+        }
+    }
+
+    // Separately timed over batched, so the number is how much the instrumented side costs
+    // relative to the clean one and a reader does not have to invert it in their head.
+    let Some(ratio) = paired_ratio(&separate_side, &batched_side, Bootstrap::default()) else {
+        bail!("{pairs} pairs is not enough to compare, try at least one");
+    };
+    let batched = summarise(&batched_side, Bootstrap::default()).expect("at least one pair");
+    let separate = summarise(&separate_side, Bootstrap::default()).expect("at least one pair");
+
+    // Neither side is clean, and the difference between them is not the whole bias. Writing `b` for
+    // the bias and `w` for one iteration of the workload, the separately timed side reports `w + b`
+    // per iteration and the batched side reports `w + b/k`, because its one clock pair is divided
+    // across `k` iterations. So the difference is `b` short by a factor of `k` and the correction
+    // is exact rather than an estimate.
+    let bias = (separate.median - batched.median) * count / (count - 1.0);
+
+    Ok(Row {
+        rounds,
+        batched: batched.median,
+        separate: separate.median,
+        bias,
+        ratio,
+    })
+}
+
+/// `batch` iterations with the clock read once around all of them.
+fn batched_pass(rounds: u64, batch: u32) -> f64 {
+    time(|| {
+        for _ in 0..batch {
+            opaque(rounds);
+        }
+    })
+    .1
+}
+
+/// `batch` iterations with the clock read once around each of them.
+///
+/// Only the timed regions are added up. The loop that adds them is outside every one of them, so
+/// what comes back is what the harness would have recorded rather than how long the loop took.
+fn separate_pass(rounds: u64, batch: u32) -> f64 {
+    let mut total = 0.0;
+    for _ in 0..batch {
+        total += time(|| opaque(rounds)).1;
+    }
+    total
+}
+
+/// Prints what was measured.
+fn report(
+    capture: &Capture,
+    rows: &[Row],
+    empty: f64,
+    batch: u32,
+    crossing: f64,
+    bar: f64,
+    floor: f64,
+) {
+    println!("{}", capture.class);
+    println!("environment {}", capture.hash);
+    println!(
+        "a pair of clock reads around an empty body takes {empty:.1} ns of wall clock, which is \
+         not what a read adds to a sample, because most of the second read lands after the elapsed \
+         time has already been fixed"
+    );
+    println!(
+        "each side of a pair ran {batch} iterations, so the two sides differ by {} clock pairs and \
+         the bias column is that difference scaled back to one",
+        batch - 1
+    );
+    println!();
+    println!("  workload      steps   instrumented         bias   overhead   interval");
+    for row in rows {
+        println!(
+            "  {:>9}  {:>9}      {:>9}   {:>7.1} ns  {:>7.2}%   {:.2}% to {:.2}%",
+            duration(row.batched),
+            row.rounds,
+            duration(row.separate),
+            row.bias,
+            (row.ratio.ratio - 1.0) * 100.0,
+            (row.ratio.lo - 1.0) * 100.0,
+            (row.ratio.hi - 1.0) * 100.0
+        );
+    }
+    println!();
+    println!(
+        "the shortest row says the harness adds {:.1} ns to every sample it reports, so it is \
+         under {:.2}% of any workload longer than {}",
+        rows.first().map_or(0.0, |row| row.bias),
+        bar * 100.0,
+        duration(crossing)
+    );
+    if crossing <= floor {
+        println!(
+            "the shortest workload this fleet intends to time is {}, so the harness is under the \
+             bar for everything it will be asked to time",
+            duration(floor)
+        );
+    } else {
+        println!(
+            "the shortest workload this fleet intends to time is {}, which is shorter than that, \
+             so the timing loop decides the answer for the workloads at that end",
+            duration(floor)
+        );
+    }
+    println!(
+        "this machine is good for {}, and these are ratios taken inside one run",
+        capture.permits()
+    );
+}
+
+/// Formats a duration in nanoseconds with a unit a reader does not have to count zeroes in.
+fn duration(nanos: f64) -> String {
+    if nanos < 1_000.0 {
+        format!("{nanos:.0} ns")
+    } else if nanos < 1_000_000.0 {
+        format!("{:.1} us", nanos / 1_000.0)
+    } else {
+        format!("{:.2} ms", nanos / 1_000_000.0)
+    }
+}
+
+/// Stops the measurement when the machine is not fit to measure.
+fn unfit(capture: &Capture, anyway: bool, when: &str) -> anyhow::Result<()> {
+    let Some(gate) = capture.failed() else {
+        return Ok(());
+    };
+    if anyway {
+        return Ok(());
+    }
+    let detail = match &gate.outcome {
+        Outcome::Pass { observed } => observed.clone(),
+        Outcome::Fail { observed, wanted } => format!("{observed}, wanted {wanted}"),
+    };
+    bail!(
+        "the {} gate failed {when}: {detail}. This measures tens of nanoseconds, which is the scale \
+         a single descheduling event dwarfs, so a reading taken next to something else running \
+         would be that something else. Wait for the machine to settle, or ask for --anyway if a \
+         working note is what is wanted",
+        gate.name
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_longer_chain_takes_longer() {
+        // Calibration is arithmetic on the assumption that duration is proportional to the step
+        // count. If that stops being true, every row in the sweep aims at the wrong duration and
+        // nothing else in this file notices.
+        let short = time(|| opaque(1_000)).1;
+        let long = time(|| opaque(1_000_000)).1;
+        assert!(long > short * 10.0, "short {short}, long {long}");
+    }
+
+    #[test]
+    fn calibration_lands_within_an_order_of_magnitude_of_what_it_aimed_at() {
+        let rounds = calibrate(100_000.0);
+        let taken = time(|| opaque(rounds)).1;
+        assert!(
+            (10_000.0..1_000_000.0).contains(&taken),
+            "aimed at 100000 ns with {rounds} steps and took {taken}"
+        );
+    }
+
+    #[test]
+    fn a_batch_of_one_is_refused_because_it_would_compare_a_thing_against_itself() {
+        let error = gate(1, 1, 0, 0.01, 1e6, true).unwrap_err();
+        assert!(format!("{error}").contains("no clock reads to count"));
+    }
+
+    #[test]
+    fn the_two_sides_run_the_same_amount_of_work() {
+        // Not a timing assertion. It checks that neither pass has been edited into running a
+        // different number of iterations from the other, which would show up as overhead.
+        let batched = batched_pass(10_000, 4);
+        let separate = separate_pass(10_000, 4);
+        assert!(batched > 0.0 && separate > 0.0);
+        assert!(
+            separate < batched * 10.0,
+            "batched {batched}, separate {separate}"
+        );
+    }
+}

--- a/crates/bench-cli/src/overhead.rs
+++ b/crates/bench-cli/src/overhead.rs
@@ -280,9 +280,9 @@ fn report(
     println!("{}", capture.class);
     println!("environment {}", capture.hash);
     println!(
-        "a pair of clock reads around an empty body takes {empty:.1} ns of wall clock, which is \
-         not what a read adds to a sample, because most of the second read lands after the elapsed \
-         time has already been fixed"
+        "a pair of clock reads around an empty body takes {empty:.1} ns of wall clock, which is a \
+         different measurement from the bias below and does not have to agree with it, because an \
+         empty body lets one pair of reads overlap the next and a workload between them does not"
     );
     println!(
         "each side of a pair ran {batch} iterations, so the two sides differ by {} clock pairs and \

--- a/docs/MACHINES.md
+++ b/docs/MACHINES.md
@@ -122,6 +122,32 @@ Every row except the pinned WSL2 one was taken with a gate failing, through `--a
 
 `busy-processes` wants nothing else above five percent of a processor and no machine here meets it reliably. The workstation reported one busy process at its quietest and thirty three a few minutes later without anything being started in between. That gate is tracked as its own issue with these readings as the evidence. It was deliberately not loosened to let these measurements through, because widening a bar until your own number gets past it is the same mistake as adding repetitions until a comparison turns significant.
 
+## What the harness adds
+
+The noise floor is a property of the machine. This one is a property of the code, and it is the only source of error on this page that gets fixed by editing something rather than by buying something. Every duration published here is the workload plus what the timing loop cost to wrap around it, so `iris-bench overhead` measures that and the number lives next to the floor.
+
+There is no single overhead percentage and quoting one would be meaningless. The harness adds a roughly fixed number of nanoseconds to each sample, so it is most of a short workload and none of a long one, and the honest form of the answer is the fixed cost plus the duration at which it drops under the bar. That form survives a workload that has not been written yet, which a percentage taken at one duration does not.
+
+Both sides of a pair run the same iterations of the same workload, a dependent multiply and add chain in registers with no memory and no system call. One side reads the clock once around the whole batch of sixty four, the other reads it once per iteration. Per iteration the batched side reports the work plus one sixty fourth of the bias and the separate side reports the work plus all of it, so the difference is the bias short by a known factor and the correction back to it is exact rather than fitted.
+
+| Workload | Instrumented | Bias | Overhead | Interval |
+| --- | --- | --- | --- | --- |
+| 72 ns | 113 ns | 41.1 ns | 56.00% | 55.29% to 56.29% |
+| 970 ns | 1.0 us | 40.8 ns | 4.14% | 4.12% to 4.20% |
+| 10.0 us | 10.1 us | 57.5 ns | 0.57% | -0.25% to 1.76% |
+| 102.0 us | 101.5 us | -500.2 ns | -0.48% | -1.40% to 0.61% |
+| 1.02 ms | 1.02 ms | -2571.6 ns | -0.25% | -1.02% to 0.53% |
+
+Taken on class B under WSL2, pinned to the performance cores, forty pairs per row with three warmup pairs, every gate passing. It is the only machine in the fleet whose floor is under the one percent bar this gate is about, so it is the only one that could have answered.
+
+The bias is read off the shortest row, because the same nanoseconds are a larger share there and the machine's own noise buries them last. The top two rows are a hundred times apart in duration and agree on 41.1 and 40.8 nanoseconds, which is the check that the quantity really is fixed rather than proportional, and that assumption is what the whole table rests on. The bottom two rows are the same quantity measured where it is a ten thousandth of the reading, and they come out negative with intervals straddling zero, which is what a fixed cost looks like once the machine's own variation is larger than it.
+
+**Verdict, and it is under the bar.** 41.1 nanoseconds per sample, interval 55.29% to 56.29% of a 72 nanosecond workload, so the harness costs under one percent of anything longer than 4.1 microseconds. The shortest workload this fleet intends to time is ten microseconds, where the same reading puts the harness at 0.57%. Two repeat runs minutes later gave 37.2 and 37.1 nanoseconds, crossing at 3.7 microseconds both times. The table above is the first of the three because it is the worst of the three, and a bound quoted from the friendliest reading is not a bound.
+
+A pair of clock reads around an empty body takes 12.0 nanoseconds of wall clock on the same machine, which is a third of the bias and is a different measurement. An empty body lets one pair of reads overlap the next, and a workload between them does not, so the empty pair understates what a clock read costs where it is actually used. That is the reason the gate is not built on it.
+
+What this does not cover: one machine, one build and one clock. `Instant::now` reads a different source on macOS and on Windows, so neither number is transferable, and class D measured 3.6 nanoseconds with an interval from 2.34% to 8.71% that is too wide to be a bound on anything. The rule that follows is about durations rather than about machines, and it is that a workload under about ten microseconds does not get published as a duration from this harness without this gate being re-run at that duration first.
+
 ## The AVX-512 problem
 
 There is no AVX-512 anywhere in this fleet. The EPYC virtual machines expose AVX2 as their ceiling, and Raptor Lake has the unit fused off. This is not a configuration choice and it cannot be worked around by trying harder.


### PR DESCRIPTION
Closes #4.

`iris-bench overhead` measures what the timing loop adds to a sample, and the number is now in `docs/MACHINES.md` next to the noise floor. The exit condition asked for the overhead with a confidence interval and under one percent. It is under one percent, but not as a single number, and the reason is worth stating because it changed the shape of the command.

There is no one overhead percentage. The harness adds a roughly fixed number of nanoseconds per sample, so it is most of a hundred nanosecond workload and none of a millisecond one, and a percentage without the duration it was taken at says nothing. What the command reports instead is the fixed cost and the duration at which it falls under the bar, which is a form a reader can apply to a workload nobody has written yet. The gate is then whether that duration is shorter than the shortest workload the fleet intends to time, which is a `--floor` argument rather than a constant, because it is a decision about what gets benchmarked rather than a fact about the machine.

## How the fixed cost is separated from the work

Both sides of a pair run the same iterations of the same workload, a dependent multiply and add chain in registers with no memory, no allocation and no system call. One side reads the clock once around the whole batch, the other once per iteration. Per iteration the batched side reports the work plus one sixty fourth of the bias and the separate side reports the work plus all of it, so the difference is the bias short by a known factor and the correction back to it is exact rather than fitted.

That is deliberately not a comparison against an empty body. Timing nothing at all does measure the clock, and it is reported for contrast, but it lets consecutive pairs of reads overlap in a way they cannot when there is real work between them. On the class B machine the empty pair costs 12.0 ns of wall clock and the bias is 41.1 ns, so the easy measurement understates the thing by a factor of three.

## Result

Class B under WSL2, pinned to the performance cores, every gate passing, forty pairs per row.

| Workload | Instrumented | Bias | Overhead | Interval |
| --- | --- | --- | --- | --- |
| 72 ns | 113 ns | 41.1 ns | 56.00% | 55.29% to 56.29% |
| 970 ns | 1.0 us | 40.8 ns | 4.14% | 4.12% to 4.20% |
| 10.0 us | 10.1 us | 57.5 ns | 0.57% | -0.25% to 1.76% |
| 102.0 us | 101.5 us | -500.2 ns | -0.48% | -1.40% to 0.61% |
| 1.02 ms | 1.02 ms | -2571.6 ns | -0.25% | -1.02% to 0.53% |

41.1 ns per sample, so under one percent of anything longer than 4.1 us. The shortest workload this fleet intends to time is ten microseconds, where the same run puts the harness at 0.57%. Two repeats minutes later gave 37.2 and 37.1 ns, crossing at 3.7 us both times. The table is the first of the three because it is the worst of the three.

The top two rows are a hundred times apart in duration and agree on 41.1 and 40.8 ns, which is the check that the quantity really is fixed rather than proportional, and that assumption is what the whole table rests on. The bottom two rows measure the same quantity where it is a ten thousandth of the reading, and they come out negative with intervals straddling zero, which is what a fixed cost looks like once the machine's variation is larger than it.

## Two things the first version got wrong

Both were caught by running it rather than by reading it, and both are the reason there is a parity check in the gate now.

It read the bias off the longest row, which is the row where the signal to noise is worst. On macOS that produced a bias of -111320.2 ns and a gate that passed because the crossing point was negative. It reads the shortest row now.

It had no way to refuse. A bias whose interval includes parity has not been measured, and deriving a crossing point from it puts a number on noise, so the gate now fails when the shortest row's interval includes one rather than reporting whatever the midpoint happened to be. That is the same rule `Ratio::within` already applies everywhere else here, which is to ask the interval and not the midpoint.

## What this does not cover

One machine, one build and one clock. `Instant::now` reads a different source on macOS and on Windows, so neither number transfers. Class D measured 3.6 ns with an interval from 2.34% to 8.71%, which is too wide to bound anything, and that is expected on a machine with a 7.83% noise floor. Class B under Linux is the only machine in the fleet whose floor is under the bar this gate is about, so it is the only one that could have answered.

Local gate green: fmt, clippy, discipline, doc, tests, doc tests, locked check.
