### PR TITLE
Cut v0.1.0 for B0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,7 +208,7 @@ checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "bench-core"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -217,7 +217,7 @@ dependencies = [
 
 [[package]]
 name = "bench-corpus"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "blake3",
  "camino",
@@ -233,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "bench-driver"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "bench-core",
  "serde",
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "bench-env"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "bench-core",
  "blake3",
@@ -254,7 +254,7 @@ dependencies = [
 
 [[package]]
 name = "bench-report"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "bench-core",
  "bench-store",
@@ -265,7 +265,7 @@ dependencies = [
 
 [[package]]
 name = "bench-run"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "bench-core",
  "bench-corpus",
@@ -281,7 +281,7 @@ dependencies = [
 
 [[package]]
 name = "bench-store"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "driver-null"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "bench-driver",
 ]
@@ -753,7 +753,7 @@ dependencies = [
 
 [[package]]
 name = "iris-bench-cli"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "bench-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*", "drivers/*"]
 
 [workspace.package]
-version = "0.0.0"
+version = "0.1.0"
 edition = "2024"
 rust-version = "1.98"
 license = "Apache-2.0"
@@ -16,13 +16,13 @@ readme = "README.md"
 publish = false
 
 [workspace.dependencies]
-bench-core = { path = "crates/bench-core", version = "0.0.0" }
-bench-corpus = { path = "crates/bench-corpus", version = "0.0.0" }
-bench-driver = { path = "crates/bench-driver", version = "0.0.0" }
-bench-env = { path = "crates/bench-env", version = "0.0.0" }
-bench-report = { path = "crates/bench-report", version = "0.0.0" }
-bench-run = { path = "crates/bench-run", version = "0.0.0" }
-bench-store = { path = "crates/bench-store", version = "0.0.0" }
+bench-core = { path = "crates/bench-core", version = "0.1.0" }
+bench-corpus = { path = "crates/bench-corpus", version = "0.1.0" }
+bench-driver = { path = "crates/bench-driver", version = "0.1.0" }
+bench-env = { path = "crates/bench-env", version = "0.1.0" }
+bench-report = { path = "crates/bench-report", version = "0.1.0" }
+bench-run = { path = "crates/bench-run", version = "0.1.0" }
+bench-store = { path = "crates/bench-store", version = "0.1.0" }
 
 anyhow = "1.0.104"
 arrow-array = "59.3.0"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ Public BI has been both the design input and the evaluation set for six years of
 
 ## Status
 
-Pre-alpha. The specification is written and the harness is not. Milestones B0 through B8 are [public](https://github.com/tamnd/iris-bench/milestones) with one issue per exit gate.
+Pre-alpha. B0 is done as of `v0.1.0`, so the measuring apparatus exists and the benchmarks do not. Milestones B0 through B8 are [public](https://github.com/tamnd/iris-bench/milestones) with one issue per exit gate.
+
+What B0 established is in `docs/ROADMAP.md` under that milestone, and the short version is that this fleet can measure, on one machine, for ratios always and for durations under a gate. The noise floor is 1.05% on the one eligible role and over two percent everywhere else, and the harness adds 41.1 ns to a sample, which is under one percent of anything longer than 4.1 microseconds. `iris-bench check`, `noise`, `overhead` and `resident` run today. Nothing else does.
 
 B0 through B4 need no `iris` code to exist, which is deliberate. If `iris` is never built, the reproduction of the published figures and the storage tier study still stand on their own.
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,25 @@
+# Releasing
+
+Nothing in this repository goes to crates.io. Every crate here carries `publish = false` and that is deliberate: this is a measuring instrument for one project rather than a library anybody should depend on, and a version on crates.io is a promise about an interface that this repository is not in a position to make. What a release is here is a tag and a set of notes, and what it marks is a milestone finishing.
+
+## What a version means
+
+While the major is zero, a minor tracks a completed milestone and a patch is everything in between. `v0.1.0` is B0. `v0.2.0` will be B1. A patch is cut when enough has accumulated between milestones to be worth a boundary, and it carries no promise beyond being a point somebody can name.
+
+The reason the numbering follows the milestones rather than the code is that the milestones are the unit of work here. A reader who compares two minors and finds a small diff should read the milestone rather than the range, because a gate is often answered by a measurement that changes one document and nothing else.
+
+## Where the version lives
+
+Only in `[workspace.package]` in the root `Cargo.toml`, and in the `version` field of each path dependency in `[workspace.dependencies]`, which all carry the same number. Nothing else in the repository names a version, so a bump is one file and then `cargo update -w` to move the lockfile.
+
+## Cutting one
+
+Open a release pull request that bumps the version and updates the lockfile, and nothing else. A release that carries a change is a release whose notes have to explain two things at once, and the notes are the part of this that has value.
+
+Merge it once CI is green, tag the merge commit, and push the tag. Tag the merge commit rather than the branch, because a version is one tree and a tag that points at a branch tip points at whatever landed next.
+
+Then write the notes and publish the release. The notes say what the milestone answered, including where the answer was not the one the gate expected, with the numbers and the machine they came from. A release note here that only lists merged pull requests has failed at the one job it has.
+
+## What is not automated
+
+All of it, for now. There is no release workflow, because a repository that publishes nothing has no step that a person can get irreversibly wrong, and automating a tag push to save one command is not worth a workflow that has to be maintained. When a release starts producing an artifact somebody else consumes, that changes, and this section is where it will be written down.


### PR DESCRIPTION
B0 is 5 of 5, so this cuts `v0.1.0`.

Nothing here goes to crates.io. Every crate carries `publish = false` and that stays true, because this is a measuring instrument for one project rather than a library anybody should depend on. A release here is a tag and a set of notes, and what it marks is a milestone finishing.

Three things, and the first release has to carry more than a version bump because the policy that makes a version mean anything does not exist yet.

`docs/RELEASING.md` is new. While the major is zero a minor tracks a completed milestone and a patch is everything in between, which is the same rule `tamnd/iris` uses. It also says the version lives in exactly two places in the root `Cargo.toml` and nowhere else, and that a release pull request bumps the version and nothing else. That last rule binds from the next release rather than this one, for the obvious reason.

The version bump itself, `0.0.0` to `0.1.0` in `[workspace.package]` and in the seven path dependencies, plus `cargo update -w`.

The README status section, which said the specification is written and the harness is not. That was true when it was written and is not now. It says what B0 established and which four commands actually run, so a reader who arrives at the `v0.1.0` tag is not told the repository is empty.

Discipline checks pass and `cargo check --locked --workspace` is clean on the new lockfile.
