### PR TITLE
Pin every corpus by digest and store it by content

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,12 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: "3.13"
+      # The validator before the thing it validates. There are no corpora in the
+      # tree yet, so the manifest rules would otherwise be code CI runs zero
+      # times, and the first manifest to arrive should meet a checker that has
+      # itself been checked.
+      - run: python3 test_discipline.py
+        working-directory: ci
       - run: python3 ci/discipline.py
 
   test:

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /corpus
 /results
 /store
+__pycache__/
 *.profraw
 lcov.info
 .DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,6 +225,7 @@ dependencies = [
  "hex",
  "serde",
  "tar",
+ "tempfile",
  "thiserror",
  "toml",
  "ureq",

--- a/ci/discipline.py
+++ b/ci/discipline.py
@@ -9,9 +9,11 @@ What it checks:
   1. Every driver in drivers/ has a CONFIG.md with all its required sections.
   2. Every driver's configuration review date is present and parseable, and is
      not more than 180 days old.
-  3. Every corpus manifest declares a source, a licence, a category, and at
-     least one digest, and every corpus in the mirror category has a licence
-     note saying what permits us to redistribute it.
+  3. Every corpus manifest matches the format in docs/CORPORA.md: it names
+     itself after its own directory, declares a description, a source, a licence
+     and one of the three categories, pins at least one file by lower case hex
+     BLAKE3 digest and size, uses paths that stay inside the corpus directory,
+     and carries a licence note if it is mirrored.
   4. No driver crate depends on anything in the tree except bench-driver.
   5. No hostname, address or account identifier from the benchmark fleet has
      leaked into a committed file.
@@ -35,6 +37,34 @@ CONFIG_SECTIONS = [
     "Rejected alternatives",
     "Last reviewed",
 ]
+
+# The three handling categories from docs/LICENSING.md. A corpus is generated
+# locally, fetched at run time, or redistributed here, and the third one is the
+# only one that needs a licence note because it is the only one where this
+# repository is the party doing the redistributing.
+CORPUS_CATEGORIES = {"generate", "fetch", "mirror"}
+
+# Lower case hex, always. An upper case spelling of the same digest is refused
+# rather than normalised, because a manifest is read by people as well as by
+# code and two spellings of one value is how a mismatch gets argued about.
+DIGEST = re.compile(r"[0-9a-f]{64}")
+
+# Every field this format has. A field that is not here is an error rather than
+# something ignored, because the field most worth typing wrongly is
+# licence_note, and a typo that silently does nothing would defeat the one check
+# in this file with legal weight.
+MANIFEST_FIELDS = {
+    "corpus": {
+        "name",
+        "description",
+        "source",
+        "licence",
+        "category",
+        "licence_note",
+    },
+    "files": {"path", "blake3", "bytes"},
+    "assertions": {"rows", "columns"},
+}
 
 # A driver may depend on the trait crate and on nothing else in this workspace.
 # Otherwise a driver can reach into the runner and special case itself, which is
@@ -85,23 +115,93 @@ def check_driver_deps(driver: pathlib.Path) -> None:
 
 
 def check_corpora() -> None:
+    """Validates every manifest in the tree against docs/CORPORA.md.
+
+    These rules are the same ones bench_corpus::Manifest applies, duplicated on
+    purpose. This runs on a tree that may not compile, which is exactly the case
+    where a bad manifest is most likely to get through, so it cannot be the Rust
+    code that does it.
+    """
     corpora = ROOT / "corpora"
     if not corpora.exists():
         return
-    for manifest_path in sorted(corpora.glob("*/manifest.toml")):
-        name = manifest_path.parent.name
+    for directory in sorted(p for p in corpora.iterdir() if p.is_dir()):
+        manifest_path = directory / "manifest.toml"
+        if not manifest_path.exists():
+            fail(f"corpus {directory.name}: no manifest.toml")
+            continue
+        check_manifest(manifest_path)
+
+
+def check_fields(name: str, table: str, values: dict, allowed: set[str]) -> None:
+    """Complains about any field in a manifest table that this format does not have."""
+    if not isinstance(values, dict):
+        fail(f"corpus {name}: '{table}' is not a table")
+        return
+    for field in sorted(set(values) - allowed):
+        fail(f"corpus {name}: '{field}' in [{table}] is not part of this format, see docs/CORPORA.md")
+
+
+def check_manifest(manifest_path: pathlib.Path) -> None:
+    directory = manifest_path.parent.name
+    try:
         manifest = tomllib.loads(manifest_path.read_text(encoding="utf-8"))
-        corpus = manifest.get("corpus", {})
-        for field in ("source", "licence", "category"):
-            if not corpus.get(field):
-                fail(f"corpus {name}: manifest has no '{field}'")
-        if not manifest.get("files"):
-            fail(f"corpus {name}: manifest declares no files, so nothing is pinned")
-        for entry in manifest.get("files", []):
-            if not entry.get("blake3"):
-                fail(f"corpus {name}: file {entry.get('path')} has no digest")
-        if corpus.get("category") == "mirror" and not corpus.get("licence_note"):
-            fail(f"corpus {name}: mirrored without a licence note saying what permits it")
+    except tomllib.TOMLDecodeError as error:
+        fail(f"corpus {directory}: manifest is not valid TOML: {error}")
+        return
+
+    corpus = manifest.get("corpus", {})
+    name = corpus.get("name") or directory
+
+    for table in manifest:
+        if table not in MANIFEST_FIELDS:
+            fail(f"corpus {name}: '{table}' is not part of this format, see docs/CORPORA.md")
+    check_fields(name, "corpus", corpus, MANIFEST_FIELDS["corpus"])
+    check_fields(name, "assertions", manifest.get("assertions", {}), MANIFEST_FIELDS["assertions"])
+    for entry in manifest.get("files", []):
+        check_fields(name, "files", entry, MANIFEST_FIELDS["files"])
+
+    for field in ("name", "description", "source", "licence", "category"):
+        if not str(corpus.get(field, "")).strip():
+            fail(f"corpus {name}: manifest has no '{field}'")
+
+    # The directory is the corpus name. Two names for one corpus is how a result
+    # ends up citing something other than what it read.
+    if corpus.get("name") and corpus["name"] != directory:
+        fail(f"corpus {name}: named '{corpus['name']}' but lives in '{directory}'")
+
+    if corpus.get("category") not in CORPUS_CATEGORIES:
+        fail(
+            f"corpus {name}: category is {corpus.get('category')!r} and the three"
+            f" in docs/LICENSING.md are {sorted(CORPUS_CATEGORIES)}"
+        )
+
+    # Only a mirrored corpus is one this repository redistributes, so it is the
+    # only one where somebody has to have read the licence and written down what
+    # it permits.
+    if corpus.get("category") == "mirror" and not str(corpus.get("licence_note", "")).strip():
+        fail(f"corpus {name}: mirrored without a licence note saying what permits it")
+
+    files = manifest.get("files", [])
+    if not files:
+        fail(f"corpus {name}: manifest declares no files, so nothing is pinned")
+
+    seen: set[str] = set()
+    for entry in files:
+        path = str(entry.get("path", "")).strip()
+        if not path:
+            fail(f"corpus {name}: a file entry has no path")
+            continue
+        if path in seen:
+            fail(f"corpus {name}: {path} is listed twice")
+        seen.add(path)
+        if pathlib.PurePosixPath(path).is_absolute() or ".." in pathlib.PurePosixPath(path).parts:
+            fail(f"corpus {name}: {path} is not a path inside the corpus directory")
+        digest = str(entry.get("blake3", ""))
+        if not DIGEST.fullmatch(digest):
+            fail(f"corpus {name}: {path} has no lower case hex BLAKE3 digest")
+        if not isinstance(entry.get("bytes"), int) or entry.get("bytes", 0) <= 0:
+            fail(f"corpus {name}: {path} declares no size, so a truncated file passes the length check")
 
 
 def check_no_machine_identity() -> None:

--- a/ci/test_discipline.py
+++ b/ci/test_discipline.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Tests for the manifest validator in discipline.py.
+
+There are no corpora in the tree yet, so without this the manifest rules are
+code that CI runs zero times and everybody assumes works. The first manifest to
+arrive should meet a checker that has been checked, rather than being the thing
+that finds out whether the checker is right.
+
+Run with `python3 ci/test_discipline.py`. No test framework, because adding a
+dependency to make five assertions readable is a bad trade in a file whose whole
+job is to run everywhere without setup.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+import tempfile
+
+import discipline
+
+GOOD = """
+[corpus]
+name = "example"
+description = "A corpus that exists to be validated"
+source = "https://example.invalid/example.parquet"
+licence = "Apache-2.0"
+category = "fetch"
+
+[[files]]
+path = "example.parquet"
+blake3 = "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"
+bytes = 1024
+"""
+
+failures: list[str] = []
+
+
+def validate(text: str, directory: str = "example") -> list[str]:
+    """Runs the manifest checks over one manifest and returns what they said."""
+    with tempfile.TemporaryDirectory() as root:
+        corpus = pathlib.Path(root) / directory
+        corpus.mkdir()
+        (corpus / "manifest.toml").write_text(text, encoding="utf-8")
+        before = list(discipline.failures)
+        discipline.failures.clear()
+        try:
+            discipline.check_manifest(corpus / "manifest.toml")
+            return list(discipline.failures)
+        finally:
+            discipline.failures[:] = before
+
+
+def expect_clean(name: str, text: str, directory: str = "example") -> None:
+    said = validate(text, directory)
+    if said:
+        failures.append(f"{name}: expected no complaint and got {said}")
+
+
+def expect_complaint(name: str, text: str, phrase: str, directory: str = "example") -> None:
+    said = validate(text, directory)
+    if not any(phrase in one for one in said):
+        failures.append(f"{name}: expected a complaint containing {phrase!r} and got {said}")
+
+
+def main() -> int:
+    expect_clean("a complete manifest passes", GOOD)
+
+    expect_complaint(
+        "a manifest that disagrees with its directory",
+        GOOD,
+        "lives in",
+        directory="something-else",
+    )
+    expect_complaint(
+        "a category that is not one of the three",
+        GOOD.replace('"fetch"', '"borrow"'),
+        "docs/LICENSING.md",
+    )
+    expect_complaint(
+        "mirrored without a licence note",
+        GOOD.replace('"fetch"', '"mirror"'),
+        "licence note",
+    )
+    expect_clean(
+        "mirrored with a licence note",
+        GOOD.replace('"fetch"', '"mirror"\nlicence_note = "Public domain"'),
+    )
+    expect_complaint(
+        "no files at all",
+        GOOD.split("[[files]]")[0],
+        "nothing is pinned",
+    )
+    expect_complaint(
+        "a digest that is not lower case hex",
+        GOOD.replace("af1349b9", "AF1349B9"),
+        "BLAKE3 digest",
+    )
+    expect_complaint(
+        "a digest of the wrong length",
+        GOOD.replace(
+            "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262", "abcdef"
+        ),
+        "BLAKE3 digest",
+    )
+    expect_complaint(
+        "a path that climbs out of the corpus",
+        GOOD.replace('"example.parquet"', '"../../etc/passwd"'),
+        "inside the corpus directory",
+    )
+    expect_complaint(
+        "a file declared as zero bytes",
+        GOOD.replace("bytes = 1024", "bytes = 0"),
+        "declares no size",
+    )
+    expect_complaint(
+        "the same path listed twice",
+        GOOD + GOOD[GOOD.index("[[files]]") :],
+        "listed twice",
+    )
+    expect_complaint(
+        "a missing description",
+        GOOD.replace('description = "A corpus that exists to be validated"', ""),
+        "'description'",
+    )
+    expect_complaint(
+        "a manifest that is not TOML",
+        "this is not toml at all {{",
+        "not valid TOML",
+    )
+    expect_complaint(
+        "a field this format does not have",
+        GOOD.replace("licence =", "licence_notes = \"nearly right\"\nlicence ="),
+        "'licence_notes'",
+    )
+
+    if failures:
+        print("Validator tests failed:\n", file=sys.stderr)
+        for failure in failures:
+            print(f"  {failure}", file=sys.stderr)
+        return 1
+    print("Validator tests passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/crates/bench-cli/src/overhead.rs
+++ b/crates/bench-cli/src/overhead.rs
@@ -366,20 +366,31 @@ fn unfit(capture: &Capture, anyway: bool, when: &str) -> anyhow::Result<()> {
 mod tests {
     use super::*;
 
+    /// The shortest of three runs of the chain, in nanoseconds.
+    ///
+    /// The same defence [`calibrate`] uses, for the same reason. These tests run alongside every
+    /// other test in the workspace, so a single reading here is a reading of whatever else the
+    /// machine was doing, and descheduling can only ever make a duration longer.
+    fn shortest(rounds: u64) -> f64 {
+        (0..3)
+            .map(|_| time(|| opaque(rounds)).1)
+            .fold(f64::INFINITY, f64::min)
+    }
+
     #[test]
     fn a_longer_chain_takes_longer() {
         // Calibration is arithmetic on the assumption that duration is proportional to the step
         // count. If that stops being true, every row in the sweep aims at the wrong duration and
         // nothing else in this file notices.
-        let short = time(|| opaque(1_000)).1;
-        let long = time(|| opaque(1_000_000)).1;
+        let short = shortest(1_000);
+        let long = shortest(1_000_000);
         assert!(long > short * 10.0, "short {short}, long {long}");
     }
 
     #[test]
     fn calibration_lands_within_an_order_of_magnitude_of_what_it_aimed_at() {
         let rounds = calibrate(100_000.0);
-        let taken = time(|| opaque(rounds)).1;
+        let taken = shortest(rounds);
         assert!(
             (10_000.0..1_000_000.0).contains(&taken),
             "aimed at 100000 ns with {rounds} steps and took {taken}"

--- a/crates/bench-corpus/Cargo.toml
+++ b/crates/bench-corpus/Cargo.toml
@@ -25,5 +25,8 @@ toml.workspace = true
 ureq.workspace = true
 walkdir.workspace = true
 
+[dev-dependencies]
+tempfile.workspace = true
+
 [lints]
 workspace = true

--- a/crates/bench-corpus/src/digest.rs
+++ b/crates/bench-corpus/src/digest.rs
@@ -1,0 +1,171 @@
+//! The content address every corpus file is pinned by.
+//!
+//! BLAKE3, because it is fast enough that hashing a hundred gigabyte corpus is not a reason to skip
+//! the check, and skipping the check is the only way this ever goes wrong. A digest that is only
+//! computed when somebody remembers to is not a pin.
+
+use std::{fmt, fs::File, io, path::Path, str::FromStr};
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error as _};
+
+/// How many bytes a BLAKE3 digest is.
+const LENGTH: usize = 32;
+
+/// A BLAKE3 digest of a file or a run of bytes.
+///
+/// Stored as bytes rather than as the hex string, so that two digests compare in one instruction
+/// and a manifest cannot smuggle in an upper case spelling of the same value that fails an equality
+/// check somewhere else.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Digest([u8; LENGTH]);
+
+impl Digest {
+    /// The digest of a run of bytes.
+    #[must_use]
+    pub fn of_bytes(bytes: &[u8]) -> Self {
+        Self(*blake3::hash(bytes).as_bytes())
+    }
+
+    /// The digest of a file, read in chunks rather than loaded.
+    ///
+    /// Corpus files here run to tens of gigabytes, so reading one into memory to hash it would put
+    /// a limit on corpus size that has nothing to do with anything.
+    ///
+    /// # Errors
+    ///
+    /// If the file cannot be opened or read.
+    pub fn of_file(path: &Path) -> Result<Self, io::Error> {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update_reader(File::open(path)?)?;
+        Ok(Self(*hasher.finalize().as_bytes()))
+    }
+
+    /// The digest as its bytes.
+    #[must_use]
+    pub const fn as_bytes(&self) -> &[u8; LENGTH] {
+        &self.0
+    }
+
+    /// The digest as lower case hex, which is the only spelling written anywhere.
+    #[must_use]
+    pub fn to_hex(&self) -> String {
+        hex::encode(self.0)
+    }
+}
+
+/// Why a string is not a digest.
+#[derive(Debug, thiserror::Error)]
+pub enum DigestError {
+    /// The string is not the length a hex BLAKE3 digest is.
+    #[error("a digest is {expected} hex characters and this is {found}")]
+    Length {
+        /// How many characters a digest is.
+        expected: usize,
+        /// How many the string had.
+        found: usize,
+    },
+    /// The string is the right length but is not hex.
+    #[error("a digest is lower case hex and this is not: {0}")]
+    NotHex(String),
+    /// The string is hex but not all of it is lower case.
+    ///
+    /// Refused rather than accepted and normalised, because a manifest is read by people as well as
+    /// by this code and two spellings of one digest is how a mismatch gets argued about.
+    #[error("a digest is written in lower case hex and this is not: {0}")]
+    NotLowerCase(String),
+}
+
+impl FromStr for Digest {
+    type Err = DigestError;
+
+    fn from_str(text: &str) -> Result<Self, Self::Err> {
+        if text.len() != LENGTH * 2 {
+            return Err(DigestError::Length {
+                expected: LENGTH * 2,
+                found: text.len(),
+            });
+        }
+        if text.chars().any(|c| c.is_ascii_uppercase()) {
+            return Err(DigestError::NotLowerCase(text.to_owned()));
+        }
+        let mut bytes = [0_u8; LENGTH];
+        hex::decode_to_slice(text, &mut bytes).map_err(|_| DigestError::NotHex(text.to_owned()))?;
+        Ok(Self(bytes))
+    }
+}
+
+impl fmt::Display for Digest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.to_hex())
+    }
+}
+
+impl fmt::Debug for Digest {
+    /// The hex rather than thirty two numbers, because a digest in a test failure is only useful if
+    /// it can be compared against the one in the manifest by eye.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Digest({})", self.to_hex())
+    }
+}
+
+impl Serialize for Digest {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.to_hex())
+    }
+}
+
+impl<'de> Deserialize<'de> for Digest {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let text = String::deserialize(deserializer)?;
+        text.parse().map_err(D::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The published BLAKE3 digest of the empty input. If this ever changes, the pin on every
+    /// corpus in the tree has silently moved and nothing else here would notice.
+    const EMPTY: &str = "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262";
+
+    #[test]
+    fn the_empty_digest_is_the_published_one() {
+        assert_eq!(Digest::of_bytes(b"").to_hex(), EMPTY);
+    }
+
+    #[test]
+    fn a_digest_survives_hex_and_back() {
+        let digest = Digest::of_bytes(b"iris-bench");
+        assert_eq!(digest.to_hex().parse::<Digest>().unwrap(), digest);
+    }
+
+    #[test]
+    fn upper_case_hex_is_refused_rather_than_normalised() {
+        let error = EMPTY.to_uppercase().parse::<Digest>().unwrap_err();
+        assert!(matches!(error, DigestError::NotLowerCase(_)));
+    }
+
+    #[test]
+    fn a_digest_of_the_wrong_length_says_what_length_it_was() {
+        let error = "abcd".parse::<Digest>().unwrap_err();
+        assert!(format!("{error}").contains("this is 4"));
+    }
+
+    #[test]
+    fn something_the_right_length_that_is_not_hex_is_refused() {
+        let error = "z".repeat(64).parse::<Digest>().unwrap_err();
+        assert!(matches!(error, DigestError::NotHex(_)));
+    }
+
+    #[test]
+    fn a_file_and_its_bytes_hash_the_same() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("corpus");
+        std::fs::write(&path, b"the same bytes either way").unwrap();
+        assert_eq!(
+            Digest::of_file(&path).unwrap(),
+            Digest::of_bytes(b"the same bytes either way")
+        );
+    }
+}

--- a/crates/bench-corpus/src/lib.rs
+++ b/crates/bench-corpus/src/lib.rs
@@ -1,12 +1,29 @@
 //! Corpus manifests, fetching, generation and content addressed storage.
 //!
-//! Every corpus is pinned by a BLAKE3 digest, including the ones that are
-//! generated rather than downloaded. A digest mismatch on fetch is a hard
-//! failure that prints both digests, because a corpus that quietly changed is
-//! worse than one that is missing.
+//! Every corpus is pinned by a BLAKE3 digest, including the ones that are generated rather than
+//! downloaded. A digest mismatch on fetch is a hard failure that prints both digests, because a
+//! corpus that quietly changed is worse than one that is missing.
 //!
-//! Nothing is implemented yet. See the milestone that owns this crate in
-//! `docs/ROADMAP.md`.
+//! # The two halves
+//!
+//! A [`Manifest`] says what a corpus is: where it comes from, what licence it arrives under, which
+//! of the three handling categories in `docs/LICENSING.md` applies, and the digest of every file.
+//! The format is documented in `docs/CORPORA.md` and validated by `ci/discipline.py` for every
+//! manifest committed to this repository.
+//!
+//! A [`Store`] holds the bytes, named by their own digest. Two runs referring to the same corpus
+//! are then referring to the same bytes rather than to the same file name, which is the property
+//! that makes a result worth re-running.
+//!
+//! Fetching and generation are not implemented yet. See B1 in `docs/ROADMAP.md`.
+
+mod digest;
+mod manifest;
+mod store;
+
+pub use digest::{Digest, DigestError};
+pub use manifest::{Assertions, Category, Corpus, Entry, Manifest, ManifestError};
+pub use store::{Inserted, Store, StoreError};
 
 /// The version of this crate, as reported by build metadata.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/crates/bench-corpus/src/manifest.rs
+++ b/crates/bench-corpus/src/manifest.rs
@@ -1,0 +1,417 @@
+//! What a corpus is, written down and checkable.
+//!
+//! A corpus that is not pinned by digest is not a corpus, it is whatever happened to download that
+//! day. A manifest says where the bytes come from, what licence they arrive under, which of the
+//! three handling categories in `docs/LICENSING.md` applies, and the digest of every file. Nothing
+//! is measured on data that does not have one.
+//!
+//! The format is documented in `docs/CORPORA.md`. The rules below are the same rules
+//! `ci/discipline.py` applies to every manifest in the tree, deliberately duplicated rather than
+//! shared, because the Python one runs on a repository that may not compile and the Rust one runs
+//! on a manifest that may not be in this repository at all.
+
+use std::{fmt, path::Path};
+
+use serde::{Deserialize, Serialize};
+
+use crate::digest::Digest;
+
+/// A whole manifest, as it is written in `corpora/<name>/manifest.toml`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Manifest {
+    /// What this corpus is and where it comes from.
+    pub corpus: Corpus,
+    /// One entry per file, each pinned by digest.
+    #[serde(default)]
+    pub files: Vec<Entry>,
+    /// Facts about the loaded corpus that a run checks before it measures anything.
+    #[serde(default)]
+    pub assertions: Assertions,
+}
+
+/// The corpus itself, as opposed to the files it is made of.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Corpus {
+    /// The identifier, which is also the directory name.
+    pub name: String,
+    /// One sentence on what this is, for a reader who has not met it before.
+    pub description: String,
+    /// Where the bytes come from, as a URL or as the generator that produces them.
+    pub source: String,
+    /// The licence the data arrives under, as an SPDX identifier where one exists.
+    pub licence: String,
+    /// How this repository handles the data.
+    pub category: Category,
+    /// What permits redistribution, which only a mirrored corpus needs and must have.
+    #[serde(default)]
+    pub licence_note: Option<String>,
+}
+
+/// How this repository handles a corpus, per `docs/LICENSING.md`.
+///
+/// The default is [`Category::Fetch`]. Mirroring requires reading the licence and writing down what
+/// it permits, which is what `licence_note` is and why it is checked rather than suggested.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Category {
+    /// Produced locally from a deterministic generator. Nothing is redistributed.
+    Generate,
+    /// Downloaded from its canonical location at run time and never redistributed by us.
+    Fetch,
+    /// Redistributed here, because the licence permits it and a broken link in three years is the
+    /// difference between a reproducible result and a story about one.
+    Mirror,
+}
+
+impl fmt::Display for Category {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Generate => "generate",
+            Self::Fetch => "fetch",
+            Self::Mirror => "mirror",
+        })
+    }
+}
+
+/// One file of a corpus.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Entry {
+    /// Where the file sits inside the corpus, relative to its own directory.
+    pub path: String,
+    /// The digest of the file's bytes.
+    pub blake3: Digest,
+    /// How large the file is, which is checked before the digest because it is free.
+    pub bytes: u64,
+}
+
+/// Facts a run checks about the loaded corpus before it measures anything.
+///
+/// `ClickBench` is 99,997,497 rows across 105 columns or the manifest is wrong, and finding that out
+/// from an assertion is much cheaper than finding it out from a number that looks slightly off.
+/// Every field is optional because not every corpus is tabular.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Assertions {
+    /// How many rows the corpus has once loaded.
+    #[serde(default)]
+    pub rows: Option<u64>,
+    /// How many columns the corpus has once loaded.
+    #[serde(default)]
+    pub columns: Option<u64>,
+}
+
+/// Why a manifest is not usable.
+#[derive(Debug, thiserror::Error)]
+pub enum ManifestError {
+    /// The file could not be read.
+    #[error("reading {path}: {source}")]
+    Read {
+        /// Which file.
+        path: String,
+        /// What went wrong underneath.
+        source: std::io::Error,
+    },
+    /// The file is not the TOML this format is.
+    #[error("parsing {path}: {source}")]
+    Parse {
+        /// Which file.
+        path: String,
+        /// What the TOML parser objected to.
+        source: Box<toml::de::Error>,
+    },
+    /// The file parsed but says something that cannot be true.
+    #[error("{name}: {problem}")]
+    Invalid {
+        /// Which corpus.
+        name: String,
+        /// What is wrong with it.
+        problem: String,
+    },
+}
+
+impl Manifest {
+    /// Reads and validates a manifest from a path.
+    ///
+    /// The directory the manifest sits in is the corpus name, and a manifest that disagrees with
+    /// its own directory is refused. Two names for one corpus is how a run ends up citing a
+    /// corpus that is not the one it read.
+    ///
+    /// # Errors
+    ///
+    /// If the file cannot be read, is not valid TOML for this format, or fails [`Self::validate`].
+    pub fn read(path: &Path) -> Result<Self, ManifestError> {
+        let shown = path.display().to_string();
+        let text = std::fs::read_to_string(path).map_err(|source| ManifestError::Read {
+            path: shown.clone(),
+            source,
+        })?;
+        let manifest = Self::parse(&text).map_err(|error| match error {
+            ManifestError::Parse { source, .. } => ManifestError::Parse {
+                path: shown.clone(),
+                source,
+            },
+            other => other,
+        })?;
+        if let Some(directory) = path.parent().and_then(|parent| parent.file_name())
+            && directory != manifest.corpus.name.as_str()
+        {
+            return Err(ManifestError::Invalid {
+                name: manifest.corpus.name.clone(),
+                problem: format!(
+                    "the manifest names this corpus {} and it lives in a directory called {}",
+                    manifest.corpus.name,
+                    directory.to_string_lossy()
+                ),
+            });
+        }
+        Ok(manifest)
+    }
+
+    /// Parses and validates a manifest from TOML.
+    ///
+    /// # Errors
+    ///
+    /// If the text is not valid TOML for this format, or fails [`Self::validate`].
+    pub fn parse(text: &str) -> Result<Self, ManifestError> {
+        let manifest: Self = toml::from_str(text).map_err(|source| ManifestError::Parse {
+            path: "<manifest>".to_owned(),
+            source: Box::new(source),
+        })?;
+        manifest.validate()?;
+        Ok(manifest)
+    }
+
+    /// Checks everything about a manifest that parsing does not.
+    ///
+    /// Parsing gets the shape right. This gets the meaning right, and the difference is that a
+    /// manifest can be perfectly well formed TOML and still pin nothing at all.
+    ///
+    /// # Errors
+    ///
+    /// If the corpus has no name, pins no files, names one file twice, uses a path that could
+    /// escape the corpus directory, declares an empty file, or is mirrored without saying what
+    /// permits it.
+    pub fn validate(&self) -> Result<(), ManifestError> {
+        let name = self.corpus.name.clone();
+        let invalid = |problem: String| ManifestError::Invalid {
+            name: name.clone(),
+            problem,
+        };
+
+        if self.corpus.name.trim().is_empty() {
+            return Err(invalid("the corpus has no name".to_owned()));
+        }
+        for (field, value) in [
+            ("description", &self.corpus.description),
+            ("source", &self.corpus.source),
+            ("licence", &self.corpus.licence),
+        ] {
+            if value.trim().is_empty() {
+                return Err(invalid(format!("{field} is empty")));
+            }
+        }
+
+        // A mirrored corpus is the only one where this repository is the party redistributing, so
+        // it is the only one where somebody has to have read the licence and written down what it
+        // permits. Checked rather than asked for, because the point at which it gets skipped is
+        // exactly the point at which somebody is in a hurry.
+        if self.corpus.category == Category::Mirror
+            && self
+                .corpus
+                .licence_note
+                .as_ref()
+                .is_none_or(|note| note.trim().is_empty())
+        {
+            return Err(invalid(
+                "mirrored without a licence note saying what permits it".to_owned(),
+            ));
+        }
+
+        if self.files.is_empty() {
+            return Err(invalid(
+                "no files, so this manifest pins nothing".to_owned(),
+            ));
+        }
+
+        let mut seen: Vec<&str> = Vec::with_capacity(self.files.len());
+        for entry in &self.files {
+            entry.validate(&invalid)?;
+            if seen.contains(&entry.path.as_str()) {
+                return Err(invalid(format!("{} is listed twice", entry.path)));
+            }
+            seen.push(&entry.path);
+        }
+
+        Ok(())
+    }
+
+    /// How large the whole corpus is, which is what a run checks it has room for.
+    #[must_use]
+    pub fn bytes(&self) -> u64 {
+        self.files.iter().map(|entry| entry.bytes).sum()
+    }
+}
+
+impl Entry {
+    /// Checks one file entry, reporting through the caller's error constructor.
+    fn validate(&self, invalid: &impl Fn(String) -> ManifestError) -> Result<(), ManifestError> {
+        if self.path.trim().is_empty() {
+            return Err(invalid("a file entry has no path".to_owned()));
+        }
+
+        // A corpus path is a name inside the corpus directory and nothing else. An absolute path or
+        // one containing a parent segment would let a manifest write outside the tree it describes,
+        // and a manifest is a file fetched from somewhere else as often as it is one somebody here
+        // wrote.
+        let path = Path::new(&self.path);
+        if path.is_absolute() {
+            return Err(invalid(format!("{} is an absolute path", self.path)));
+        }
+        if path
+            .components()
+            .any(|part| matches!(part, std::path::Component::ParentDir))
+        {
+            return Err(invalid(format!(
+                "{} climbs out of the corpus directory",
+                self.path
+            )));
+        }
+        if self.bytes == 0 {
+            return Err(invalid(format!(
+                "{} is declared as zero bytes, which pins nothing",
+                self.path
+            )));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const EMPTY_DIGEST: &str = "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262";
+
+    fn manifest(extra: &str) -> String {
+        format!(
+            "[corpus]\n\
+             name = \"example\"\n\
+             description = \"A corpus that exists to be parsed\"\n\
+             source = \"https://example.invalid/example.parquet\"\n\
+             licence = \"Apache-2.0\"\n\
+             category = \"fetch\"\n\
+             {extra}\n\
+             [[files]]\n\
+             path = \"example.parquet\"\n\
+             blake3 = \"{EMPTY_DIGEST}\"\n\
+             bytes = 1024\n"
+        )
+    }
+
+    #[test]
+    fn a_complete_manifest_parses() {
+        let parsed = Manifest::parse(&manifest("")).unwrap();
+        assert_eq!(parsed.corpus.name, "example");
+        assert_eq!(parsed.corpus.category, Category::Fetch);
+        assert_eq!(parsed.bytes(), 1024);
+        assert!(parsed.assertions.rows.is_none());
+    }
+
+    #[test]
+    fn assertions_are_read_when_they_are_there() {
+        let text = format!(
+            "{}\n[assertions]\nrows = 99997497\ncolumns = 105\n",
+            manifest("")
+        );
+        let parsed = Manifest::parse(&text).unwrap();
+        assert_eq!(parsed.assertions.rows, Some(99_997_497));
+        assert_eq!(parsed.assertions.columns, Some(105));
+    }
+
+    #[test]
+    fn a_mirrored_corpus_without_a_licence_note_is_refused() {
+        let text = manifest("").replace("\"fetch\"", "\"mirror\"");
+        let error = Manifest::parse(&text).unwrap_err();
+        assert!(format!("{error}").contains("licence note"));
+    }
+
+    #[test]
+    fn a_mirrored_corpus_with_a_licence_note_is_accepted() {
+        let text = manifest("licence_note = \"Public domain, so redistribution is permitted\"")
+            .replace("\"fetch\"", "\"mirror\"");
+        assert_eq!(
+            Manifest::parse(&text).unwrap().corpus.category,
+            Category::Mirror
+        );
+    }
+
+    #[test]
+    fn a_manifest_that_pins_no_files_is_refused() {
+        let text = manifest("");
+        let (head, _) = text.split_once("[[files]]").unwrap();
+        let error = Manifest::parse(head).unwrap_err();
+        assert!(format!("{error}").contains("pins nothing"));
+    }
+
+    #[test]
+    fn the_same_path_listed_twice_is_refused() {
+        let text = manifest("");
+        let (_, files) = text.split_once("[[files]]").unwrap();
+        let error = Manifest::parse(&format!("{text}[[files]]{files}")).unwrap_err();
+        assert!(format!("{error}").contains("listed twice"));
+    }
+
+    #[test]
+    fn a_path_that_climbs_out_of_the_corpus_is_refused() {
+        let text = manifest("").replace("\"example.parquet\"", "\"../../etc/passwd\"");
+        let error = Manifest::parse(&text).unwrap_err();
+        assert!(format!("{error}").contains("climbs out"));
+    }
+
+    #[test]
+    fn a_file_declared_as_zero_bytes_is_refused() {
+        let text = manifest("").replace("bytes = 1024", "bytes = 0");
+        let error = Manifest::parse(&text).unwrap_err();
+        assert!(format!("{error}").contains("pins nothing"));
+    }
+
+    #[test]
+    fn a_field_this_format_does_not_have_is_refused_rather_than_ignored() {
+        // A typo in a field name is otherwise a field that silently does nothing, and the field
+        // most worth typoing is `licence_note`.
+        let text = manifest("licence_notes = \"nearly right\"");
+        let error = Manifest::parse(&text).unwrap_err();
+        assert!(format!("{error}").contains("licence_notes"));
+    }
+
+    #[test]
+    fn a_digest_that_is_not_a_digest_is_refused_at_parse_time() {
+        let text = manifest("").replace(EMPTY_DIGEST, "not-a-digest");
+        let error = Manifest::parse(&text).unwrap_err();
+        assert!(matches!(error, ManifestError::Parse { .. }));
+    }
+
+    #[test]
+    fn a_manifest_that_disagrees_with_its_directory_is_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let corpus = dir.path().join("something-else");
+        std::fs::create_dir(&corpus).unwrap();
+        let path = corpus.join("manifest.toml");
+        std::fs::write(&path, manifest("")).unwrap();
+        let error = Manifest::read(&path).unwrap_err();
+        assert!(format!("{error}").contains("directory called something-else"));
+    }
+
+    #[test]
+    fn a_manifest_that_agrees_with_its_directory_is_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let corpus = dir.path().join("example");
+        std::fs::create_dir(&corpus).unwrap();
+        let path = corpus.join("manifest.toml");
+        std::fs::write(&path, manifest("")).unwrap();
+        assert_eq!(Manifest::read(&path).unwrap().corpus.name, "example");
+    }
+}

--- a/crates/bench-corpus/src/store.rs
+++ b/crates/bench-corpus/src/store.rs
@@ -1,0 +1,454 @@
+//! Where corpus bytes live once they have been verified.
+//!
+//! Objects are named by their own digest, so two runs referring to the same corpus are provably
+//! referring to the same bytes rather than to the same file name. That is the whole point. A file
+//! name is a claim about content and a digest is the content, and the gap between those two is
+//! where a result that cannot be reproduced comes from.
+//!
+//! # What the layout buys
+//!
+//! ```text
+//! <root>/objects/af/1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+//! ```
+//!
+//! The first byte of the digest is a directory, which keeps any one directory to a few hundred
+//! entries rather than a few tens of thousands. That is not about lookup speed, since every lookup
+//! here is a direct path from a known digest. It is about the directory staying listable by a
+//! person trying to work out what is on a machine.
+//!
+//! Deduplication falls out of the naming rather than being a feature. Two corpora that share a file
+//! store it once, and re-fetching a corpus that is already present writes nothing.
+//!
+//! # Why writes go through a temporary file
+//!
+//! An object is written under a temporary name and renamed into place once it is complete. A
+//! process that dies halfway through leaves a temporary file rather than a truncated object at a
+//! path that claims to be a digest, and a truncated object at a name that asserts its own content
+//! is the one failure this store exists to make impossible.
+
+use std::{
+    fs::File,
+    io::{self, Read, Write},
+    path::{Path, PathBuf},
+};
+
+use crate::digest::Digest;
+
+/// Where objects live under the store root.
+const OBJECTS: &str = "objects";
+
+/// How many bytes to move at a time when copying a file in.
+const CHUNK: usize = 1 << 20;
+
+/// A content addressed store of corpus files.
+#[derive(Clone, Debug)]
+pub struct Store {
+    /// The directory everything lives under.
+    root: PathBuf,
+}
+
+/// What happened when something was put into the store.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct Inserted {
+    /// The digest the object is now addressed by.
+    pub digest: Digest,
+    /// Whether the store already had these bytes, in which case nothing was written.
+    pub deduplicated: bool,
+}
+
+/// Why a store operation did not work.
+#[derive(Debug, thiserror::Error)]
+pub enum StoreError {
+    /// The filesystem said no.
+    #[error("{doing} {path}: {source}")]
+    Io {
+        /// What was being attempted.
+        doing: &'static str,
+        /// Which path it was being attempted on.
+        path: String,
+        /// What the filesystem said.
+        source: io::Error,
+    },
+    /// The bytes that arrived are not the bytes that were promised.
+    ///
+    /// Both digests are in the message. A mismatch reported as a boolean is a mismatch somebody
+    /// has to reproduce before they can start working out what happened.
+    #[error("{path} was expected to be {wanted} and is {found}")]
+    DigestMismatch {
+        /// Which file.
+        path: String,
+        /// The digest the manifest promised.
+        wanted: Digest,
+        /// The digest the bytes actually have.
+        found: Digest,
+    },
+    /// Something was asked for that the store does not have.
+    #[error("the store has no object {0}")]
+    Missing(Digest),
+}
+
+impl Store {
+    /// Opens a store, creating the directories if they are not there.
+    ///
+    /// # Errors
+    ///
+    /// If the directories cannot be created.
+    pub fn open(root: impl Into<PathBuf>) -> Result<Self, StoreError> {
+        let root = root.into();
+        let objects = root.join(OBJECTS);
+        std::fs::create_dir_all(&objects).map_err(|source| StoreError::Io {
+            doing: "creating",
+            path: objects.display().to_string(),
+            source,
+        })?;
+        Ok(Self { root })
+    }
+
+    /// The directory this store lives in.
+    #[must_use]
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Where an object with this digest sits, whether or not it is there.
+    #[must_use]
+    pub fn path(&self, digest: &Digest) -> PathBuf {
+        let hex = digest.to_hex();
+        let (prefix, rest) = hex.split_at(2);
+        self.root.join(OBJECTS).join(prefix).join(rest)
+    }
+
+    /// Whether the store already holds these bytes.
+    #[must_use]
+    pub fn contains(&self, digest: &Digest) -> bool {
+        self.path(digest).is_file()
+    }
+
+    /// Puts a run of bytes into the store and returns what it is addressed by.
+    ///
+    /// # Errors
+    ///
+    /// If the object cannot be written.
+    pub fn insert_bytes(&self, bytes: &[u8]) -> Result<Inserted, StoreError> {
+        let digest = Digest::of_bytes(bytes);
+        if self.contains(&digest) {
+            return Ok(Inserted {
+                digest,
+                deduplicated: true,
+            });
+        }
+        self.write(&digest, |file| file.write_all(bytes))?;
+        Ok(Inserted {
+            digest,
+            deduplicated: false,
+        })
+    }
+
+    /// Puts a file into the store, copying it rather than moving it.
+    ///
+    /// Copying rather than moving because the source is often a download somebody wants to keep, or
+    /// a file inside an extracted archive that other entries in the same manifest also point into.
+    ///
+    /// # Errors
+    ///
+    /// If the file cannot be read or the object cannot be written.
+    pub fn insert_file(&self, source: &Path) -> Result<Inserted, StoreError> {
+        let digest = Digest::of_file(source).map_err(|error| StoreError::Io {
+            doing: "hashing",
+            path: source.display().to_string(),
+            source: error,
+        })?;
+        if self.contains(&digest) {
+            return Ok(Inserted {
+                digest,
+                deduplicated: true,
+            });
+        }
+        let mut input = File::open(source).map_err(|error| StoreError::Io {
+            doing: "opening",
+            path: source.display().to_string(),
+            source: error,
+        })?;
+        self.write(&digest, |file| {
+            let mut buffer = vec![0_u8; CHUNK];
+            loop {
+                let read = input.read(&mut buffer)?;
+                if read == 0 {
+                    return Ok(());
+                }
+                file.write_all(&buffer[..read])?;
+            }
+        })?;
+        Ok(Inserted {
+            digest,
+            deduplicated: false,
+        })
+    }
+
+    /// Puts a file in and refuses it if it is not what the manifest promised.
+    ///
+    /// This is the call a fetch uses. [`Self::insert_file`] takes whatever it is given and names it
+    /// correctly, which is the right behaviour for bytes this repository produced and the wrong one
+    /// for bytes that arrived over a network.
+    ///
+    /// # Errors
+    ///
+    /// If the file cannot be read, the object cannot be written, or the digest is not `wanted`.
+    pub fn insert_verified(&self, source: &Path, wanted: &Digest) -> Result<Inserted, StoreError> {
+        let found = Digest::of_file(source).map_err(|error| StoreError::Io {
+            doing: "hashing",
+            path: source.display().to_string(),
+            source: error,
+        })?;
+        if found != *wanted {
+            return Err(StoreError::DigestMismatch {
+                path: source.display().to_string(),
+                wanted: *wanted,
+                found,
+            });
+        }
+        self.insert_file(source)
+    }
+
+    /// Opens an object for reading.
+    ///
+    /// # Errors
+    ///
+    /// If the store does not have it, or it cannot be opened.
+    pub fn open_object(&self, digest: &Digest) -> Result<File, StoreError> {
+        let path = self.path(digest);
+        if !path.is_file() {
+            return Err(StoreError::Missing(*digest));
+        }
+        File::open(&path).map_err(|source| StoreError::Io {
+            doing: "opening",
+            path: path.display().to_string(),
+            source,
+        })
+    }
+
+    /// Re-reads an object and checks it still hashes to its own name.
+    ///
+    /// Nothing calls this on the happy path. It is for the case where a result looks wrong and
+    /// somebody needs to rule out the store, which is a question worth being able to answer in one
+    /// command rather than by reasoning about it.
+    ///
+    /// # Errors
+    ///
+    /// If the store does not have it, it cannot be read, or its content no longer matches its name.
+    pub fn verify(&self, digest: &Digest) -> Result<(), StoreError> {
+        let path = self.path(digest);
+        if !path.is_file() {
+            return Err(StoreError::Missing(*digest));
+        }
+        let found = Digest::of_file(&path).map_err(|source| StoreError::Io {
+            doing: "hashing",
+            path: path.display().to_string(),
+            source,
+        })?;
+        if found == *digest {
+            Ok(())
+        } else {
+            Err(StoreError::DigestMismatch {
+                path: path.display().to_string(),
+                wanted: *digest,
+                found,
+            })
+        }
+    }
+
+    /// Writes an object through a temporary file and renames it into place.
+    fn write(
+        &self,
+        digest: &Digest,
+        fill: impl FnOnce(&mut File) -> io::Result<()>,
+    ) -> Result<(), StoreError> {
+        let final_path = self.path(digest);
+        let directory = final_path
+            .parent()
+            .expect("an object path always has a parent");
+        std::fs::create_dir_all(directory).map_err(|source| StoreError::Io {
+            doing: "creating",
+            path: directory.display().to_string(),
+            source,
+        })?;
+
+        // The temporary name carries the process id so that two processes filling the store at once
+        // do not write over each other's partial files. They may both write the same object, which
+        // is harmless, because the rename at the end is atomic and both of them are producing
+        // identical bytes by construction.
+        let temporary = directory.join(format!(".{}.{}", digest.to_hex(), std::process::id()));
+        let shown = temporary.display().to_string();
+        let io_error = |doing: &'static str| {
+            let path = shown.clone();
+            move |source| StoreError::Io {
+                doing,
+                path,
+                source,
+            }
+        };
+
+        let mut sink = File::create(&temporary).map_err(io_error("creating"))?;
+        let filled = fill(&mut sink)
+            .and_then(|()| sink.sync_all())
+            .map_err(io_error("writing"));
+        drop(sink);
+        if let Err(error) = filled {
+            let _ = std::fs::remove_file(&temporary);
+            return Err(error);
+        }
+
+        std::fs::rename(&temporary, &final_path).map_err(io_error("renaming"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn store() -> (tempfile::TempDir, Store) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(dir.path()).unwrap();
+        (dir, store)
+    }
+
+    #[test]
+    fn an_object_is_addressed_by_its_own_digest() {
+        let (_dir, store) = store();
+        let inserted = store.insert_bytes(b"corpus bytes").unwrap();
+        assert!(!inserted.deduplicated);
+        assert_eq!(inserted.digest, Digest::of_bytes(b"corpus bytes"));
+        assert!(store.contains(&inserted.digest));
+    }
+
+    #[test]
+    fn the_same_bytes_twice_are_stored_once() {
+        let (_dir, store) = store();
+        let first = store.insert_bytes(b"the very same bytes").unwrap();
+        let second = store.insert_bytes(b"the very same bytes").unwrap();
+        assert_eq!(first.digest, second.digest);
+        assert!(!first.deduplicated);
+        assert!(second.deduplicated);
+    }
+
+    #[test]
+    fn the_path_splits_on_the_first_byte_of_the_digest() {
+        let (_dir, store) = store();
+        let digest = Digest::of_bytes(b"anything");
+        let hex = digest.to_hex();
+        let path = store.path(&digest);
+        assert_eq!(path.file_name().unwrap().to_str().unwrap(), &hex[2..]);
+        assert_eq!(
+            path.parent()
+                .unwrap()
+                .file_name()
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            &hex[..2]
+        );
+    }
+
+    #[test]
+    fn a_file_goes_in_and_comes_back_out_unchanged() {
+        let (dir, store) = store();
+        let source = dir.path().join("incoming");
+        // Larger than one copy chunk, so the loop that moves it runs more than once.
+        let bytes: Vec<u8> = (0..3_000_000_u32).map(|i| (i % 251) as u8).collect();
+        std::fs::write(&source, &bytes).unwrap();
+
+        let inserted = store.insert_file(&source).unwrap();
+        let mut round_tripped = Vec::new();
+        store
+            .open_object(&inserted.digest)
+            .unwrap()
+            .read_to_end(&mut round_tripped)
+            .unwrap();
+        assert_eq!(round_tripped, bytes);
+    }
+
+    #[test]
+    fn inserting_a_file_leaves_the_original_where_it_was() {
+        let (dir, store) = store();
+        let source = dir.path().join("incoming");
+        std::fs::write(&source, b"still here afterwards").unwrap();
+        store.insert_file(&source).unwrap();
+        assert!(source.is_file());
+    }
+
+    #[test]
+    fn a_verified_insert_refuses_bytes_that_are_not_what_was_promised() {
+        let (dir, store) = store();
+        let source = dir.path().join("incoming");
+        std::fs::write(&source, b"what actually arrived").unwrap();
+
+        let promised = Digest::of_bytes(b"what was promised");
+        let error = store.insert_verified(&source, &promised).unwrap_err();
+        let message = format!("{error}");
+        // Both digests, because a mismatch reported as a boolean is one somebody has to reproduce
+        // before they can begin working out what happened.
+        assert!(message.contains(&promised.to_hex()));
+        assert!(message.contains(&Digest::of_bytes(b"what actually arrived").to_hex()));
+        assert!(!store.contains(&promised));
+    }
+
+    #[test]
+    fn a_verified_insert_accepts_bytes_that_are() {
+        let (dir, store) = store();
+        let source = dir.path().join("incoming");
+        std::fs::write(&source, b"exactly as promised").unwrap();
+        let promised = Digest::of_bytes(b"exactly as promised");
+        assert_eq!(
+            store.insert_verified(&source, &promised).unwrap().digest,
+            promised
+        );
+    }
+
+    #[test]
+    fn asking_for_something_the_store_does_not_have_says_so() {
+        let (_dir, store) = store();
+        let absent = Digest::of_bytes(b"never inserted");
+        assert!(matches!(
+            store.open_object(&absent),
+            Err(StoreError::Missing(_))
+        ));
+        assert!(matches!(store.verify(&absent), Err(StoreError::Missing(_))));
+    }
+
+    #[test]
+    fn verify_catches_an_object_whose_content_no_longer_matches_its_name() {
+        let (_dir, store) = store();
+        let inserted = store.insert_bytes(b"the original bytes").unwrap();
+        store.verify(&inserted.digest).unwrap();
+
+        std::fs::write(store.path(&inserted.digest), b"something else entirely").unwrap();
+        assert!(matches!(
+            store.verify(&inserted.digest),
+            Err(StoreError::DigestMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn no_temporary_files_are_left_behind_by_a_successful_write() {
+        let (_dir, store) = store();
+        let inserted = store.insert_bytes(b"written cleanly").unwrap();
+        let directory = store.path(&inserted.digest).parent().unwrap().to_owned();
+        let strays: Vec<_> = std::fs::read_dir(directory)
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|entry| entry.file_name().to_string_lossy().starts_with('.'))
+            .collect();
+        assert!(strays.is_empty(), "left behind {strays:?}");
+    }
+
+    #[test]
+    fn a_store_reopened_on_the_same_root_still_has_everything() {
+        let dir = tempfile::tempdir().unwrap();
+        let digest = Store::open(dir.path())
+            .unwrap()
+            .insert_bytes(b"survives a restart")
+            .unwrap()
+            .digest;
+        assert!(Store::open(dir.path()).unwrap().contains(&digest));
+    }
+}

--- a/docs/CORPORA.md
+++ b/docs/CORPORA.md
@@ -1,0 +1,77 @@
+# Corpora and the manifest format
+
+A corpus that is not pinned by digest is not a corpus, it is whatever happened to download that day. This page is the format that does the pinning and the store the bytes end up in. What each corpus is licensed under and how this repository is allowed to handle it is in `LICENSING.md`, which this format encodes rather than replaces.
+
+## Where a manifest lives
+
+One directory per corpus under `corpora/`, and one `manifest.toml` in it. The directory name is the corpus name, and a manifest that disagrees with its own directory is refused rather than being taken as authoritative over it. Two names for one corpus is how a result ends up citing something other than what it read.
+
+## The format
+
+```toml
+[corpus]
+name = "example"
+description = "One sentence, for a reader who has not met this corpus before"
+source = "https://example.invalid/example.parquet"
+licence = "Apache-2.0"
+category = "fetch"
+
+[[files]]
+path = "example.parquet"
+blake3 = "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"
+bytes = 14779976446
+
+[assertions]
+rows = 99997497
+columns = 105
+```
+
+`name` is the identifier every other document cites and is also the directory name.
+
+`description` is one sentence. It exists so that somebody reading a result table can find out what they are looking at without leaving the repository.
+
+`source` is where the bytes come from: a URL for anything downloaded, or the generator and its arguments for anything produced locally.
+
+`licence` is an SPDX identifier where one exists and prose where one does not.
+
+`category` is `generate`, `fetch` or `mirror`, and the three are defined in `LICENSING.md`. The default is `fetch`. A `mirror` corpus must also carry `licence_note`, which says in plain terms what permits this repository to redistribute it. That field is checked rather than encouraged, because the moment it gets skipped is the moment somebody is in a hurry.
+
+`[[files]]` is one entry per file, each with a path relative to the corpus directory, a BLAKE3 digest in lower case hex, and a size in bytes. A manifest with no files is refused, because it pins nothing and the pin is the entire point. So is a path that is absolute or that contains a parent segment, since a manifest is as often something fetched from elsewhere as something written here. So is a file declared as zero bytes, and so is the same path listed twice.
+
+`[assertions]` is optional and is checked after the corpus loads rather than after it downloads. ClickBench is 99,997,497 rows across 105 columns or the manifest is wrong, and an assertion catches that far more cheaply than a number that looks slightly off six weeks later. Both fields are optional because not every corpus is tabular.
+
+Unknown fields are an error rather than being ignored. The field most worth typing wrongly is `licence_note`, and a typo that silently does nothing would defeat the one check on this page that has legal weight.
+
+## Digests
+
+Lower case hex, always, and an upper case spelling is refused rather than normalised. A manifest is read by people as well as by code, and two spellings of one digest is how a mismatch turns into an argument about whether it is a mismatch.
+
+BLAKE3 rather than SHA-256, because hashing a hundred gigabyte corpus has to be cheap enough that nobody is ever tempted to skip it. A check that only runs when somebody remembers to run it is not a pin.
+
+A digest mismatch on fetch is a hard failure with no override, and the message carries both digests. A mismatch reported as a boolean is a mismatch somebody has to reproduce before they can begin working out what happened.
+
+## The store
+
+Verified bytes go into a content addressed store, and an object is named by its own digest:
+
+```text
+<root>/objects/af/1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262
+```
+
+Two runs referring to the same corpus are then provably referring to the same bytes rather than to the same file name. A file name is a claim about content and a digest is the content, and the distance between those two is where an unreproducible result comes from.
+
+The first byte of the digest becomes a directory. That is not about lookup speed, since every lookup here is a direct path from a digest that is already known. It is about any one directory staying listable by a person trying to work out what is on a machine.
+
+Deduplication is not a feature, it is what the naming does. Two corpora sharing a file store it once, and re-fetching a corpus that is already present writes nothing at all.
+
+Writes go through a temporary file that is renamed into place once it is complete. A process that dies halfway through leaves a stray temporary file rather than a truncated object sitting at a path that asserts its own content, and that second thing is the one failure the store exists to make impossible. A file is copied in rather than moved, because the source is usually either a download somebody wants to keep or a file inside an extracted archive that other entries in the same manifest also point into.
+
+## What is checked, and where
+
+Twice, deliberately, and the duplication is not an accident.
+
+`ci/discipline.py` validates every manifest committed to this repository and fails the build. It runs on a tree that may not compile, which is the case where a bad manifest is most likely to slip past, so it cannot be the Rust code.
+
+`bench_corpus::Manifest` validates the same rules at run time. It runs on manifests that are not in this repository at all, which is where the format is heading once corpora are contributed rather than curated.
+
+The two lists are kept in step by hand. If they drift, the Python one is the one that gates the build and the Rust one is the one that gates a run, and either catching something the other misses is a bug in the one that missed it.


### PR DESCRIPTION
A corpus that is not pinned by digest is not a corpus, it is whatever happened to download that day. This is the format that does the pinning and the store the bytes land in.

`bench_corpus::Digest` is BLAKE3, held as bytes rather than as hex so that two digests compare in one instruction. Lower case hex is the only spelling accepted, and an upper case one is refused rather than normalised, because a manifest is read by people as well as by code and two spellings of one value is how a mismatch turns into an argument about whether it is a mismatch. BLAKE3 rather than SHA-256 because hashing a hundred gigabyte corpus has to stay cheap enough that nobody is tempted to skip it.

`bench_corpus::Manifest` is the TOML format documented in `docs/CORPORA.md`. It declares a source, a licence and one of the three handling categories from `LICENSING.md`, and it pins each file by digest and by size. Unknown fields are an error rather than being ignored, because the field most worth typing wrongly is `licence_note` and a typo that silently did nothing would defeat the one rule here with legal weight.

`bench_corpus::Store` names an object by its own digest, so two runs referring to the same corpus are provably referring to the same bytes rather than to the same file name. Deduplication is not a feature of this, it is what the naming does. Writes go through a temporary file that is renamed into place, so a process that dies halfway leaves a stray temporary rather than a truncated object sitting at a path that asserts its own content.

`ci/discipline.py` validates every manifest committed here, duplicating the Rust rules on purpose. It runs on a tree that may not compile, which is exactly the case where a bad manifest is most likely to get through, so it cannot be the Rust code that does it. `ci/test_discipline.py` is new and tests that validator, because there are no corpora in the tree yet and without it the manifest rules are code CI runs zero times and everybody assumes works. The first manifest to arrive should meet a checker that has itself been checked.

Also fixes a flake in the overhead tests that predates this branch. Two of them took a single clock reading and asserted a bound on it, and a descheduled reading crossed that bound about one run in three when the whole workspace tests at once. They now take the shortest of three, which is the defence `calibrate` already used, and descheduling can only ever make a duration longer.

Closes #7