### PR TITLE
Fetch ClickBench hits and assert its shape before anything measures it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,21 +32,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloc-no-stdlib"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
-
-[[package]]
-name = "alloc-stdlib"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
-dependencies = [
- "alloc-no-stdlib",
-]
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,6 +208,7 @@ dependencies = [
  "camino",
  "flate2",
  "hex",
+ "parquet",
  "serde",
  "tar",
  "tempfile",
@@ -310,27 +296,6 @@ dependencies = [
  "cfg-if",
  "constant_time_eq",
  "cpufeatures",
-]
-
-[[package]]
-name = "brotli"
-version = "8.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
- "brotli-decompressor",
-]
-
-[[package]]
-name = "brotli-decompressor"
-version = "5.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
 ]
 
 [[package]]
@@ -861,15 +826,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
-name = "lz4_flex"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecbdfe44b1bd960b68170b417450a628c43f7cf56bb3c5317e61cb230ee7f226"
-dependencies = [
- "twox-hash",
-]
-
-[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1056,19 +1012,14 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "base64",
- "brotli",
  "bytes",
  "chrono",
- "flate2",
  "half",
  "hashbrown",
- "lz4_flex",
  "num-bigint",
  "num-integer",
  "num-traits",
  "seq-macro",
- "simdutf8",
- "snap",
  "twox-hash",
  "zstd",
 ]
@@ -1361,12 +1312,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
-name = "simdutf8"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
-
-[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1377,12 +1322,6 @@ name = "smallvec"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
-
-[[package]]
-name = "snap"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "199905e6153d6405f9728fe44daace35f8f837bbf830bb6e85fbd5828709a886"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,9 @@ iris-source = "0.5.0"
 jiff = "0.2.35"
 libc = "0.2.189"
 object_store = "0.14.1"
-parquet = "59.3.0"
+# Off by default so that a crate which only reads footers does not drag in every codec and the
+# whole Arrow bridge. Anything that reads actual column data asks for what it needs.
+parquet = { version = "59.3.0", default-features = false }
 rand = "0.10.2"
 rand_chacha = "0.10.0"
 serde = { version = "1.0.229", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Public BI has been both the design input and the evaluation set for six years of
 
 Pre-alpha. B0 is done as of `v0.1.0`, so the measuring apparatus exists and the benchmarks do not. Milestones B0 through B8 are [public](https://github.com/tamnd/iris-bench/milestones) with one issue per exit gate.
 
-What B0 established is in `docs/ROADMAP.md` under that milestone, and the short version is that this fleet can measure, on one machine, for ratios always and for durations under a gate. The noise floor is 1.05% on the one eligible role and over two percent everywhere else, and the harness adds 41.1 ns to a sample, which is under one percent of anything longer than 4.1 microseconds. `iris-bench check`, `noise`, `overhead` and `resident` run today. Nothing else does.
+What B0 established is in `docs/ROADMAP.md` under that milestone, and the short version is that this fleet can measure, on one machine, for ratios always and for durations under a gate. The noise floor is 1.05% on the one eligible role and over two percent everywhere else, and the harness adds 41.1 ns to a sample, which is under one percent of anything longer than 4.1 microseconds. `iris-bench check`, `noise`, `overhead`, `resident` and `corpus` run today. Nothing else does.
 
 B0 through B4 need no `iris` code to exist, which is deliberate. If `iris` is never built, the reproduction of the published figures and the storage tier study still stand on their own.
 
@@ -60,6 +60,14 @@ cargo test --workspace
 ```
 
 The harness refuses to produce a publishable number on a machine that fails the eligibility gates, and it says which gate failed. That is not configurable.
+
+Getting a corpus onto the machine is one command, and it is worth pointing the store somewhere with room because ClickBench alone is 13.8 GiB.
+
+```
+cargo run -p iris-bench-cli -- corpus clickbench-hits --store /var/tmp/iris-corpus
+```
+
+The digest is checked in the same pass that writes the file, so bytes that are not what the manifest promised never land in the store. The asserted row and column counts are checked after, which is what catches a download that stopped early and still parses. `docs/CORPORA.md` is the format.
 
 ## Machines
 

--- a/ci/discipline.py
+++ b/ci/discipline.py
@@ -62,7 +62,7 @@ MANIFEST_FIELDS = {
         "category",
         "licence_note",
     },
-    "files": {"path", "blake3", "bytes"},
+    "files": {"path", "blake3", "bytes", "url"},
     "assertions": {"rows", "columns"},
 }
 
@@ -202,6 +202,14 @@ def check_manifest(manifest_path: pathlib.Path) -> None:
             fail(f"corpus {name}: {path} has no lower case hex BLAKE3 digest")
         if not isinstance(entry.get("bytes"), int) or entry.get("bytes", 0) <= 0:
             fail(f"corpus {name}: {path} declares no size, so a truncated file passes the length check")
+        # A fetched corpus has to be fetchable from what the manifest says, and the only two places
+        # that can come from are the entry's own url or the corpus source resolved against it.
+        if corpus.get("category") == "fetch" and not str(entry.get("url", "")).strip():
+            if not str(corpus.get("source", "")).startswith(("http://", "https://")):
+                fail(
+                    f"corpus {name}: {path} has no url and the source is not one either,"
+                    f" so there is nowhere to fetch it from"
+                )
 
 
 def check_no_machine_identity() -> None:

--- a/ci/test_discipline.py
+++ b/ci/test_discipline.py
@@ -124,6 +124,17 @@ def main() -> int:
         "'description'",
     )
     expect_complaint(
+        "a fetched corpus with nowhere to fetch from",
+        GOOD.replace('"https://example.invalid/example.parquet"', '"tpch-dbgen -s 20"'),
+        "nowhere to fetch it from",
+    )
+    expect_clean(
+        "a fetched corpus whose entry says where its bytes are",
+        GOOD.replace('"https://example.invalid/example.parquet"', '"tpch-dbgen -s 20"').replace(
+            "bytes = 1024", 'bytes = 1024\nurl = "https://example.invalid/example.parquet"'
+        ),
+    )
+    expect_complaint(
         "a manifest that is not TOML",
         "this is not toml at all {{",
         "not valid TOML",

--- a/corpora/clickbench-hits/manifest.toml
+++ b/corpora/clickbench-hits/manifest.toml
@@ -1,0 +1,25 @@
+# ClickBench hits, the single file Parquet distribution.
+#
+# The row and column counts are asserted rather than assumed. A download that stops early and still
+# parses is the failure that quietly invalidates a month of results, and the digest catches that for
+# a file while saying nothing about a corpus assembled from the wrong set of them.
+#
+# 105 columns is also why a fixed size 64 bit projection mask is not an acceptable ABI design, which
+# is a finding this repository hands back to iris. A finding is worth more when the number behind it
+# is checked on every run than when it is recalled from a page somebody read once.
+
+[corpus]
+name = "clickbench-hits"
+description = "Anonymised web analytics traffic, the corpus every ClickBench result is measured on"
+source = "https://datasets.clickhouse.com/hits_compatible/hits.parquet"
+licence = "Apache-2.0"
+category = "fetch"
+
+[[files]]
+path = "hits.parquet"
+blake3 = "0645797d99f4f15757cb3a336b2d164ecf34de53a61914b3c5102c3267fe4ec6"
+bytes = 14779976446
+
+[assertions]
+rows = 99997497
+columns = 105

--- a/crates/bench-cli/src/corpus.rs
+++ b/crates/bench-cli/src/corpus.rs
@@ -1,0 +1,191 @@
+//! `iris-bench corpus`, which gets a corpus onto the machine and then refuses to believe it.
+//!
+//! Three things happen in order and the order is the point. The manifest is read and validated, so
+//! a corpus that describes itself badly never reaches the network. The files are fetched and hashed
+//! in the same pass, so bytes that are not what was promised never reach the store. The footers are
+//! read and checked against the asserted row and column counts, so a corpus that is short never
+//! reaches a measurement.
+//!
+//! The last of those is the one worth being explicit about. A digest catches a file that changed
+//! and says nothing about a corpus assembled from the wrong set of files, and a download that stops
+//! early and still parses is exactly the failure that quietly invalidates a month of results.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context as _, bail};
+use bench_corpus::{Manifest, Progress, Shape, Store, fetch, shape};
+
+/// Where corpora are described, relative to the repository root.
+const CORPORA: &str = "corpora";
+
+/// Where the bytes go when nothing else says.
+const DEFAULT_STORE: &str = "corpus";
+
+/// Reads a corpus manifest, fetches what it names, and checks what arrived.
+pub(crate) fn run(name: &str, root: Option<PathBuf>, store: Option<PathBuf>) -> anyhow::Result<()> {
+    let root = root.unwrap_or_else(|| PathBuf::from(CORPORA));
+    let path = root.join(name).join("manifest.toml");
+    if !path.is_file() {
+        bail!(
+            "no manifest at {}. The corpora in this tree are {}",
+            path.display(),
+            available(&root)
+        );
+    }
+
+    let manifest = Manifest::read(&path)?;
+    println!("{}, {}", manifest.corpus.name, manifest.corpus.description);
+    println!(
+        "  {} under {}, {} in {} file{}",
+        manifest.corpus.category,
+        manifest.corpus.licence,
+        bytes(manifest.bytes()),
+        manifest.files.len(),
+        if manifest.files.len() == 1 { "" } else { "s" }
+    );
+    println!("  from {}", manifest.corpus.source);
+
+    let store = Store::open(store.unwrap_or_else(|| PathBuf::from(DEFAULT_STORE)))
+        .context("opening the corpus store")?;
+    println!("  into {}", store.root().display());
+    println!();
+
+    let mut last = String::new();
+    let fetched = fetch::corpus(&manifest, &store, &mut |progress| {
+        report(&mut last, &progress);
+    })?;
+    for file in &fetched {
+        println!(
+            "  {}  {}  {}{}",
+            if file.deduplicated { "have" } else { "got " },
+            file.digest,
+            file.path,
+            if file.deduplicated {
+                ", already in the store"
+            } else {
+                ""
+            }
+        );
+    }
+    println!();
+
+    describe(&manifest, shape::check(&manifest, &store)?);
+    Ok(())
+}
+
+/// Says what the shape check looked at and, more importantly, what it did not.
+fn describe(manifest: &Manifest, found: Shape) {
+    let tabular = manifest
+        .files
+        .iter()
+        .any(|entry| entry.path.to_ascii_lowercase().ends_with(".parquet"));
+    if !tabular {
+        println!("  nothing here is tabular, so there is no row or column count to check");
+        return;
+    }
+
+    println!("  {} rows and {} columns", found.rows, found.columns);
+    match (manifest.assertions.rows, manifest.assertions.columns) {
+        (Some(_), Some(_)) => println!("  both are what the manifest asserts"),
+        // Said out loud rather than left to be inferred from silence. A number that was read is
+        // printed exactly like a number that was checked, and only one of them would have caught a
+        // download that stopped early.
+        (None, None) => println!(
+            "  note: this manifest asserts neither, so both were read rather than checked and a \
+             short download would have passed"
+        ),
+        (rows, _) => println!(
+            "  note: this manifest asserts the {} count and not the other, so only one of them was \
+             checked",
+            if rows.is_some() { "row" } else { "column" }
+        ),
+    }
+}
+
+/// Prints how far along a download is, on one line that keeps being rewritten.
+fn report(last: &mut String, progress: &Progress<'_>) {
+    let line = format!(
+        "  {} of {}  {}",
+        bytes(progress.done),
+        bytes(progress.total),
+        progress.path
+    );
+    if line == *last {
+        return;
+    }
+    // Carriage return rather than a newline, because a fifteen gigabyte download reporting every
+    // sixty four mebibytes is two hundred lines of scrollback nobody wants.
+    print!("\r{line}    ");
+    let _ = std::io::Write::flush(&mut std::io::stdout());
+    if progress.done >= progress.total {
+        println!();
+    }
+    *last = line;
+}
+
+/// What corpora are in the tree, for the message when somebody asks for one that is not.
+fn available(root: &Path) -> String {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return format!("not readable at {}", root.display());
+    };
+    let mut names: Vec<String> = entries
+        .filter_map(Result::ok)
+        .filter(|entry| entry.path().join("manifest.toml").is_file())
+        .map(|entry| entry.file_name().to_string_lossy().into_owned())
+        .collect();
+    names.sort();
+    if names.is_empty() {
+        format!("none, {} has no manifests in it", root.display())
+    } else {
+        names.join(", ")
+    }
+}
+
+/// A byte count a person can read at a glance.
+fn bytes(count: u64) -> String {
+    #[allow(
+        clippy::cast_precision_loss,
+        reason = "this is a label on a progress line, not a measurement"
+    )]
+    let mut value = count as f64;
+    for unit in ["B", "KiB", "MiB", "GiB"] {
+        if value < 1024.0 {
+            return if unit == "B" {
+                format!("{count} B")
+            } else {
+                format!("{value:.1} {unit}")
+            };
+        }
+        value /= 1024.0;
+    }
+    format!("{value:.1} TiB")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn byte_counts_read_the_way_a_person_would_say_them() {
+        assert_eq!(bytes(512), "512 B");
+        assert_eq!(bytes(2048), "2.0 KiB");
+        assert_eq!(bytes(14_779_976_446), "13.8 GiB");
+    }
+
+    #[test]
+    fn asking_for_a_corpus_that_is_not_there_lists_the_ones_that_are() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join("clickbench-hits")).unwrap();
+        std::fs::write(dir.path().join("clickbench-hits").join("manifest.toml"), "").unwrap();
+
+        let error = run("not-a-corpus", Some(dir.path().to_owned()), None).unwrap_err();
+        assert!(format!("{error}").contains("clickbench-hits"));
+    }
+
+    #[test]
+    fn a_directory_with_no_manifest_in_it_is_not_offered() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join("half-finished")).unwrap();
+        assert!(available(dir.path()).contains("no manifests"));
+    }
+}

--- a/crates/bench-cli/src/main.rs
+++ b/crates/bench-cli/src/main.rs
@@ -1,8 +1,9 @@
 //! `iris-bench`, the command line tool.
 //!
-//! Only `check`, `noise`, `overhead` and `resident` are implemented. See `docs/ROADMAP.md` for the
-//! rest.
+//! Only `check`, `corpus`, `noise`, `overhead` and `resident` are implemented. See
+//! `docs/ROADMAP.md` for the rest.
 
+mod corpus;
 mod noise;
 mod overhead;
 mod resident;
@@ -128,10 +129,23 @@ enum Command {
         #[arg(long)]
         anyway: bool,
     },
-    /// Fetch or generate a corpus and verify it against its manifest.
+    /// Fetch a corpus and verify it against its manifest.
+    ///
+    /// The digest is checked in the same pass that writes the file, and the asserted row and column
+    /// counts are checked after. A corpus that is not what the manifest says never reaches a
+    /// measurement, which is the only reason any number here is worth comparing to a later one.
     Corpus {
         /// Corpus name, as it appears in the manifest directory.
         name: String,
+        /// Where the corpus manifests are, when they are not in `corpora/`.
+        #[arg(long, value_name = "PATH")]
+        root: Option<PathBuf>,
+        /// Where the bytes go, when they are not going in `corpus/`.
+        ///
+        /// Worth pointing somewhere with room. The store is content addressed, so pointing several
+        /// checkouts at one store is the supported way to have a corpus once rather than per clone.
+        #[arg(long, value_name = "PATH")]
+        store: Option<PathBuf>,
     },
     /// Run a workload and append the results to the store.
     Run {
@@ -254,6 +268,7 @@ fn main() -> anyhow::Result<()> {
             f64::from(floor) * 1_000.0,
             anyway,
         ),
+        Command::Corpus { name, root, store } => corpus::run(&name, root, store),
         other => anyhow::bail!("not implemented yet: {other:?}"),
     }
 }

--- a/crates/bench-corpus/Cargo.toml
+++ b/crates/bench-corpus/Cargo.toml
@@ -18,6 +18,9 @@ blake3.workspace = true
 camino.workspace = true
 flate2.workspace = true
 hex.workspace = true
+# No default features. Only the footer is read here, and the footer is not compressed, so pulling in
+# every codec and the whole Arrow bridge would be a dependency tree bought with nothing.
+parquet.workspace = true
 serde.workspace = true
 tar.workspace = true
 thiserror.workspace = true

--- a/crates/bench-corpus/src/digest.rs
+++ b/crates/bench-corpus/src/digest.rs
@@ -40,6 +40,15 @@ impl Digest {
         Ok(Self(*hasher.finalize().as_bytes()))
     }
 
+    /// A digest from bytes that have already been hashed somewhere else.
+    ///
+    /// For the streaming case, where the hasher is fed the same bytes that are being written and
+    /// there is never a complete copy to hand to [`Self::of_bytes`].
+    #[must_use]
+    pub const fn from_bytes(bytes: [u8; LENGTH]) -> Self {
+        Self(bytes)
+    }
+
     /// The digest as its bytes.
     #[must_use]
     pub const fn as_bytes(&self) -> &[u8; LENGTH] {

--- a/crates/bench-corpus/src/fetch.rs
+++ b/crates/bench-corpus/src/fetch.rs
@@ -1,0 +1,509 @@
+//! Getting a corpus onto the machine and refusing it if it is not what was promised.
+//!
+//! A fetch is not a download. A download gets bytes, and a fetch gets the bytes a manifest named,
+//! or it fails. The digest is checked in the same pass that writes the file, so a corpus that
+//! quietly changed at its source never reaches the store at all.
+//!
+//! # Where a file comes from
+//!
+//! An entry may carry its own `url`. When it does not, the file's URL is its `path` resolved
+//! against the corpus `source`, which is ordinary URL resolution: everything after the last slash
+//! of `source` is replaced by `path`. For a single file corpus whose source is the file itself,
+//! that resolves to the source unchanged, which is the common case and needs nothing written down.
+//! For a corpus of many files under one directory, `source` names any one of them, or the directory
+//! with a trailing slash, and each entry's path is appended.
+
+use std::{
+    io::{self, Read},
+    time::Duration,
+};
+
+use crate::{
+    digest::Digest,
+    manifest::{Category, Entry, Manifest},
+    store::{Store, StoreError},
+};
+
+/// How long to wait for the far end to start answering.
+///
+/// There is no limit on the transfer itself. A corpus here is tens of gigabytes and the honest
+/// upper bound on how long that takes on an unknown link is not a number anybody can write down, so
+/// the timeout that exists is the one that catches a host which is not answering at all.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// How often to tell the caller how far along a download is, in bytes.
+const REPORT_EVERY: u64 = 64 << 20;
+
+/// What a fetch did to one file.
+#[derive(Clone, Debug)]
+pub struct Fetched {
+    /// The path inside the corpus.
+    pub path: String,
+    /// What the file is addressed by, which is also what the manifest promised.
+    pub digest: Digest,
+    /// How many bytes it is.
+    pub bytes: u64,
+    /// Whether the store already had it, in which case nothing was downloaded.
+    pub deduplicated: bool,
+}
+
+/// How far along one file is.
+#[derive(Clone, Copy, Debug)]
+pub struct Progress<'a> {
+    /// The path inside the corpus.
+    pub path: &'a str,
+    /// How many bytes have arrived.
+    pub done: u64,
+    /// How many the manifest says there are.
+    pub total: u64,
+}
+
+/// Why a corpus did not arrive.
+#[derive(Debug, thiserror::Error)]
+pub enum FetchError {
+    /// The corpus is not one that can be downloaded.
+    #[error(
+        "{name} is a {category} corpus, so there is nothing to fetch. A generated corpus is \
+         produced locally and a mirrored one is already in the tree"
+    )]
+    NotFetchable {
+        /// Which corpus.
+        name: String,
+        /// What it is instead.
+        category: Category,
+    },
+    /// The corpus source is not a URL and no entry says where its bytes are.
+    #[error(
+        "{name}: {path} has no url and the corpus source is {declared}, which is not one either. A \
+         fetched corpus needs somewhere to fetch from"
+    )]
+    NoUrl {
+        /// Which corpus.
+        name: String,
+        /// Which file.
+        path: String,
+        /// What the corpus source says.
+        declared: String,
+    },
+    /// The request did not get through.
+    #[error("requesting {url}: {source}")]
+    Request {
+        /// Which URL.
+        url: String,
+        /// What the HTTP client said.
+        source: Box<ureq::Error>,
+    },
+    /// The far end answered, and answered no.
+    #[error("{url} answered {status}")]
+    Status {
+        /// Which URL.
+        url: String,
+        /// What it answered.
+        status: u16,
+    },
+    /// The transfer stopped partway.
+    #[error("reading {url}: {source}")]
+    Transfer {
+        /// Which URL.
+        url: String,
+        /// What went wrong underneath.
+        source: io::Error,
+    },
+    /// What arrived is not the size the manifest declared.
+    ///
+    /// Checked separately from the digest even though the digest would catch it, because a wrong
+    /// length says truncated download and a wrong digest says different file, and those two send
+    /// somebody to look in completely different places.
+    #[error("{path} was expected to be {wanted} bytes and is {found}")]
+    Size {
+        /// Which file.
+        path: String,
+        /// What the manifest declared.
+        wanted: u64,
+        /// What arrived.
+        found: u64,
+    },
+    /// What arrived is not the file the manifest pinned.
+    ///
+    /// Reported here rather than passed through from the store, because the store's version of this
+    /// names the path the bytes briefly occupied, which reads like there is a corrupt object sitting
+    /// in the store when the whole point is that there is not. What somebody needs is the URL.
+    #[error(
+        "{path} was expected to be {wanted} and what {url} served is {found}. This is not \
+         overridable. A corpus that changed at its source is a different corpus, and a result \
+         measured on it is not comparable with one measured before it changed"
+    )]
+    Digest {
+        /// Which file inside the corpus.
+        path: String,
+        /// Where the bytes came from.
+        url: String,
+        /// The digest the manifest pinned.
+        wanted: Digest,
+        /// The digest of what arrived.
+        found: Digest,
+    },
+    /// The store refused it for some reason other than the digest.
+    #[error(transparent)]
+    Store(#[from] StoreError),
+}
+
+/// Where one entry's bytes are.
+///
+/// # Errors
+///
+/// If the entry has no url of its own and the corpus source is not a URL either.
+pub fn url_for(manifest: &Manifest, entry: &Entry) -> Result<String, FetchError> {
+    if let Some(url) = entry.url.as_ref().filter(|url| !url.trim().is_empty()) {
+        return Ok(url.clone());
+    }
+    // Ordinary relative URL resolution against a base, spelled out rather than pulled in. Splitting
+    // on the scheme separator first is what keeps the slashes in `https://` from being mistaken for
+    // the last slash of a path.
+    let Some((scheme, rest)) = manifest
+        .corpus
+        .source
+        .trim()
+        .split_once("://")
+        .filter(|(scheme, _)| *scheme == "http" || *scheme == "https")
+    else {
+        return Err(FetchError::NoUrl {
+            name: manifest.corpus.name.clone(),
+            path: entry.path.clone(),
+            declared: manifest.corpus.source.clone(),
+        });
+    };
+    let base = match rest.rfind('/') {
+        Some(cut) => &rest[..=cut],
+        None => return Ok(format!("{scheme}://{rest}/{}", entry.path)),
+    };
+    Ok(format!("{scheme}://{base}{}", entry.path))
+}
+
+/// Downloads every file a manifest names that the store does not already have.
+///
+/// `watch` is called as bytes arrive, often enough to show that something is happening and rarely
+/// enough that it is not itself the slow part.
+///
+/// # Errors
+///
+/// If the corpus is not fetchable, a URL cannot be worked out, a request fails, a transfer stops
+/// partway, or what arrives is not the size or the digest the manifest promised.
+pub fn corpus(
+    manifest: &Manifest,
+    store: &Store,
+    watch: &mut dyn FnMut(Progress<'_>),
+) -> Result<Vec<Fetched>, FetchError> {
+    if manifest.corpus.category != Category::Fetch {
+        return Err(FetchError::NotFetchable {
+            name: manifest.corpus.name.clone(),
+            category: manifest.corpus.category,
+        });
+    }
+
+    let mut client = Client::new();
+    let mut fetched = Vec::with_capacity(manifest.files.len());
+    for entry in &manifest.files {
+        fetched.push(one(&mut client, manifest, entry, store, watch)?);
+    }
+    Ok(fetched)
+}
+
+/// The HTTP client, and the one piece of network reality it has to cope with.
+///
+/// A machine can have a default IPv6 route that does not work. The name resolves to an AAAA record,
+/// the connection fails with network unreachable, and every browser and curl on that machine is
+/// fine because they try the other family. This does the same thing, once, and then remembers.
+///
+/// Forcing IPv4 everywhere would be the shorter fix and the wrong one, since it would break the
+/// machines where IPv6 is the family that works. This is not covered by a test, because what it
+/// handles is a property of a network rather than of this code.
+struct Client {
+    /// Whichever family resolves first, which is what should normally be used.
+    any: ureq::Agent,
+    /// The fallback, built once and only when something has already failed.
+    ipv4: Option<ureq::Agent>,
+    /// Set once the fallback has worked, so the rest of a corpus does not pay for the failure.
+    fallen_back: bool,
+}
+
+impl Client {
+    /// Builds the client with no fallback yet.
+    fn new() -> Self {
+        Self {
+            any: agent(ureq::config::IpFamily::Any),
+            ipv4: None,
+            fallen_back: false,
+        }
+    }
+
+    /// Gets a URL, trying the other address family if the first attempt cannot connect at all.
+    fn get(&mut self, url: &str) -> Result<ureq::http::Response<ureq::Body>, FetchError> {
+        if !self.fallen_back {
+            match self.any.get(url).call() {
+                Ok(response) => return Ok(response),
+                // A status code is an answer. Asking the same question over a different address
+                // family would get the same answer and waste a request finding that out.
+                Err(ureq::Error::StatusCode(status)) => {
+                    return Err(FetchError::Status {
+                        url: url.to_owned(),
+                        status,
+                    });
+                }
+                Err(first) => {
+                    let ipv4 = self
+                        .ipv4
+                        .get_or_insert_with(|| agent(ureq::config::IpFamily::Ipv4Only));
+                    let Ok(response) = ipv4.get(url).call() else {
+                        // The first error is the one reported. The retry existing is an
+                        // implementation detail and its error would only be confusing.
+                        return Err(FetchError::Request {
+                            url: url.to_owned(),
+                            source: Box::new(first),
+                        });
+                    };
+                    self.fallen_back = true;
+                    return Ok(response);
+                }
+            }
+        }
+
+        let ipv4 = self
+            .ipv4
+            .get_or_insert_with(|| agent(ureq::config::IpFamily::Ipv4Only));
+        ipv4.get(url).call().map_err(|source| match source {
+            ureq::Error::StatusCode(status) => FetchError::Status {
+                url: url.to_owned(),
+                status,
+            },
+            other => FetchError::Request {
+                url: url.to_owned(),
+                source: Box::new(other),
+            },
+        })
+    }
+}
+
+/// An agent restricted to one address family.
+fn agent(family: ureq::config::IpFamily) -> ureq::Agent {
+    ureq::Agent::config_builder()
+        .timeout_connect(Some(CONNECT_TIMEOUT))
+        .ip_family(family)
+        .build()
+        .into()
+}
+
+/// Downloads one entry.
+fn one(
+    client: &mut Client,
+    manifest: &Manifest,
+    entry: &Entry,
+    store: &Store,
+    watch: &mut dyn FnMut(Progress<'_>),
+) -> Result<Fetched, FetchError> {
+    // Asked before the request is made, because the whole point of addressing by content is that a
+    // corpus already on the machine costs nothing to have again.
+    if store.contains(&entry.blake3) {
+        watch(Progress {
+            path: &entry.path,
+            done: entry.bytes,
+            total: entry.bytes,
+        });
+        return Ok(Fetched {
+            path: entry.path.clone(),
+            digest: entry.blake3,
+            bytes: entry.bytes,
+            deduplicated: true,
+        });
+    }
+
+    let url = url_for(manifest, entry)?;
+    let response = client.get(&url)?;
+
+    let mut counting = Counting {
+        inner: response.into_body().into_reader(),
+        seen: 0,
+        next: REPORT_EVERY,
+        path: &entry.path,
+        total: entry.bytes,
+        watch,
+    };
+    let inserted = store.insert_stream(&mut counting, &entry.blake3);
+    let found = counting.seen;
+
+    // A wrong length and a wrong digest are the same event as far as the store is concerned, and it
+    // has already refused and removed whatever arrived either way. Which of the two gets reported
+    // matters to the person reading it, though: a short read is a truncated download and a full
+    // length mismatch is a different file, and those send somebody to look in different places.
+    if found != entry.bytes {
+        return Err(FetchError::Size {
+            path: entry.path.clone(),
+            wanted: entry.bytes,
+            found,
+        });
+    }
+
+    let inserted = match inserted {
+        Ok(inserted) => inserted,
+        Err(StoreError::DigestMismatch { wanted, found, .. }) => {
+            return Err(FetchError::Digest {
+                path: entry.path.clone(),
+                url,
+                wanted,
+                found,
+            });
+        }
+        Err(other) => return Err(other.into()),
+    };
+    Ok(Fetched {
+        path: entry.path.clone(),
+        digest: inserted.digest,
+        bytes: found,
+        deduplicated: inserted.deduplicated,
+    })
+}
+
+/// A reader that counts what goes through it and says so every so often.
+struct Counting<'a, R> {
+    /// The reader the bytes are actually coming from.
+    inner: R,
+    /// How many have gone through.
+    seen: u64,
+    /// The count at which to report next.
+    next: u64,
+    /// Which file, for the report.
+    path: &'a str,
+    /// How many bytes the manifest says there are, for the report.
+    total: u64,
+    /// Who to tell.
+    watch: &'a mut dyn FnMut(Progress<'_>),
+}
+
+impl<R: Read> Read for Counting<'_, R> {
+    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        let read = self.inner.read(buffer)?;
+        self.seen += read as u64;
+        if self.seen >= self.next || read == 0 {
+            self.next = self.seen + REPORT_EVERY;
+            (self.watch)(Progress {
+                path: self.path,
+                done: self.seen,
+                total: self.total,
+            });
+        }
+        Ok(read)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const EMPTY_DIGEST: &str = "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262";
+
+    fn manifest(source: &str, files: &str) -> Manifest {
+        Manifest::parse(&format!(
+            "[corpus]\n\
+             name = \"example\"\n\
+             description = \"A corpus that exists to have its URLs worked out\"\n\
+             source = \"{source}\"\n\
+             licence = \"Apache-2.0\"\n\
+             category = \"fetch\"\n\
+             {files}"
+        ))
+        .unwrap()
+    }
+
+    fn file(path: &str, url: &str) -> String {
+        format!("[[files]]\npath = \"{path}\"\nblake3 = \"{EMPTY_DIGEST}\"\nbytes = 1024\n{url}\n")
+    }
+
+    #[test]
+    fn a_single_file_source_resolves_to_itself() {
+        let manifest = manifest(
+            "https://example.invalid/sets/hits.parquet",
+            &file("hits.parquet", ""),
+        );
+        assert_eq!(
+            url_for(&manifest, &manifest.files[0]).unwrap(),
+            "https://example.invalid/sets/hits.parquet"
+        );
+    }
+
+    #[test]
+    fn a_path_resolves_against_the_last_slash_of_the_source() {
+        let manifest = manifest(
+            "https://example.invalid/sets/hits.parquet",
+            &file("part-1.parquet", ""),
+        );
+        assert_eq!(
+            url_for(&manifest, &manifest.files[0]).unwrap(),
+            "https://example.invalid/sets/part-1.parquet"
+        );
+    }
+
+    #[test]
+    fn a_source_ending_in_a_slash_is_a_directory() {
+        let manifest = manifest("https://example.invalid/sets/", &file("part-1.parquet", ""));
+        assert_eq!(
+            url_for(&manifest, &manifest.files[0]).unwrap(),
+            "https://example.invalid/sets/part-1.parquet"
+        );
+    }
+
+    #[test]
+    fn an_entry_with_its_own_url_uses_it() {
+        let manifest = manifest(
+            "https://example.invalid/sets/hits.parquet",
+            &file(
+                "part-1.parquet",
+                "url = \"https://elsewhere.invalid/mirror/part-1.parquet\"",
+            ),
+        );
+        assert_eq!(
+            url_for(&manifest, &manifest.files[0]).unwrap(),
+            "https://elsewhere.invalid/mirror/part-1.parquet"
+        );
+    }
+
+    #[test]
+    fn a_source_that_is_not_a_url_and_an_entry_that_does_not_say_is_an_error() {
+        let manifest = manifest("tpch-dbgen -s 20", &file("lineitem.parquet", ""));
+        let error = url_for(&manifest, &manifest.files[0]).unwrap_err();
+        assert!(matches!(error, FetchError::NoUrl { .. }));
+    }
+
+    #[test]
+    fn a_generated_corpus_is_not_fetched() {
+        let mut generated = manifest(
+            "https://example.invalid/sets/hits.parquet",
+            &file("hits.parquet", ""),
+        );
+        generated.corpus.category = Category::Generate;
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(dir.path()).unwrap();
+        let error = corpus(&generated, &store, &mut |_| {}).unwrap_err();
+        assert!(matches!(error, FetchError::NotFetchable { .. }));
+    }
+
+    #[test]
+    fn a_corpus_already_in_the_store_is_not_requested_again() {
+        // The source is unreachable on purpose. If this passes, nothing went near the network.
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(dir.path()).unwrap();
+        store.insert_bytes(b"").unwrap();
+
+        let manifest = manifest(
+            "https://nothing.invalid/hits.parquet",
+            &file("hits.parquet", ""),
+        );
+        let mut seen = Vec::new();
+        let fetched = corpus(&manifest, &store, &mut |progress| {
+            seen.push(progress.done);
+        })
+        .unwrap();
+        assert!(fetched[0].deduplicated);
+        assert_eq!(fetched[0].digest.to_hex(), EMPTY_DIGEST);
+        assert_eq!(seen, vec![1024]);
+    }
+}

--- a/crates/bench-corpus/src/lib.rs
+++ b/crates/bench-corpus/src/lib.rs
@@ -15,14 +15,25 @@
 //! are then referring to the same bytes rather than to the same file name, which is the property
 //! that makes a result worth re-running.
 //!
-//! Fetching and generation are not implemented yet. See B1 in `docs/ROADMAP.md`.
+//! # What a fetch guarantees
+//!
+//! [`fetch::corpus`] downloads what a manifest names and hashes it in the same pass that writes it,
+//! so bytes that are not what was promised never reach the store. [`shape::check`] then reads the
+//! Parquet footers and refuses a corpus that is not the row and column count the manifest asserted,
+//! which is the check that catches a download that stopped early and still parses.
+//!
+//! Generation is not implemented yet. See B1 in `docs/ROADMAP.md`.
 
 mod digest;
+pub mod fetch;
 mod manifest;
+pub mod shape;
 mod store;
 
 pub use digest::{Digest, DigestError};
+pub use fetch::{FetchError, Fetched, Progress};
 pub use manifest::{Assertions, Category, Corpus, Entry, Manifest, ManifestError};
+pub use shape::{Shape, ShapeError};
 pub use store::{Inserted, Store, StoreError};
 
 /// The version of this crate, as reported by build metadata.

--- a/crates/bench-corpus/src/manifest.rs
+++ b/crates/bench-corpus/src/manifest.rs
@@ -85,6 +85,13 @@ pub struct Entry {
     pub blake3: Digest,
     /// How large the file is, which is checked before the digest because it is free.
     pub bytes: u64,
+    /// Where this particular file comes from, when the corpus source does not already say.
+    ///
+    /// Left out for almost every corpus. It exists for the case where the files of one corpus are
+    /// not all under one prefix, which is common enough in published datasets that the format
+    /// having no answer for it would mean forking the corpus rather than describing it.
+    #[serde(default)]
+    pub url: Option<String>,
 }
 
 /// Facts a run checks about the loaded corpus before it measures anything.

--- a/crates/bench-corpus/src/shape.rs
+++ b/crates/bench-corpus/src/shape.rs
@@ -1,0 +1,468 @@
+//! Checking that a corpus is the size it is supposed to be, before anything measures it.
+//!
+//! `ClickBench` hits is 99,997,497 rows across 105 columns. A download that stops early and still
+//! parses is the failure that quietly invalidates a month of results, and the digest catches that
+//! for a file while saying nothing about a corpus assembled from the wrong set of files. The row
+//! count is the check that covers the corpus rather than the file.
+//!
+//! The column count earns its place for a second reason. 105 is why a fixed size 64 bit projection
+//! mask is not an acceptable ABI design, which is a finding this repository hands back to iris, and
+//! a finding is worth more when the number behind it is asserted on every run than when it is
+//! recalled from a page somebody read once.
+//!
+//! # What this reads
+//!
+//! The Parquet footer and nothing else. Row and column counts are metadata, so this is a seek and a
+//! few kilobytes rather than a pass over the file, which is what makes it affordable to run before
+//! every measurement rather than once when the corpus was added.
+
+use std::{fs::File, path::Path};
+
+use parquet::file::reader::{FileReader, SerializedFileReader};
+
+use crate::{
+    manifest::Manifest,
+    store::{Store, StoreError},
+};
+
+/// How large a corpus turned out to be.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct Shape {
+    /// How many rows, summed across every file.
+    pub rows: u64,
+    /// How many columns, which every file has to agree on.
+    pub columns: u64,
+}
+
+/// Why a shape could not be read, or was read and was wrong.
+#[derive(Debug, thiserror::Error)]
+pub enum ShapeError {
+    /// The file is not there or cannot be opened.
+    #[error("opening {path}: {source}")]
+    Open {
+        /// Which file.
+        path: String,
+        /// What the filesystem said.
+        source: std::io::Error,
+    },
+    /// The file is not the Parquet it is named as.
+    #[error("reading the footer of {path}: {source}")]
+    Parquet {
+        /// Which file.
+        path: String,
+        /// What the Parquet reader objected to.
+        source: Box<parquet::errors::ParquetError>,
+    },
+    /// Two files of one corpus disagree about how many columns it has.
+    #[error(
+        "{corpus} is not one table: {first} has {expected} columns and {second} has {found}. A \
+         corpus whose files have different schemas cannot be scanned as one thing"
+    )]
+    Ragged {
+        /// Which corpus.
+        corpus: String,
+        /// The file that set the expectation.
+        first: String,
+        /// How many columns it has.
+        expected: u64,
+        /// The file that broke it.
+        second: String,
+        /// How many columns that one has.
+        found: u64,
+    },
+    /// The corpus loaded and is not the shape the manifest asserted.
+    #[error(
+        "{corpus} was asserted to have {wanted} {what} and has {found}. Either the download is not \
+         what it was last time or the manifest is wrong, and both are worth stopping for"
+    )]
+    Mismatch {
+        /// Which corpus.
+        corpus: String,
+        /// Rows or columns.
+        what: &'static str,
+        /// What the manifest asserted.
+        wanted: u64,
+        /// What the files actually have.
+        found: u64,
+    },
+    /// The manifest asserts a shape and nothing in the corpus has one.
+    #[error(
+        "{corpus} asserts a {what} and none of its files are Parquet, so there is no footer to \
+         check it against. Either the assertion belongs to a different corpus or the files do"
+    )]
+    Unreadable {
+        /// Which corpus.
+        corpus: String,
+        /// Rows or columns.
+        what: &'static str,
+    },
+    /// The store does not have a file the manifest names.
+    #[error(transparent)]
+    Store(#[from] StoreError),
+}
+
+/// Whether this is a file a shape can be read out of.
+///
+/// Decided by the path the manifest declares rather than by looking at the bytes, because the
+/// manifest is this repository's own statement about what a file is. A corpus of compressed text
+/// like Silesia has no rows or columns and is not being guessed at here, while a `.parquet` file
+/// that turns out not to be Parquet is a hard error rather than something quietly skipped.
+fn is_parquet(path: &str) -> bool {
+    Path::new(path)
+        .extension()
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("parquet"))
+}
+
+/// Reads the row and column counts out of one Parquet file's footer.
+///
+/// # Errors
+///
+/// If the file cannot be opened or its footer cannot be read.
+pub fn of_file(path: &Path) -> Result<Shape, ShapeError> {
+    let shown = path.display().to_string();
+    let file = File::open(path).map_err(|source| ShapeError::Open {
+        path: shown.clone(),
+        source,
+    })?;
+    let reader = SerializedFileReader::new(file).map_err(|source| ShapeError::Parquet {
+        path: shown.clone(),
+        source: Box::new(source),
+    })?;
+    let metadata = reader.metadata().file_metadata();
+    Ok(Shape {
+        // A negative row count would mean a Parquet writer wrote one, and taking it as zero here
+        // would turn that into a corpus that silently asserts nothing.
+        rows: u64::try_from(metadata.num_rows()).unwrap_or(0),
+        columns: metadata.schema_descr().num_columns() as u64,
+    })
+}
+
+/// Measures a whole corpus out of the store.
+///
+/// Rows are summed and columns have to agree, because a corpus split across files is one table and
+/// files with different schemas are not one table however they are named. Files that are not
+/// Parquet do not contribute, so a corpus of compressed text measures as nothing rather than as an
+/// error, and a manifest that asserts a shape for such a corpus is caught by [`check`].
+///
+/// # Errors
+///
+/// If the store is missing a file, a footer cannot be read, or the files disagree on column count.
+pub fn of_corpus(manifest: &Manifest, store: &Store) -> Result<Shape, ShapeError> {
+    let mut rows = 0_u64;
+    let mut columns: Option<(&str, u64)> = None;
+    for entry in manifest
+        .files
+        .iter()
+        .filter(|entry| is_parquet(&entry.path))
+    {
+        let path = store.path(&entry.blake3);
+        if !path.is_file() {
+            return Err(ShapeError::Store(StoreError::Missing(entry.blake3)));
+        }
+        let shape = of_file(&path)?;
+        rows += shape.rows;
+        match columns {
+            None => columns = Some((&entry.path, shape.columns)),
+            Some((first, expected)) if expected != shape.columns => {
+                return Err(ShapeError::Ragged {
+                    corpus: manifest.corpus.name.clone(),
+                    first: first.to_owned(),
+                    expected,
+                    second: entry.path.clone(),
+                    found: shape.columns,
+                });
+            }
+            Some(_) => {}
+        }
+    }
+    Ok(Shape {
+        rows,
+        columns: columns.map_or(0, |(_, count)| count),
+    })
+}
+
+/// Reads the corpus and refuses it if it is not what the manifest asserted.
+///
+/// Returns the shape it read, so that a caller can print what it checked rather than only that it
+/// checked something. A manifest with no assertions is not an error, it is a corpus nobody has
+/// written the numbers down for yet, and the shape comes back all the same.
+///
+/// # Errors
+///
+/// If the corpus cannot be measured, or its row or column count is not what was asserted.
+pub fn check(manifest: &Manifest, store: &Store) -> Result<Shape, ShapeError> {
+    let readable = manifest.files.iter().any(|entry| is_parquet(&entry.path));
+    let found = of_corpus(manifest, store)?;
+    for (what, wanted, actual) in [
+        ("rows", manifest.assertions.rows, found.rows),
+        ("columns", manifest.assertions.columns, found.columns),
+    ] {
+        // An assertion nothing can be checked against is worse than no assertion, because it reads
+        // on the page like something is being verified.
+        if wanted.is_some() && !readable {
+            return Err(ShapeError::Unreadable {
+                corpus: manifest.corpus.name.clone(),
+                what,
+            });
+        }
+        if let Some(wanted) = wanted
+            && wanted != actual
+        {
+            return Err(ShapeError::Mismatch {
+                corpus: manifest.corpus.name.clone(),
+                what,
+                wanted,
+                found: actual,
+            });
+        }
+    }
+    Ok(found)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::digest::Digest;
+
+    const EMPTY_DIGEST: &str = "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262";
+
+    fn manifest(files: &str, assertions: &str) -> Manifest {
+        Manifest::parse(&format!(
+            "[corpus]\n\
+             name = \"example\"\n\
+             description = \"A corpus that exists to have its shape checked\"\n\
+             source = \"https://example.invalid/example.parquet\"\n\
+             licence = \"Apache-2.0\"\n\
+             category = \"fetch\"\n\
+             {files}{assertions}"
+        ))
+        .unwrap()
+    }
+
+    /// A Parquet file with `columns` columns and `rows` rows, written to `path`.
+    fn write_parquet(path: &Path, columns: usize, rows: usize) {
+        use parquet::{
+            basic::Type,
+            file::{properties::WriterProperties, writer::SerializedFileWriter},
+            schema::types::Type as SchemaType,
+        };
+        use std::sync::Arc;
+
+        let fields: Vec<Arc<SchemaType>> = (0..columns)
+            .map(|i| {
+                Arc::new(
+                    SchemaType::primitive_type_builder(&format!("c{i}"), Type::INT64)
+                        .with_repetition(parquet::basic::Repetition::REQUIRED)
+                        .build()
+                        .unwrap(),
+                )
+            })
+            .collect();
+        let schema = Arc::new(
+            SchemaType::group_type_builder("row")
+                .with_fields(fields)
+                .build()
+                .unwrap(),
+        );
+
+        let file = File::create(path).unwrap();
+        let mut writer =
+            SerializedFileWriter::new(file, schema, Arc::new(WriterProperties::new())).unwrap();
+        let mut group = writer.next_row_group().unwrap();
+        let values: Vec<i64> = (0..i64::try_from(rows).unwrap()).collect();
+        while let Some(mut column) = group.next_column().unwrap() {
+            column
+                .typed::<parquet::data_type::Int64Type>()
+                .write_batch(&values, None, None)
+                .unwrap();
+            column.close().unwrap();
+        }
+        group.close().unwrap();
+        writer.close().unwrap();
+    }
+
+    /// A store holding one Parquet file, and the digest it went in under.
+    fn stored(columns: usize, rows: usize) -> (tempfile::TempDir, Store, Digest) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(dir.path().join("store")).unwrap();
+        let path = dir.path().join("part.parquet");
+        write_parquet(&path, columns, rows);
+        let digest = store.insert_file(&path).unwrap().digest;
+        (dir, store, digest)
+    }
+
+    fn entry(path: &str, digest: &Digest) -> String {
+        format!(
+            "[[files]]\npath = \"{path}\"\nblake3 = \"{}\"\nbytes = 1024\n",
+            digest.to_hex()
+        )
+    }
+
+    #[test]
+    fn the_shape_of_one_file_is_read_from_its_footer() {
+        let (_dir, store, digest) = stored(7, 40);
+        let manifest = manifest(&entry("part.parquet", &digest), "");
+        assert_eq!(
+            of_corpus(&manifest, &store).unwrap(),
+            Shape {
+                rows: 40,
+                columns: 7
+            }
+        );
+    }
+
+    #[test]
+    fn rows_sum_across_the_files_of_one_corpus() {
+        let (dir, store, first) = stored(7, 40);
+        let second_path = dir.path().join("part-2.parquet");
+        write_parquet(&second_path, 7, 60);
+        let second = store.insert_file(&second_path).unwrap().digest;
+
+        let manifest = manifest(
+            &format!(
+                "{}{}",
+                entry("part-1.parquet", &first),
+                entry("part-2.parquet", &second)
+            ),
+            "",
+        );
+        assert_eq!(
+            of_corpus(&manifest, &store).unwrap(),
+            Shape {
+                rows: 100,
+                columns: 7
+            }
+        );
+    }
+
+    #[test]
+    fn files_that_disagree_on_columns_are_not_one_corpus() {
+        let (dir, store, first) = stored(7, 40);
+        let second_path = dir.path().join("part-2.parquet");
+        write_parquet(&second_path, 9, 40);
+        let second = store.insert_file(&second_path).unwrap().digest;
+
+        let manifest = manifest(
+            &format!(
+                "{}{}",
+                entry("part-1.parquet", &first),
+                entry("part-2.parquet", &second)
+            ),
+            "",
+        );
+        let error = of_corpus(&manifest, &store).unwrap_err();
+        assert!(matches!(error, ShapeError::Ragged { .. }));
+    }
+
+    #[test]
+    fn an_assertion_that_holds_passes() {
+        let (_dir, store, digest) = stored(105, 40);
+        let manifest = manifest(
+            &entry("part.parquet", &digest),
+            "[assertions]\nrows = 40\ncolumns = 105\n",
+        );
+        assert_eq!(check(&manifest, &store).unwrap().columns, 105);
+    }
+
+    #[test]
+    fn a_row_count_that_does_not_hold_is_refused() {
+        let (_dir, store, digest) = stored(7, 40);
+        let manifest = manifest(
+            &entry("part.parquet", &digest),
+            "[assertions]\nrows = 99997497\n",
+        );
+        let message = format!("{}", check(&manifest, &store).unwrap_err());
+        // Both numbers, because the interesting part of a truncated corpus is how short it is.
+        assert!(message.contains("99997497"), "{message}");
+        assert!(message.contains("40"), "{message}");
+    }
+
+    #[test]
+    fn a_column_count_that_does_not_hold_is_refused() {
+        let (_dir, store, digest) = stored(64, 40);
+        let manifest = manifest(
+            &entry("part.parquet", &digest),
+            "[assertions]\ncolumns = 105\n",
+        );
+        assert!(matches!(
+            check(&manifest, &store),
+            Err(ShapeError::Mismatch {
+                what: "columns",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn a_corpus_the_store_does_not_have_says_so_rather_than_reading_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(dir.path()).unwrap();
+        let manifest = manifest(
+            &entry("part.parquet", &EMPTY_DIGEST.parse().unwrap()),
+            "[assertions]\nrows = 40\n",
+        );
+        assert!(matches!(
+            check(&manifest, &store),
+            Err(ShapeError::Store(StoreError::Missing(_)))
+        ));
+    }
+
+    #[test]
+    fn a_corpus_that_is_not_tabular_measures_as_nothing_rather_than_as_an_error() {
+        // Silesia and enwik8 are compressed text. Reading a Parquet footer out of them is not a
+        // check that fails, it is a check that does not apply.
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(dir.path().join("store")).unwrap();
+        let path = dir.path().join("silesia.tar");
+        std::fs::write(&path, b"not parquet and not pretending to be").unwrap();
+        let digest = store.insert_file(&path).unwrap().digest;
+
+        let manifest = manifest(&entry("silesia.tar", &digest), "");
+        assert_eq!(
+            check(&manifest, &store).unwrap(),
+            Shape {
+                rows: 0,
+                columns: 0
+            }
+        );
+    }
+
+    #[test]
+    fn asserting_a_shape_for_a_corpus_that_has_none_is_refused() {
+        // Worse than asserting nothing, because on the page it reads like something is being
+        // verified, and what would actually happen is a comparison against zero.
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(dir.path().join("store")).unwrap();
+        let path = dir.path().join("silesia.tar");
+        std::fs::write(&path, b"not parquet and not pretending to be").unwrap();
+        let digest = store.insert_file(&path).unwrap().digest;
+
+        let manifest = manifest(&entry("silesia.tar", &digest), "[assertions]\nrows = 40\n");
+        assert!(matches!(
+            check(&manifest, &store),
+            Err(ShapeError::Unreadable { .. })
+        ));
+    }
+
+    #[test]
+    fn a_file_named_parquet_that_is_not_parquet_is_a_hard_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(dir.path().join("store")).unwrap();
+        let path = dir.path().join("part.parquet");
+        std::fs::write(&path, b"claims to be parquet and is not").unwrap();
+        let digest = store.insert_file(&path).unwrap().digest;
+
+        let manifest = manifest(&entry("part.parquet", &digest), "");
+        assert!(matches!(
+            check(&manifest, &store),
+            Err(ShapeError::Parquet { .. })
+        ));
+    }
+
+    #[test]
+    fn a_manifest_with_no_assertions_still_reports_what_it_read() {
+        let (_dir, store, digest) = stored(7, 40);
+        let manifest = manifest(&entry("part.parquet", &digest), "");
+        assert_eq!(check(&manifest, &store).unwrap().rows, 40);
+    }
+}

--- a/crates/bench-corpus/src/store.rs
+++ b/crates/bench-corpus/src/store.rs
@@ -210,6 +210,65 @@ impl Store {
         self.insert_file(source)
     }
 
+    /// Streams bytes in, hashing as they arrive, and keeps them only if they are what was promised.
+    ///
+    /// This is what a fetch uses. [`Self::insert_verified`] reads its source three times, once to
+    /// hash and twice to copy, which is the right shape for a file already on disk and the wrong
+    /// one for fifteen gigabytes arriving over a network. Here the bytes are hashed and written in
+    /// the same pass, and a download that does not match is deleted rather than renamed, so a
+    /// mismatch never reaches a path that asserts its own content.
+    ///
+    /// # Errors
+    ///
+    /// If the stream cannot be read, the object cannot be written, or the digest is not `wanted`.
+    pub fn insert_stream(
+        &self,
+        mut reader: impl Read,
+        wanted: &Digest,
+    ) -> Result<Inserted, StoreError> {
+        if self.contains(wanted) {
+            return Ok(Inserted {
+                digest: *wanted,
+                deduplicated: true,
+            });
+        }
+        let mut hasher = blake3::Hasher::new();
+        self.write(wanted, |sink| {
+            let mut buffer = vec![0_u8; CHUNK];
+            loop {
+                let read = reader.read(&mut buffer)?;
+                if read == 0 {
+                    return Ok(());
+                }
+                hasher.update(&buffer[..read]);
+                sink.write_all(&buffer[..read])?;
+            }
+        })?;
+
+        let found = Digest::from_bytes(*hasher.finalize().as_bytes());
+        if found == *wanted {
+            return Ok(Inserted {
+                digest: found,
+                deduplicated: false,
+            });
+        }
+
+        // The object was renamed into place under the wanted name before this was known, because
+        // the digest is only final once the last byte has arrived. Removing it here is what keeps
+        // the invariant true: an object in this store hashes to its own name.
+        let path = self.path(wanted);
+        std::fs::remove_file(&path).map_err(|source| StoreError::Io {
+            doing: "removing",
+            path: path.display().to_string(),
+            source,
+        })?;
+        Err(StoreError::DigestMismatch {
+            path: path.display().to_string(),
+            wanted: *wanted,
+            found,
+        })
+    }
+
     /// Opens an object for reading.
     ///
     /// # Errors
@@ -305,6 +364,15 @@ impl Store {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A reader that panics if anything reads it, for asserting that nothing did.
+    struct Never;
+
+    impl Read for Never {
+        fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
+            panic!("the store read a stream it already had");
+        }
+    }
 
     fn store() -> (tempfile::TempDir, Store) {
         let dir = tempfile::tempdir().unwrap();
@@ -402,6 +470,58 @@ mod tests {
             store.insert_verified(&source, &promised).unwrap().digest,
             promised
         );
+    }
+
+    #[test]
+    fn a_stream_that_is_what_was_promised_lands_in_the_store() {
+        let (_dir, store) = store();
+        // Larger than one chunk, so the loop that hashes and writes runs more than once and the
+        // hasher is being fed in pieces rather than all at once.
+        let bytes: Vec<u8> = (0..3_000_000_u32).map(|i| (i % 251) as u8).collect();
+        let promised = Digest::of_bytes(&bytes);
+
+        let inserted = store.insert_stream(&bytes[..], &promised).unwrap();
+        assert_eq!(inserted.digest, promised);
+        assert!(!inserted.deduplicated);
+
+        let mut back = Vec::new();
+        store
+            .open_object(&promised)
+            .unwrap()
+            .read_to_end(&mut back)
+            .unwrap();
+        assert_eq!(back, bytes);
+    }
+
+    #[test]
+    fn a_stream_that_is_not_what_was_promised_leaves_nothing_behind() {
+        let (_dir, store) = store();
+        let promised = Digest::of_bytes(b"what was promised");
+        let error = store
+            .insert_stream(&b"what actually arrived"[..], &promised)
+            .unwrap_err();
+
+        let message = format!("{error}");
+        assert!(message.contains(&promised.to_hex()));
+        assert!(message.contains(&Digest::of_bytes(b"what actually arrived").to_hex()));
+
+        // The object was renamed into place before the digest was known, because the digest is only
+        // final once the last byte has arrived. What matters is that it is gone again.
+        assert!(!store.contains(&promised));
+        let directory = store.path(&promised).parent().unwrap().to_owned();
+        let left: Vec<_> = std::fs::read_dir(&directory)
+            .map(|entries| entries.filter_map(Result::ok).collect())
+            .unwrap_or_default();
+        assert!(left.is_empty(), "left behind {left:?}");
+    }
+
+    #[test]
+    fn a_stream_whose_bytes_are_already_there_is_not_read_at_all() {
+        let (_dir, store) = store();
+        let promised = store.insert_bytes(b"already here").unwrap().digest;
+        // If this passes, dedup happened before anything was read, which is the whole reason a
+        // fetch asks the store first rather than downloading and then noticing.
+        assert!(store.insert_stream(Never, &promised).unwrap().deduplicated);
     }
 
     #[test]

--- a/crates/bench-store/Cargo.toml
+++ b/crates/bench-store/Cargo.toml
@@ -15,7 +15,9 @@ publish.workspace = true
 
 [dependencies]
 bench-core.workspace = true
-parquet.workspace = true
+# This one writes column data rather than reading footers, so it needs the Arrow bridge and a
+# codec. Zstd because it is what every result file here is written with.
+parquet = { workspace = true, features = ["arrow", "zstd"] }
 arrow-array.workspace = true
 arrow-schema.workspace = true
 serde.workspace = true

--- a/docs/CORPORA.md
+++ b/docs/CORPORA.md
@@ -38,7 +38,13 @@ columns = 105
 
 `[[files]]` is one entry per file, each with a path relative to the corpus directory, a BLAKE3 digest in lower case hex, and a size in bytes. A manifest with no files is refused, because it pins nothing and the pin is the entire point. So is a path that is absolute or that contains a parent segment, since a manifest is as often something fetched from elsewhere as something written here. So is a file declared as zero bytes, and so is the same path listed twice.
 
-`[assertions]` is optional and is checked after the corpus loads rather than after it downloads. ClickBench is 99,997,497 rows across 105 columns or the manifest is wrong, and an assertion catches that far more cheaply than a number that looks slightly off six weeks later. Both fields are optional because not every corpus is tabular.
+An entry may also carry `url`, and almost none do. Without it the file's URL is its path resolved against the corpus `source` in the ordinary way, meaning everything after the last slash of `source` is replaced by the path. For a single file corpus whose source is the file itself that resolves back to the source unchanged, which is why the common case needs nothing written down. For a corpus of many files under one prefix, `source` names the directory with a trailing slash and each path is appended. `url` exists for the case where one corpus is assembled from files that are not under a common prefix, which happens often enough in published datasets that a format with no answer for it would mean forking a corpus rather than describing it.
+
+`[assertions]` is optional and is checked after the corpus loads rather than after it downloads. ClickBench is 99,997,497 rows across 105 columns or the manifest is wrong, and an assertion catches that far more cheaply than a number that looks slightly off six weeks later. Both fields are optional because not every corpus is tabular, and a corpus that asserts neither gets told so on every fetch rather than passing quietly.
+
+Rows are summed across the files of a corpus and columns have to agree between them, because a corpus split across files is one table and files with different schemas are not one table however they are named. Both counts come out of the Parquet footer, which is a seek and a few kilobytes rather than a pass over the data, and that is what makes it affordable to check before every measurement instead of once when the corpus was added.
+
+Only files whose declared path ends in `.parquet` are read for a shape, and that is decided from the manifest rather than from the bytes because the manifest is this repository's own statement about what a file is. Silesia and enwik8 are compressed text with no rows or columns at all, and for them the shape check does not apply rather than fails. A file named `.parquet` that turns out not to be Parquet is still a hard error, and a manifest that asserts a shape for a corpus where nothing can carry one is refused, because an assertion nothing checks against is worse than no assertion: on the page it reads like something is being verified.
 
 Unknown fields are an error rather than being ignored. The field most worth typing wrongly is `licence_note`, and a typo that silently does nothing would defeat the one check on this page that has legal weight.
 
@@ -46,9 +52,21 @@ Unknown fields are an error rather than being ignored. The field most worth typi
 
 Lower case hex, always, and an upper case spelling is refused rather than normalised. A manifest is read by people as well as by code, and two spellings of one digest is how a mismatch turns into an argument about whether it is a mismatch.
 
-BLAKE3 rather than SHA-256, because hashing a hundred gigabyte corpus has to be cheap enough that nobody is ever tempted to skip it. A check that only runs when somebody remembers to run it is not a pin.
+BLAKE3 rather than SHA-256, because hashing a hundred gigabyte corpus has to be cheap enough that nobody is ever tempted to skip it. A check that only runs when somebody remembers to run it is not a pin. On the i9-13900K under Linux, the 13.8 GiB ClickBench file hashes in 2.4 seconds off a warm page cache, which is about 5.7 GiB per second, so on that machine the check is bounded by the disk rather than by the hash.
 
 A digest mismatch on fetch is a hard failure with no override, and the message carries both digests. A mismatch reported as a boolean is a mismatch somebody has to reproduce before they can begin working out what happened.
+
+The size is checked as well as the digest, even though the digest would catch anything the size would. They are reported separately because a wrong length is a truncated download and a full length mismatch is a different file, and those two send somebody to look in completely different places.
+
+## Fetching
+
+`iris-bench corpus <name>` reads the manifest, fetches what it names, and checks what arrived, in that order. A corpus that describes itself badly never reaches the network, bytes that are not what was promised never reach the store, and a corpus that is short never reaches a measurement.
+
+The digest is computed in the same pass that writes the file rather than by reading it back afterwards. That is not only about speed on a fifteen gigabyte download, although it is that too. It means a file that does not match is deleted rather than left sitting under a name that asserts its own content, so the store's one invariant holds even when a fetch fails halfway.
+
+A file the store already has is never requested. That is not a cache, it is what content addressing means: the manifest already said which bytes it wants, and the store either has those bytes or it does not. Fetching ClickBench a second time on a machine that already has it takes 56 milliseconds including reading the footer and checking the assertions.
+
+The first fetch of ClickBench on the i9-13900K under Linux took about twenty minutes for 13.8 GiB, arrived at the digest pinned in the manifest, and reported 99,997,497 rows across 105 columns. Those numbers were pinned before the fetch ran, from a separate download hashed with `b3sum` and from the ClickBench documentation, so this was the manifest being checked rather than written.
 
 ## The store
 


### PR DESCRIPTION
99,997,497 rows and 105 columns, both asserted rather than assumed, because a truncated download that still parses is the failure mode that quietly invalidates a month of results. The digest catches that for a file while saying nothing about a corpus assembled from the wrong set of files, so the row count is the check that covers the corpus rather than the file.

The column count earns its place for a second reason. 105 is why a fixed size 64 bit projection mask is not an acceptable ABI design, which is a finding this repository hands back to iris, and a finding is worth more when the number behind it is checked on every run than when it is recalled from a page somebody read once.

`bench_corpus::fetch` downloads what a manifest names, and `bench_corpus::shape` reads the Parquet footers and refuses a corpus that is not what was asserted. Three things happen in order and the order is the point: the manifest is validated before anything reaches the network, the digest is checked in the same pass that writes the file so bytes that are not what was promised never reach the store, and the footers are read before a measurement can see the corpus at all.

`Store::insert_stream` is what makes the middle one true. `insert_verified` reads its source three times, once to hash and twice to copy, which is the right shape for a file already on disk and the wrong one for fifteen gigabytes arriving over a network. Streaming also means a file that does not match is deleted rather than renamed, so the store's one invariant holds even when a fetch fails halfway.

Two things the format grew. An entry may carry its own `url`, and almost none do, for the case where the files of one corpus are not under a common prefix. Without it the URL is the path resolved against the corpus source in the ordinary way, which for a single file corpus resolves back to the source unchanged. And only files whose declared path ends in `.parquet` are read for a shape, decided from the manifest rather than from the bytes, because Silesia and enwik8 are compressed text where the check does not apply rather than fails. A manifest that asserts a shape for a corpus where nothing can carry one is refused, since an assertion nothing checks against reads on the page like something is being verified.

The client falls back to IPv4 once when a connection cannot be made at all. A machine can have a default IPv6 route that does not work, which is what every browser and curl on that machine already work around, and forcing IPv4 everywhere would be the shorter fix and the wrong one.

Ran end to end on the i9-13900K under Linux. 13.8 GiB in about twenty minutes, arriving at the digest pinned in the manifest and reporting 99,997,497 rows across 105 columns. Both numbers were pinned before the fetch, from a separate download hashed with `b3sum` and from the ClickBench documentation, so this was the manifest being checked rather than written. A second fetch on the same machine takes 56 milliseconds, which is what content addressing buys.

Closes #8