### PR TITLE
Cut v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,7 +193,7 @@ checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "bench-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "bench-corpus"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "blake3",
  "camino",
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "bench-driver"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bench-core",
  "serde",
@@ -229,7 +229,7 @@ dependencies = [
 
 [[package]]
 name = "bench-env"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bench-core",
  "blake3",
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "bench-report"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bench-core",
  "bench-store",
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "bench-run"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bench-core",
  "bench-corpus",
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "bench-store"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -514,7 +514,7 @@ dependencies = [
 
 [[package]]
 name = "driver-null"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bench-driver",
 ]
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "iris-bench-cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "bench-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*", "drivers/*"]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 rust-version = "1.98"
 license = "Apache-2.0"
@@ -16,13 +16,13 @@ readme = "README.md"
 publish = false
 
 [workspace.dependencies]
-bench-core = { path = "crates/bench-core", version = "0.1.0" }
-bench-corpus = { path = "crates/bench-corpus", version = "0.1.0" }
-bench-driver = { path = "crates/bench-driver", version = "0.1.0" }
-bench-env = { path = "crates/bench-env", version = "0.1.0" }
-bench-report = { path = "crates/bench-report", version = "0.1.0" }
-bench-run = { path = "crates/bench-run", version = "0.1.0" }
-bench-store = { path = "crates/bench-store", version = "0.1.0" }
+bench-core = { path = "crates/bench-core", version = "0.1.1" }
+bench-corpus = { path = "crates/bench-corpus", version = "0.1.1" }
+bench-driver = { path = "crates/bench-driver", version = "0.1.1" }
+bench-env = { path = "crates/bench-env", version = "0.1.1" }
+bench-report = { path = "crates/bench-report", version = "0.1.1" }
+bench-run = { path = "crates/bench-run", version = "0.1.1" }
+bench-store = { path = "crates/bench-store", version = "0.1.1" }
 
 anyhow = "1.0.104"
 arrow-array = "59.3.0"


### PR DESCRIPTION
A point between milestones rather than a milestone. B0 was v0.1.0 and B1 will
be v0.2.0, and what has accumulated since is worth a boundary somebody can name.

Three things landed in the range. The move to iris-source 0.5.0 and a refreshed
lockfile, the corpus manifest format with its content addressed store, and
ClickBench hits fetched and shape checked end to end.

The version and the lockfile, nothing else.