### PR TITLE
Generate TPC-H at scale factor 1 and 20, and make the wording rules code

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Pre-alpha. B0 is done as of `v0.1.0`, so the measuring apparatus exists and the 
 
 What B0 established is in `docs/ROADMAP.md` under that milestone, and the short version is that this fleet can measure, on one machine, for ratios always and for durations under a gate. The noise floor is 1.05% on the one eligible role and over two percent everywhere else, and the harness adds 41.1 ns to a sample, which is under one percent of anything longer than 4.1 microseconds. `iris-bench check`, `noise`, `overhead`, `resident` and `corpus` run today. Nothing else does.
 
+B1 is in progress and is the corpora. ClickBench, TPC-H at scale factor 1 and TPC-H at scale factor 20 are pinned and reproduce, the first by download and the other two from `dbgen`.
+
 B0 through B4 need no `iris` code to exist, which is deliberate. If `iris` is never built, the reproduction of the published figures and the storage tier study still stand on their own.
 
 ## Layout
@@ -68,6 +70,12 @@ cargo run -p iris-bench-cli -- corpus clickbench-hits --store /var/tmp/iris-corp
 ```
 
 The digest is checked in the same pass that writes the file, so bytes that are not what the manifest promised never land in the store. The asserted row and column counts are checked after, which is what catches a download that stopped early and still parses. `docs/CORPORA.md` is the format.
+
+A generated corpus is the same command with the generator pointed at. Nothing is downloaded and nothing is redistributed, and the tool checks that the generator is the pinned version before it produces a byte, because a different generator writes different bytes and a digest mismatch on its own does not say which of those two things went wrong.
+
+```
+cargo run -p iris-bench-cli -- corpus tpch-sf1 --generator ~/tpch-kit/dbgen/dbgen --store /var/tmp/iris-corpus
+```
 
 ## Machines
 

--- a/ci/discipline.py
+++ b/ci/discipline.py
@@ -63,6 +63,13 @@ MANIFEST_FIELDS = {
         "licence_note",
     },
     "files": {"path", "blake3", "bytes", "url"},
+    "generator": {
+        "program",
+        "arguments",
+        "version",
+        "version_arguments",
+        "environment",
+    },
     "assertions": {"rows", "columns"},
 }
 
@@ -158,6 +165,7 @@ def check_manifest(manifest_path: pathlib.Path) -> None:
             fail(f"corpus {name}: '{table}' is not part of this format, see docs/CORPORA.md")
     check_fields(name, "corpus", corpus, MANIFEST_FIELDS["corpus"])
     check_fields(name, "assertions", manifest.get("assertions", {}), MANIFEST_FIELDS["assertions"])
+    check_fields(name, "generator", manifest.get("generator", {}), MANIFEST_FIELDS["generator"])
     for entry in manifest.get("files", []):
         check_fields(name, "files", entry, MANIFEST_FIELDS["files"])
 
@@ -181,6 +189,8 @@ def check_manifest(manifest_path: pathlib.Path) -> None:
     # it permits.
     if corpus.get("category") == "mirror" and not str(corpus.get("licence_note", "")).strip():
         fail(f"corpus {name}: mirrored without a licence note saying what permits it")
+
+    check_generator(name, corpus, manifest.get("generator"))
 
     files = manifest.get("files", [])
     if not files:
@@ -210,6 +220,57 @@ def check_manifest(manifest_path: pathlib.Path) -> None:
                     f"corpus {name}: {path} has no url and the source is not one either,"
                     f" so there is nowhere to fetch it from"
                 )
+
+
+def check_generator(name: str, corpus: dict, generator: dict | None) -> None:
+    """A generated corpus says what produces it, and no other kind may.
+
+    A manifest carrying both a generator and a download location is making two
+    claims about one set of bytes, and the second of those is the one that would
+    go unread.
+    """
+    category = corpus.get("category")
+    if category == "generate" and generator is None:
+        fail(f"corpus {name}: generated without a [generator], so nothing says how")
+        return
+    if generator is not None and category != "generate":
+        fail(
+            f"corpus {name}: has a [generator] and is a {category!r} corpus, which are two"
+            f" different answers to where the bytes come from"
+        )
+        return
+    if generator is None:
+        return
+
+    # The source of a generated corpus names the generator, so a URL there is a
+    # statement that these bytes are downloaded, which they are not.
+    if str(corpus.get("source", "")).startswith(("http://", "https://")):
+        fail(
+            f"corpus {name}: is generated and its source is a URL, so the manifest says both"
+            f" that the bytes are produced here and that they are downloaded"
+        )
+
+    for field in ("program", "version"):
+        if not str(generator.get(field, "")).strip():
+            fail(f"corpus {name}: the generator has no '{field}'")
+
+    # The version is what turns a digest mismatch on gigabytes of output into a
+    # sentence about which dbgen is installed, so an unprobeable version is worse
+    # than no version at all: it reads on the page like something is checked.
+    probe = generator.get("version_arguments", ["-h"])
+    if not isinstance(probe, list) or not probe:
+        fail(f"corpus {name}: the generator has no version_arguments, so its version cannot be checked")
+
+    if not isinstance(generator.get("arguments", []), list):
+        fail(f"corpus {name}: the generator's arguments are not a list")
+
+    environment = generator.get("environment", {})
+    if not isinstance(environment, dict):
+        fail(f"corpus {name}: the generator's environment is not a table")
+        return
+    for key, value in sorted(environment.items()):
+        if not isinstance(value, str):
+            fail(f"corpus {name}: the generator's {key} is not a string")
 
 
 def check_no_machine_identity() -> None:

--- a/ci/test_discipline.py
+++ b/ci/test_discipline.py
@@ -33,6 +33,29 @@ blake3 = "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"
 bytes = 1024
 """
 
+GENERATED = """
+[corpus]
+name = "example"
+description = "A corpus that exists to be validated"
+source = "example-gen 1.0.0, scale factor 1"
+licence = "Apache-2.0"
+category = "generate"
+
+[generator]
+program = "example-gen"
+arguments = ["-s", "1"]
+version = "1.0.0"
+version_arguments = ["-h"]
+
+[generator.environment]
+OUT = "{output}"
+
+[[files]]
+path = "example.tbl"
+blake3 = "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"
+bytes = 1024
+"""
+
 failures: list[str] = []
 
 
@@ -133,6 +156,44 @@ def main() -> int:
         GOOD.replace('"https://example.invalid/example.parquet"', '"tpch-dbgen -s 20"').replace(
             "bytes = 1024", 'bytes = 1024\nurl = "https://example.invalid/example.parquet"'
         ),
+    )
+    expect_clean("a generated corpus that says what produces it", GENERATED)
+    expect_complaint(
+        "a generated corpus with no generator",
+        GOOD.replace('"fetch"', '"generate"'),
+        "nothing says how",
+    )
+    expect_complaint(
+        "a fetched corpus that has a generator anyway",
+        GENERATED.replace('"generate"', '"fetch"'),
+        "two different answers",
+    )
+    expect_complaint(
+        "a generated corpus whose source is a download",
+        GENERATED.replace(
+            '"example-gen 1.0.0, scale factor 1"', '"https://example.invalid/example.tbl"'
+        ),
+        "produced here and that they are downloaded",
+    )
+    expect_complaint(
+        "a generator whose version cannot be probed",
+        GENERATED.replace('version_arguments = ["-h"]', "version_arguments = []"),
+        "cannot be checked",
+    )
+    expect_complaint(
+        "a generator with no version at all",
+        GENERATED.replace('version = "1.0.0"', ""),
+        "'version'",
+    )
+    expect_complaint(
+        "a generator field this format does not have",
+        GENERATED.replace("version =", 'versions = "nearly right"\nversion ='),
+        "'versions'",
+    )
+    expect_complaint(
+        "a generator environment that is not strings",
+        GENERATED.replace('OUT = "{output}"', "OUT = 3"),
+        "is not a string",
     )
     expect_complaint(
         "a manifest that is not TOML",

--- a/corpora/tpch-sf1/manifest.toml
+++ b/corpora/tpch-sf1/manifest.toml
@@ -1,0 +1,78 @@
+# TPC-H at scale factor 1, the size that exists so a change can be tried in under a minute.
+#
+# Generated locally and never redistributed. The licence field names the terms the tools arrive
+# under rather than terms on the data, because TPC's tools are downloaded under TPC's own end user
+# agreement by whoever runs the generation and are not in this repository. docs/LICENSING.md says
+# what that means for anything published from these tables.
+#
+# The version below is part of the pin and is checked before generation starts. dbgen is
+# deterministic given a scale factor, so the digests are stable, and they are stable across a
+# different operating system on a different architecture rather than only across two runs on one
+# machine. What they are not stable across is a different dbgen, and a digest mismatch on a
+# gigabyte of output says nothing at all about which of those two things happened unless the version
+# was checked first.
+#
+# There is no [assertions] block. For a corpus generated file by file and pinned file by file, the
+# digest already says everything a row count would: 6,001,215 lineitem rows is what these bytes are,
+# not something they could fail to be. ClickBench asserts its shape because the digest there is a
+# claim about a file on somebody else's server.
+
+[corpus]
+name = "tpch-sf1"
+description = "The TPC-H tables at scale factor 1, generated with dbgen and never redistributed"
+source = "TPC-H dbgen 2.17.3, scale factor 1"
+licence = "TPC tools EULA"
+category = "generate"
+
+[generator]
+program = "dbgen"
+arguments = ["-s", "1", "-f"]
+version = "2.17.3"
+version_arguments = ["-h"]
+
+# dbgen writes to DSS_PATH and reads its column distributions from dists.dss, which lives beside the
+# binary rather than anywhere a package manager would put it. Both are facts about dbgen rather than
+# about generators, which is why they are written here and not in the code that runs it.
+[generator.environment]
+DSS_PATH = "{output}"
+DSS_CONFIG = "{program_directory}"
+
+[[files]]
+path = "customer.tbl"
+blake3 = "f22501b1d9ebdc8e08d4a2a925d55b54b6927549886c30227a47b2602dec9b52"
+bytes = 24196144
+
+[[files]]
+path = "lineitem.tbl"
+blake3 = "cb8c9a123316d2e0b8d699354ed32b917ca14a45bf266e3d17688dab95530198"
+bytes = 753862072
+
+[[files]]
+path = "nation.tbl"
+blake3 = "c13f500e0360abb6b1fb8055daddfd929d258fa1808df0d0dd7e3d962b49259d"
+bytes = 2199
+
+[[files]]
+path = "orders.tbl"
+blake3 = "07f4e603775a9227769944d9daa8f892a67138166c6419410a39f58eed4ece84"
+bytes = 170452161
+
+[[files]]
+path = "part.tbl"
+blake3 = "499329360d06d88cc7c1c9a5f60c95bc4e2cff6702e27eda301af1cf47365471"
+bytes = 23935125
+
+[[files]]
+path = "partsupp.tbl"
+blake3 = "8ba8c05a6c940518bc7b12c94afe48ed1a58ba817413114cf07180681ec3a3ef"
+bytes = 118184616
+
+[[files]]
+path = "region.tbl"
+blake3 = "bf437aa6ea633c1364c370428cc542cc9996039fcbaebf4f2ddf6232549bd843"
+bytes = 384
+
+[[files]]
+path = "supplier.tbl"
+blake3 = "6807c33d3b1f89c9f7c4991b81f1f86c0c6b04c9d7290df88fb99519c986b463"
+bytes = 1399184

--- a/corpora/tpch-sf20/manifest.toml
+++ b/corpora/tpch-sf20/manifest.toml
@@ -1,0 +1,73 @@
+# TPC-H at scale factor 20, the size that stops fitting comfortably in cache on the workstation
+# class. That is the whole reason for it: scale factor 1 fits in the last level cache of a modern
+# desktop part, and a benchmark that fits in cache measures the cache.
+#
+# 20 is not a compliant TPC-H scale factor. The specification defines 1, 10, 30 and upwards, and 20
+# is in the gap on purpose. Every row of published output carrying one of these numbers is marked as
+# a deviation by bench_report, which is a rule that runs rather than a rule somebody remembers.
+#
+# Generated locally and never redistributed, same as scale factor 1, and the licence field names the
+# terms TPC's tools arrive under rather than terms on the data for the same reason. The version below
+# is checked before generation starts. nation.tbl and region.tbl are byte for byte
+# what scale factor 1 produces, because those two tables do not scale, so the store holds them once
+# across both corpora rather than twice.
+
+[corpus]
+name = "tpch-sf20"
+description = "The TPC-H tables at scale factor 20, generated with dbgen and never redistributed"
+source = "TPC-H dbgen 2.17.3, scale factor 20"
+licence = "TPC tools EULA"
+category = "generate"
+
+[generator]
+program = "dbgen"
+arguments = ["-s", "20", "-f"]
+version = "2.17.3"
+version_arguments = ["-h"]
+
+# dbgen writes to DSS_PATH and reads its column distributions from dists.dss, which lives beside the
+# binary rather than anywhere a package manager would put it. Both are facts about dbgen rather than
+# about generators, which is why they are written here and not in the code that runs it.
+[generator.environment]
+DSS_PATH = "{output}"
+DSS_CONFIG = "{program_directory}"
+
+[[files]]
+path = "customer.tbl"
+blake3 = "a4d31542fe55a4c053d2accc1abab5a6a2b0ad50ac20cdb4c84d019e79e5845a"
+bytes = 487806602
+
+[[files]]
+path = "lineitem.tbl"
+blake3 = "6aa4da6bb7426701367b57d1296b7b3fb57e5024f4128177a6470fb293337c46"
+bytes = 15565406377
+
+[[files]]
+path = "nation.tbl"
+blake3 = "c13f500e0360abb6b1fb8055daddfd929d258fa1808df0d0dd7e3d962b49259d"
+bytes = 2199
+
+[[files]]
+path = "orders.tbl"
+blake3 = "c5fa30d43972d68168e9b9e0c7706b12f8e31d3ce0ee4901f860b5a413bdf239"
+bytes = 3487488366
+
+[[files]]
+path = "part.tbl"
+blake3 = "fd7b9f5cca4b2f9316dc1799be1b6257f33d8ae335d6a8f394af77e11b6a1ad9"
+bytes = 483760640
+
+[[files]]
+path = "partsupp.tbl"
+blake3 = "5ea2e9931aedef8375ca9bb53a0e15e013bd41e01ec02df6288ef36ebc862997"
+bytes = 2406915386
+
+[[files]]
+path = "region.tbl"
+blake3 = "bf437aa6ea633c1364c370428cc542cc9996039fcbaebf4f2ddf6232549bd843"
+bytes = 384
+
+[[files]]
+path = "supplier.tbl"
+blake3 = "7b40e8399dd1e9f362c923e79fd919b64c424f1346f23d98f4581925e62ba7ed"
+bytes = 28271512

--- a/crates/bench-cli/src/corpus.rs
+++ b/crates/bench-cli/src/corpus.rs
@@ -1,10 +1,10 @@
 //! `iris-bench corpus`, which gets a corpus onto the machine and then refuses to believe it.
 //!
 //! Three things happen in order and the order is the point. The manifest is read and validated, so
-//! a corpus that describes itself badly never reaches the network. The files are fetched and hashed
-//! in the same pass, so bytes that are not what was promised never reach the store. The footers are
-//! read and checked against the asserted row and column counts, so a corpus that is short never
-//! reaches a measurement.
+//! a corpus that describes itself badly never reaches the network or a generator. The files are
+//! fetched or generated and hashed in the same pass, so bytes that are not what was promised never
+//! reach the store. The footers are read and checked against the asserted row and column counts, so
+//! a corpus that is short never reaches a measurement.
 //!
 //! The last of those is the one worth being explicit about. A digest catches a file that changed
 //! and says nothing about a corpus assembled from the wrong set of files, and a download that stops
@@ -13,7 +13,7 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context as _, bail};
-use bench_corpus::{Manifest, Progress, Shape, Store, fetch, shape};
+use bench_corpus::{Category, Manifest, Progress, Shape, Store, fetch, generate, shape};
 
 /// Where corpora are described, relative to the repository root.
 const CORPORA: &str = "corpora";
@@ -21,8 +21,27 @@ const CORPORA: &str = "corpora";
 /// Where the bytes go when nothing else says.
 const DEFAULT_STORE: &str = "corpus";
 
-/// Reads a corpus manifest, fetches what it names, and checks what arrived.
-pub(crate) fn run(name: &str, root: Option<PathBuf>, store: Option<PathBuf>) -> anyhow::Result<()> {
+/// Where a generator is allowed to write when nothing else says.
+const DEFAULT_SCRATCH: &str = "corpus-scratch";
+
+/// What a corpus did to one file, whichever way it arrived.
+struct Arrived {
+    /// The path inside the corpus.
+    path: String,
+    /// What the file is addressed by.
+    digest: bench_corpus::Digest,
+    /// Whether the store already had it, in which case nothing arrived at all.
+    deduplicated: bool,
+}
+
+/// Reads a corpus manifest, gets what it names, and checks what arrived.
+pub(crate) fn run(
+    name: &str,
+    root: Option<PathBuf>,
+    store: Option<PathBuf>,
+    generator: Option<&Path>,
+    scratch: Option<PathBuf>,
+) -> anyhow::Result<()> {
     let root = root.unwrap_or_else(|| PathBuf::from(CORPORA));
     let path = root.join(name).join("manifest.toml");
     if !path.is_file() {
@@ -51,10 +70,33 @@ pub(crate) fn run(name: &str, root: Option<PathBuf>, store: Option<PathBuf>) -> 
     println!();
 
     let mut last = String::new();
-    let fetched = fetch::corpus(&manifest, &store, &mut |progress| {
-        report(&mut last, &progress);
-    })?;
-    for file in &fetched {
+    let arrived = match manifest.corpus.category {
+        Category::Generate => {
+            let scratch = scratch.unwrap_or_else(|| PathBuf::from(DEFAULT_SCRATCH));
+            generate::corpus(&manifest, &store, generator, &scratch, &mut |progress| {
+                report(&mut last, &progress);
+            })?
+            .into_iter()
+            .map(|file| Arrived {
+                path: file.path,
+                digest: file.digest,
+                deduplicated: file.deduplicated,
+            })
+            .collect()
+        }
+        _ => fetch::corpus(&manifest, &store, &mut |progress| {
+            report(&mut last, &progress);
+        })?
+        .into_iter()
+        .map(|file| Arrived {
+            path: file.path,
+            digest: file.digest,
+            deduplicated: file.deduplicated,
+        })
+        .collect::<Vec<_>>(),
+    };
+
+    for file in &arrived {
         println!(
             "  {}  {}  {}{}",
             if file.deduplicated { "have" } else { "got " },
@@ -178,7 +220,14 @@ mod tests {
         std::fs::create_dir(dir.path().join("clickbench-hits")).unwrap();
         std::fs::write(dir.path().join("clickbench-hits").join("manifest.toml"), "").unwrap();
 
-        let error = run("not-a-corpus", Some(dir.path().to_owned()), None).unwrap_err();
+        let error = run(
+            "not-a-corpus",
+            Some(dir.path().to_owned()),
+            None,
+            None,
+            None,
+        )
+        .unwrap_err();
         assert!(format!("{error}").contains("clickbench-hits"));
     }
 

--- a/crates/bench-cli/src/main.rs
+++ b/crates/bench-cli/src/main.rs
@@ -129,11 +129,13 @@ enum Command {
         #[arg(long)]
         anyway: bool,
     },
-    /// Fetch a corpus and verify it against its manifest.
+    /// Get a corpus onto this machine and verify it against its manifest.
     ///
-    /// The digest is checked in the same pass that writes the file, and the asserted row and column
-    /// counts are checked after. A corpus that is not what the manifest says never reaches a
-    /// measurement, which is the only reason any number here is worth comparing to a later one.
+    /// A fetched corpus is downloaded and a generated one is produced by a generator the manifest
+    /// names. Either way the digest is checked in the same pass that writes the file, and the
+    /// asserted row and column counts are checked after. A corpus that is not what the manifest
+    /// says never reaches a measurement, which is the only reason any number here is worth
+    /// comparing to a later one.
     Corpus {
         /// Corpus name, as it appears in the manifest directory.
         name: String,
@@ -146,6 +148,18 @@ enum Command {
         /// checkouts at one store is the supported way to have a corpus once rather than per clone.
         #[arg(long, value_name = "PATH")]
         store: Option<PathBuf>,
+        /// Where the generator is, for a generated corpus whose program is not on `PATH`.
+        ///
+        /// The usual case, since TPC's `dbgen` is built in a directory of its own and is not
+        /// something anybody installs.
+        #[arg(long, value_name = "PATH")]
+        generator: Option<PathBuf>,
+        /// Where a generator is allowed to write, when that is not `corpus-scratch/`.
+        ///
+        /// Needs room for the whole corpus. A generator writes what it writes and only then can any
+        /// of it be checked, so this is a second copy for as long as the generation takes.
+        #[arg(long, value_name = "PATH")]
+        scratch: Option<PathBuf>,
     },
     /// Run a workload and append the results to the store.
     Run {
@@ -268,7 +282,13 @@ fn main() -> anyhow::Result<()> {
             f64::from(floor) * 1_000.0,
             anyway,
         ),
-        Command::Corpus { name, root, store } => corpus::run(&name, root, store),
+        Command::Corpus {
+            name,
+            root,
+            store,
+            generator,
+            scratch,
+        } => corpus::run(&name, root, store, generator.as_deref(), scratch),
         other => anyhow::bail!("not implemented yet: {other:?}"),
     }
 }

--- a/crates/bench-corpus/src/fetch.rs
+++ b/crates/bench-corpus/src/fetch.rs
@@ -13,14 +13,12 @@
 //! For a corpus of many files under one directory, `source` names any one of them, or the directory
 //! with a trailing slash, and each entry's path is appended.
 
-use std::{
-    io::{self, Read},
-    time::Duration,
-};
+use std::{io, time::Duration};
 
 use crate::{
     digest::Digest,
     manifest::{Category, Entry, Manifest},
+    progress::{Counting, Progress},
     store::{Store, StoreError},
 };
 
@@ -30,9 +28,6 @@ use crate::{
 /// upper bound on how long that takes on an unknown link is not a number anybody can write down, so
 /// the timeout that exists is the one that catches a host which is not answering at all.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
-
-/// How often to tell the caller how far along a download is, in bytes.
-const REPORT_EVERY: u64 = 64 << 20;
 
 /// What a fetch did to one file.
 #[derive(Clone, Debug)]
@@ -45,17 +40,6 @@ pub struct Fetched {
     pub bytes: u64,
     /// Whether the store already had it, in which case nothing was downloaded.
     pub deduplicated: bool,
-}
-
-/// How far along one file is.
-#[derive(Clone, Copy, Debug)]
-pub struct Progress<'a> {
-    /// The path inside the corpus.
-    pub path: &'a str,
-    /// How many bytes have arrived.
-    pub done: u64,
-    /// How many the manifest says there are.
-    pub total: u64,
 }
 
 /// Why a corpus did not arrive.
@@ -320,14 +304,12 @@ fn one(
     let url = url_for(manifest, entry)?;
     let response = client.get(&url)?;
 
-    let mut counting = Counting {
-        inner: response.into_body().into_reader(),
-        seen: 0,
-        next: REPORT_EVERY,
-        path: &entry.path,
-        total: entry.bytes,
+    let mut counting = Counting::new(
+        response.into_body().into_reader(),
+        &entry.path,
+        entry.bytes,
         watch,
-    };
+    );
     let inserted = store.insert_stream(&mut counting, &entry.blake3);
     let found = counting.seen;
 
@@ -361,38 +343,6 @@ fn one(
         bytes: found,
         deduplicated: inserted.deduplicated,
     })
-}
-
-/// A reader that counts what goes through it and says so every so often.
-struct Counting<'a, R> {
-    /// The reader the bytes are actually coming from.
-    inner: R,
-    /// How many have gone through.
-    seen: u64,
-    /// The count at which to report next.
-    next: u64,
-    /// Which file, for the report.
-    path: &'a str,
-    /// How many bytes the manifest says there are, for the report.
-    total: u64,
-    /// Who to tell.
-    watch: &'a mut dyn FnMut(Progress<'_>),
-}
-
-impl<R: Read> Read for Counting<'_, R> {
-    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
-        let read = self.inner.read(buffer)?;
-        self.seen += read as u64;
-        if self.seen >= self.next || read == 0 {
-            self.next = self.seen + REPORT_EVERY;
-            (self.watch)(Progress {
-                path: self.path,
-                done: self.seen,
-                total: self.total,
-            });
-        }
-        Ok(read)
-    }
 }
 
 #[cfg(test)]

--- a/crates/bench-corpus/src/generate.rs
+++ b/crates/bench-corpus/src/generate.rs
@@ -1,0 +1,626 @@
+//! Producing a corpus locally and refusing it if it is not what was promised.
+//!
+//! The same contract as a fetch, with a generator where the network would be. The manifest pins the
+//! digest of every file, the generator runs, and what it wrote is checked against the pin. A
+//! generator that is deterministic given its arguments makes that pin meaningful, and one that is
+//! not fails here rather than six weeks later.
+//!
+//! # Why the version is checked first
+//!
+//! The bytes a generator writes are a property of the generator, so the pin is only a pin if the
+//! program is the one the manifest was written against. Checking the version costs one process
+//! start. Not checking it costs a digest mismatch on twenty gigabytes of output with nothing in the
+//! message to suggest that the cause is a build two releases along.
+//!
+//! # Where the program comes from
+//!
+//! Not from here. TPC's tools are downloaded by the person running the generation, under TPC's own
+//! terms, and `docs/LICENSING.md` says why this repository neither ships them nor redistributes
+//! what they produce.
+
+use std::{
+    collections::BTreeMap,
+    fs::File,
+    io,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use crate::{
+    digest::Digest,
+    manifest::{Category, Entry, Generator, Manifest},
+    progress::{Counting, Progress},
+    store::{Store, StoreError},
+};
+
+/// What generating did to one file.
+#[derive(Clone, Debug)]
+pub struct Generated {
+    /// The path inside the corpus.
+    pub path: String,
+    /// What the file is addressed by, which is also what the manifest promised.
+    pub digest: Digest,
+    /// How many bytes it is.
+    pub bytes: u64,
+    /// Whether the store already had it, in which case nothing was generated.
+    pub deduplicated: bool,
+}
+
+/// Why a corpus was not produced.
+#[derive(Debug, thiserror::Error)]
+pub enum GenerateError {
+    /// The corpus is not one that is produced locally.
+    #[error(
+        "{name} is a {category} corpus, so there is nothing to generate. A fetched corpus is \
+         downloaded and a mirrored one is already in the tree"
+    )]
+    NotGeneratable {
+        /// Which corpus.
+        name: String,
+        /// What it is instead.
+        category: Category,
+    },
+    /// The program could not be started.
+    #[error(
+        "running {program}: {source}. The generator is not shipped with this repository and has \
+         to be obtained separately, which docs/CORPORA.md explains"
+    )]
+    Missing {
+        /// What was being run.
+        program: String,
+        /// What the operating system said.
+        source: io::Error,
+    },
+    /// The program that is there is not the one this corpus was pinned against.
+    #[error(
+        "{program} says it is {found}, and this corpus was generated with {wanted}. A different \
+         generator writes different bytes, so the digests below would not match and the message \
+         would not say why"
+    )]
+    Version {
+        /// What was being run.
+        program: String,
+        /// What the manifest pins.
+        wanted: String,
+        /// What the program said about itself, trimmed to its first line.
+        found: String,
+    },
+    /// The program ran and gave up.
+    #[error("{program} exited with {status}")]
+    Failed {
+        /// What was being run.
+        program: String,
+        /// How it ended.
+        status: String,
+    },
+    /// The program succeeded and did not write a file the manifest names.
+    #[error(
+        "{program} reported success and did not write {path}. Either the manifest names a file \
+         this generator does not produce or the arguments are not the ones it was written for"
+    )]
+    Absent {
+        /// What was being run.
+        program: String,
+        /// Which file the manifest names.
+        path: String,
+    },
+    /// What was written is not the size the manifest declared.
+    #[error("{path} was expected to be {wanted} bytes and is {found}")]
+    Size {
+        /// Which file.
+        path: String,
+        /// What the manifest declared.
+        wanted: u64,
+        /// What was written.
+        found: u64,
+    },
+    /// What was written is not the file the manifest pinned.
+    #[error(
+        "{path} was expected to be {wanted} and {program} wrote {found}. This is not overridable. \
+         A generator that no longer produces the pinned bytes is producing a different corpus, and \
+         a result measured on it is not comparable with one measured before it changed"
+    )]
+    Digest {
+        /// Which file inside the corpus.
+        path: String,
+        /// What produced the bytes.
+        program: String,
+        /// The digest the manifest pinned.
+        wanted: Digest,
+        /// The digest of what was written.
+        found: Digest,
+    },
+    /// The scratch directory the generator writes into could not be prepared or cleared.
+    #[error("{doing} the scratch directory {path}: {source}")]
+    Scratch {
+        /// What was being attempted.
+        doing: &'static str,
+        /// Which directory.
+        path: String,
+        /// What went wrong underneath.
+        source: io::Error,
+    },
+    /// The store refused a file for some reason other than the digest.
+    #[error(transparent)]
+    Store(#[from] StoreError),
+}
+
+/// Runs a manifest's generator and takes in every file it names.
+///
+/// `program` overrides where the generator is found, for the usual case of a `dbgen` built in a
+/// directory of its own rather than installed. `scratch` is where the generator is allowed to write
+/// and has to have room for the whole corpus, because a generator writes what it writes and only
+/// then can any of it be checked.
+///
+/// `watch` is called as each written file is read back into the store, often enough to show that
+/// something is happening and rarely enough that it is not itself the slow part.
+///
+/// # Errors
+///
+/// If the corpus is not generated, the program is absent or is a different version, the run fails,
+/// a named file is not written, or what is written is not the size or the digest the manifest
+/// promised.
+pub fn corpus(
+    manifest: &Manifest,
+    store: &Store,
+    program: Option<&Path>,
+    scratch: &Path,
+    watch: &mut dyn FnMut(Progress<'_>),
+) -> Result<Vec<Generated>, GenerateError> {
+    if manifest.corpus.category != Category::Generate {
+        return Err(GenerateError::NotGeneratable {
+            name: manifest.corpus.name.clone(),
+            category: manifest.corpus.category,
+        });
+    }
+    // Checked by `Manifest::validate`, which every path into a manifest goes through. Treated as a
+    // missing generator rather than unwrapped, because a panic here would be a worse way to say the
+    // same thing.
+    let Some(generator) = manifest.generator.as_ref() else {
+        return Err(GenerateError::NotGeneratable {
+            name: manifest.corpus.name.clone(),
+            category: manifest.corpus.category,
+        });
+    };
+
+    // Asked before the generator runs, because a corpus already on the machine costs nothing to
+    // have again and generating it costs hours. This is the whole payoff of addressing by content.
+    if manifest
+        .files
+        .iter()
+        .all(|entry| store.contains(&entry.blake3))
+    {
+        return Ok(manifest
+            .files
+            .iter()
+            .map(|entry| {
+                watch(Progress {
+                    path: &entry.path,
+                    done: entry.bytes,
+                    total: entry.bytes,
+                });
+                Generated {
+                    path: entry.path.clone(),
+                    digest: entry.blake3,
+                    bytes: entry.bytes,
+                    deduplicated: true,
+                }
+            })
+            .collect());
+    }
+
+    let program = program.map_or_else(|| PathBuf::from(&generator.program), Path::to_path_buf);
+    check_version(generator, &program)?;
+    prepare(scratch)?;
+    run(generator, &program, scratch)?;
+
+    let mut generated = Vec::with_capacity(manifest.files.len());
+    for entry in &manifest.files {
+        generated.push(one(&program, entry, scratch, store, watch)?);
+    }
+    Ok(generated)
+}
+
+/// Asks the program what it is and refuses to go on if the answer is not what the manifest pins.
+fn check_version(generator: &Generator, program: &Path) -> Result<(), GenerateError> {
+    let output = Command::new(program)
+        .args(&generator.version_arguments)
+        .output()
+        .map_err(|source| GenerateError::Missing {
+            program: program.display().to_string(),
+            source,
+        })?;
+
+    // Both streams, and the exit status is ignored on purpose. A program asked to print its usage
+    // commonly writes it to stderr and exits non zero, and that is a program answering the question
+    // rather than a program failing.
+    let mut said = String::from_utf8_lossy(&output.stdout).into_owned();
+    said.push_str(&String::from_utf8_lossy(&output.stderr));
+    if said.contains(generator.version.trim()) {
+        return Ok(());
+    }
+    Err(GenerateError::Version {
+        program: program.display().to_string(),
+        wanted: generator.version.clone(),
+        found: said.lines().next().unwrap_or("nothing").trim().to_owned(),
+    })
+}
+
+/// Empties the scratch directory, or makes it.
+///
+/// Emptied rather than reused, because a generator that writes only some of its output leaves the
+/// rest of a previous run in place, and a file from a previous run has every chance of matching its
+/// digest. That is the one way this could report a corpus it did not produce.
+fn prepare(scratch: &Path) -> Result<(), GenerateError> {
+    let shown = scratch.display().to_string();
+    if scratch.exists() {
+        std::fs::remove_dir_all(scratch).map_err(|source| GenerateError::Scratch {
+            doing: "clearing",
+            path: shown.clone(),
+            source,
+        })?;
+    }
+    std::fs::create_dir_all(scratch).map_err(|source| GenerateError::Scratch {
+        doing: "creating",
+        path: shown,
+        source,
+    })
+}
+
+/// Runs the generator with its working directory and environment pointed at the scratch directory.
+fn run(generator: &Generator, program: &Path, scratch: &Path) -> Result<(), GenerateError> {
+    let status = Command::new(program)
+        .args(&generator.arguments)
+        .current_dir(scratch)
+        .envs(environment(generator, program, scratch))
+        .status()
+        .map_err(|source| GenerateError::Missing {
+            program: program.display().to_string(),
+            source,
+        })?;
+    if status.success() {
+        return Ok(());
+    }
+    Err(GenerateError::Failed {
+        program: program.display().to_string(),
+        status: status.to_string(),
+    })
+}
+
+/// The environment the manifest asks for, with its two placeholders filled in.
+///
+/// `dbgen` needs one variable saying where to write and another saying where its distribution file
+/// is, and those are facts about `dbgen` rather than about generators. They belong in the manifest
+/// that names `dbgen`, which is why this substitutes rather than knowing.
+fn environment(generator: &Generator, program: &Path, scratch: &Path) -> BTreeMap<String, String> {
+    let directory = program
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or(Path::new("."));
+    generator
+        .environment
+        .iter()
+        .map(|(name, value)| {
+            let filled = value
+                .replace("{output}", &scratch.display().to_string())
+                .replace("{program_directory}", &directory.display().to_string());
+            (name.clone(), filled)
+        })
+        .collect()
+}
+
+/// Takes one written file into the store, checking it against what the manifest pinned.
+fn one(
+    program: &Path,
+    entry: &Entry,
+    scratch: &Path,
+    store: &Store,
+    watch: &mut dyn FnMut(Progress<'_>),
+) -> Result<Generated, GenerateError> {
+    let written = scratch.join(&entry.path);
+    let file = File::open(&written).map_err(|_| GenerateError::Absent {
+        program: program.display().to_string(),
+        path: entry.path.clone(),
+    })?;
+
+    let mut counting = Counting::new(file, &entry.path, entry.bytes, watch);
+    let inserted = store.insert_stream(&mut counting, &entry.blake3);
+    let found = counting.seen;
+
+    // Size before digest, for the same reason a fetch reports them apart. Here a wrong length says
+    // the generator was given different arguments and a full length mismatch says it is a different
+    // generator, and those send somebody to look in different places.
+    if found != entry.bytes {
+        return Err(GenerateError::Size {
+            path: entry.path.clone(),
+            wanted: entry.bytes,
+            found,
+        });
+    }
+
+    let inserted = match inserted {
+        Ok(inserted) => inserted,
+        Err(StoreError::DigestMismatch { wanted, found, .. }) => {
+            return Err(GenerateError::Digest {
+                path: entry.path.clone(),
+                program: program.display().to_string(),
+                wanted,
+                found,
+            });
+        }
+        Err(other) => return Err(other.into()),
+    };
+    Ok(Generated {
+        path: entry.path.clone(),
+        digest: inserted.digest,
+        bytes: found,
+        deduplicated: inserted.deduplicated,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A generator written as a shell script, so these tests exercise the real process machinery
+    /// rather than a stand in for it. Everything here is about what happens around a generator, and
+    /// what a generator is has to stay outside this repository.
+    fn script(dir: &Path, name: &str, body: &str) -> PathBuf {
+        let path = dir.join(name);
+        std::fs::write(&path, format!("#!/bin/sh\n{body}\n")).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        path
+    }
+
+    /// A manifest for a corpus of one file holding `contents`.
+    fn manifest(contents: &str) -> Manifest {
+        let digest = Digest::of_bytes(contents.as_bytes());
+        Manifest::parse(&format!(
+            "[corpus]\n\
+             name = \"example\"\n\
+             description = \"A corpus produced by a shell script\"\n\
+             source = \"example-gen 1.0.0\"\n\
+             licence = \"Apache-2.0\"\n\
+             category = \"generate\"\n\
+             \n\
+             [generator]\n\
+             program = \"example-gen\"\n\
+             version = \"1.0.0\"\n\
+             \n\
+             [[files]]\n\
+             path = \"table.tbl\"\n\
+             blake3 = \"{}\"\n\
+             bytes = {}\n",
+            digest.to_hex(),
+            contents.len()
+        ))
+        .unwrap()
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_generator_that_writes_what_was_pinned_fills_the_store() {
+        let dir = tempfile::tempdir().unwrap();
+        let program = script(
+            dir.path(),
+            "example-gen",
+            "if [ \"$1\" = -h ]; then echo 1.0.0 >&2; exit 1; fi\nprintf 'a|b|\\n' > table.tbl",
+        );
+        let store = Store::open(dir.path().join("store")).unwrap();
+
+        let generated = corpus(
+            &manifest("a|b|\n"),
+            &store,
+            Some(&program),
+            &dir.path().join("scratch"),
+            &mut |_| {},
+        )
+        .unwrap();
+        assert_eq!(generated.len(), 1);
+        assert!(!generated[0].deduplicated);
+        assert!(store.contains(&generated[0].digest));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_generator_that_writes_something_else_is_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let program = script(
+            dir.path(),
+            "example-gen",
+            "if [ \"$1\" = -h ]; then echo 1.0.0 >&2; exit 1; fi\nprintf 'x|y|\\n' > table.tbl",
+        );
+        let store = Store::open(dir.path().join("store")).unwrap();
+
+        let error = corpus(
+            &manifest("a|b|\n"),
+            &store,
+            Some(&program),
+            &dir.path().join("scratch"),
+            &mut |_| {},
+        )
+        .unwrap_err();
+        // Same length, different bytes, so this has to come out as a digest rather than a size.
+        assert!(matches!(error, GenerateError::Digest { .. }));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_generator_of_the_wrong_version_is_refused_before_it_runs() {
+        let dir = tempfile::tempdir().unwrap();
+        let program = script(
+            dir.path(),
+            "example-gen",
+            "if [ \"$1\" = -h ]; then echo 2.0.0 >&2; exit 1; fi\nprintf 'a|b|\\n' > table.tbl",
+        );
+        let store = Store::open(dir.path().join("store")).unwrap();
+        let scratch = dir.path().join("scratch");
+
+        let error = corpus(
+            &manifest("a|b|\n"),
+            &store,
+            Some(&program),
+            &scratch,
+            &mut |_| {},
+        )
+        .unwrap_err();
+        assert!(matches!(error, GenerateError::Version { .. }));
+        // Before it runs, and not partway through: nothing was written and nothing was cleared.
+        assert!(!scratch.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_generator_that_does_not_write_the_named_file_says_so() {
+        let dir = tempfile::tempdir().unwrap();
+        let program = script(
+            dir.path(),
+            "example-gen",
+            "if [ \"$1\" = -h ]; then echo 1.0.0 >&2; exit 1; fi\nprintf 'a|b|\\n' > other.tbl",
+        );
+        let store = Store::open(dir.path().join("store")).unwrap();
+
+        let error = corpus(
+            &manifest("a|b|\n"),
+            &store,
+            Some(&program),
+            &dir.path().join("scratch"),
+            &mut |_| {},
+        )
+        .unwrap_err();
+        assert!(matches!(error, GenerateError::Absent { .. }));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_generator_that_fails_is_not_asked_for_its_output() {
+        let dir = tempfile::tempdir().unwrap();
+        let program = script(
+            dir.path(),
+            "example-gen",
+            "if [ \"$1\" = -h ]; then echo 1.0.0 >&2; exit 1; fi\nexit 3",
+        );
+        let store = Store::open(dir.path().join("store")).unwrap();
+
+        let error = corpus(
+            &manifest("a|b|\n"),
+            &store,
+            Some(&program),
+            &dir.path().join("scratch"),
+            &mut |_| {},
+        )
+        .unwrap_err();
+        assert!(matches!(error, GenerateError::Failed { .. }));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_corpus_already_in_the_store_is_not_generated_again() {
+        let dir = tempfile::tempdir().unwrap();
+        // Refuses to run at all. If this passes, the generator was never started.
+        let program = script(dir.path(), "example-gen", "exit 9");
+        let store = Store::open(dir.path().join("store")).unwrap();
+        store.insert_bytes(b"a|b|\n").unwrap();
+
+        let generated = corpus(
+            &manifest("a|b|\n"),
+            &store,
+            Some(&program),
+            &dir.path().join("scratch"),
+            &mut |_| {},
+        )
+        .unwrap();
+        assert!(generated[0].deduplicated);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn what_a_previous_run_left_behind_is_cleared_before_the_generator_runs() {
+        let dir = tempfile::tempdir().unwrap();
+        let scratch = dir.path().join("scratch");
+        std::fs::create_dir_all(&scratch).unwrap();
+        std::fs::write(scratch.join("table.tbl"), "a|b|\n").unwrap();
+
+        // Writes nothing at all, so the only way `table.tbl` could be there is the stale copy.
+        let program = script(
+            dir.path(),
+            "example-gen",
+            "if [ \"$1\" = -h ]; then echo 1.0.0 >&2; exit 1; fi\ntrue",
+        );
+        let store = Store::open(dir.path().join("store")).unwrap();
+
+        let error = corpus(
+            &manifest("a|b|\n"),
+            &store,
+            Some(&program),
+            &scratch,
+            &mut |_| {},
+        )
+        .unwrap_err();
+        assert!(matches!(error, GenerateError::Absent { .. }));
+    }
+
+    #[test]
+    fn a_fetched_corpus_is_not_generated() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(dir.path()).unwrap();
+        let mut fetched = manifest("a|b|\n");
+        fetched.corpus.category = Category::Fetch;
+        fetched.generator = None;
+
+        let error = corpus(&fetched, &store, None, dir.path(), &mut |_| {}).unwrap_err();
+        assert!(matches!(error, GenerateError::NotGeneratable { .. }));
+    }
+
+    #[test]
+    fn a_program_that_is_not_there_says_where_to_get_one() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(dir.path().join("store")).unwrap();
+
+        let error = corpus(
+            &manifest("a|b|\n"),
+            &store,
+            Some(Path::new("no-such-generator-anywhere")),
+            &dir.path().join("scratch"),
+            &mut |_| {},
+        )
+        .unwrap_err();
+        assert!(format!("{error}").contains("obtained separately"));
+    }
+
+    #[test]
+    fn the_placeholders_a_manifest_may_use_are_filled_in() {
+        let generated = manifest("a|b|\n");
+        let mut generator = generated.generator.unwrap();
+        generator
+            .environment
+            .insert("OUT".to_owned(), "{output}".to_owned());
+        generator
+            .environment
+            .insert("CFG".to_owned(), "{program_directory}/dists.dss".to_owned());
+
+        let filled = environment(
+            &generator,
+            Path::new("/opt/tpch/dbgen"),
+            Path::new("/var/tmp/scratch"),
+        );
+        assert_eq!(filled["OUT"], "/var/tmp/scratch");
+        assert_eq!(filled["CFG"], "/opt/tpch/dists.dss");
+    }
+
+    #[test]
+    fn a_program_with_no_directory_resolves_its_directory_to_here() {
+        let generated = manifest("a|b|\n");
+        let mut generator = generated.generator.unwrap();
+        generator
+            .environment
+            .insert("CFG".to_owned(), "{program_directory}".to_owned());
+
+        let filled = environment(&generator, Path::new("dbgen"), Path::new("scratch"));
+        assert_eq!(filled["CFG"], ".");
+    }
+}

--- a/crates/bench-corpus/src/lib.rs
+++ b/crates/bench-corpus/src/lib.rs
@@ -15,24 +15,29 @@
 //! are then referring to the same bytes rather than to the same file name, which is the property
 //! that makes a result worth re-running.
 //!
-//! # What a fetch guarantees
+//! # What arriving guarantees
 //!
 //! [`fetch::corpus`] downloads what a manifest names and hashes it in the same pass that writes it,
-//! so bytes that are not what was promised never reach the store. [`shape::check`] then reads the
-//! Parquet footers and refuses a corpus that is not the row and column count the manifest asserted,
-//! which is the check that catches a download that stopped early and still parses.
-//!
-//! Generation is not implemented yet. See B1 in `docs/ROADMAP.md`.
+//! so bytes that are not what was promised never reach the store. [`generate::corpus`] does the same
+//! for a corpus produced locally, with a generator where the network would be, and checks the
+//! generator's version first because the bytes a generator writes are a property of the generator.
+//! [`shape::check`] then reads the Parquet footers and refuses a corpus that is not the row and
+//! column count the manifest asserted, which is the check that catches a download that stopped early
+//! and still parses.
 
 mod digest;
 pub mod fetch;
+pub mod generate;
 mod manifest;
+mod progress;
 pub mod shape;
 mod store;
 
 pub use digest::{Digest, DigestError};
-pub use fetch::{FetchError, Fetched, Progress};
-pub use manifest::{Assertions, Category, Corpus, Entry, Manifest, ManifestError};
+pub use fetch::{FetchError, Fetched};
+pub use generate::{GenerateError, Generated};
+pub use manifest::{Assertions, Category, Corpus, Entry, Generator, Manifest, ManifestError};
+pub use progress::Progress;
 pub use shape::{Shape, ShapeError};
 pub use store::{Inserted, Store, StoreError};
 

--- a/crates/bench-corpus/src/manifest.rs
+++ b/crates/bench-corpus/src/manifest.rs
@@ -25,6 +25,9 @@ pub struct Manifest {
     /// One entry per file, each pinned by digest.
     #[serde(default)]
     pub files: Vec<Entry>,
+    /// What produces the bytes, which a generated corpus has and no other kind may.
+    #[serde(default)]
+    pub generator: Option<Generator>,
     /// Facts about the loaded corpus that a run checks before it measures anything.
     #[serde(default)]
     pub assertions: Assertions,
@@ -92,6 +95,41 @@ pub struct Entry {
     /// having no answer for it would mean forking the corpus rather than describing it.
     #[serde(default)]
     pub url: Option<String>,
+}
+
+/// What produces a generated corpus, written down closely enough to run.
+///
+/// A generated corpus is pinned by digest like every other kind, and the digest of what a generator
+/// writes depends on which generator it was. So the version is part of the pin and is checked before
+/// anything runs, because the alternative is a digest mismatch on ten gigabytes of output with no
+/// indication that the cause is a build of `dbgen` two releases along.
+///
+/// The program itself is never in this repository. TPC's tools are obtained by the person running
+/// the generation, under TPC's own terms, and `docs/LICENSING.md` says why.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Generator {
+    /// What to run, found on `PATH` unless the caller supplies a path.
+    pub program: String,
+    /// What to pass it.
+    #[serde(default)]
+    pub arguments: Vec<String>,
+    /// The version this corpus was generated with, which must appear in the program's own banner.
+    pub version: String,
+    /// What to pass the program to make it print that banner.
+    #[serde(default = "Generator::default_version_arguments")]
+    pub version_arguments: Vec<String>,
+    /// Environment the program needs, where `{output}` is the directory the files should land in
+    /// and `{program_directory}` is the directory the program itself was found in.
+    #[serde(default)]
+    pub environment: std::collections::BTreeMap<String, String>,
+}
+
+impl Generator {
+    /// What to pass a program to make it say what it is, when the manifest does not say.
+    fn default_version_arguments() -> Vec<String> {
+        vec!["-h".to_owned()]
+    }
 }
 
 /// Facts a run checks about the loaded corpus before it measures anything.
@@ -237,6 +275,27 @@ impl Manifest {
             ));
         }
 
+        // A generated corpus says what produces it and every other kind says where it is downloaded
+        // from, and a manifest carrying both would be making two claims about one set of bytes. The
+        // second of those is the one that would go unread.
+        match (self.corpus.category, self.generator.as_ref()) {
+            (Category::Generate, None) => {
+                return Err(invalid(
+                    "generated without a [generator], so nothing says how".to_owned(),
+                ));
+            }
+            (category, Some(_)) if category != Category::Generate => {
+                return Err(invalid(format!(
+                    "has a [generator] and is a {category} corpus, which are two different \
+                     answers to where the bytes come from"
+                )));
+            }
+            _ => {}
+        }
+        if let Some(generator) = self.generator.as_ref() {
+            generator.validate(&invalid)?;
+        }
+
         if self.files.is_empty() {
             return Err(invalid(
                 "no files, so this manifest pins nothing".to_owned(),
@@ -259,6 +318,27 @@ impl Manifest {
     #[must_use]
     pub fn bytes(&self) -> u64 {
         self.files.iter().map(|entry| entry.bytes).sum()
+    }
+}
+
+impl Generator {
+    /// Checks a generator, reporting through the caller's error constructor.
+    fn validate(&self, invalid: &impl Fn(String) -> ManifestError) -> Result<(), ManifestError> {
+        for (field, value) in [("program", &self.program), ("version", &self.version)] {
+            if value.trim().is_empty() {
+                return Err(invalid(format!("the generator has no {field}")));
+            }
+        }
+        // Without something to run the version probe on, the version in the manifest is a comment.
+        // It is the field that turns a mismatch from a mystery into a sentence, so an empty probe
+        // is refused rather than skipped.
+        if self.version_arguments.is_empty() {
+            return Err(invalid(
+                "the generator has no version_arguments, so its version cannot be checked"
+                    .to_owned(),
+            ));
+        }
+        Ok(())
     }
 }
 
@@ -352,6 +432,68 @@ mod tests {
         assert_eq!(
             Manifest::parse(&text).unwrap().corpus.category,
             Category::Mirror
+        );
+    }
+
+    /// A generate manifest, which needs a different source and a generator to go with it.
+    fn generated(extra: &str) -> String {
+        manifest("")
+            .replace("\"fetch\"", "\"generate\"")
+            .replace(
+                "https://example.invalid/example.parquet",
+                "example-gen 1.0.0 at scale factor 1",
+            )
+            .replace(
+                "[[files]]",
+                &format!(
+                    "[generator]\n\
+                     program = \"example-gen\"\n\
+                     arguments = [\"-s\", \"1\"]\n\
+                     version = \"1.0.0\"\n\
+                     {extra}\n\
+                     [[files]]"
+                ),
+            )
+    }
+
+    #[test]
+    fn a_generated_corpus_says_what_produces_it() {
+        let parsed = Manifest::parse(&generated("")).unwrap();
+        let generator = parsed.generator.unwrap();
+        assert_eq!(generator.program, "example-gen");
+        assert_eq!(generator.arguments, ["-s", "1"]);
+        // Not written in the manifest above, so this is the default arriving.
+        assert_eq!(generator.version_arguments, ["-h"]);
+    }
+
+    #[test]
+    fn a_generated_corpus_with_no_generator_is_refused() {
+        let text = manifest("").replace("\"fetch\"", "\"generate\"");
+        let error = Manifest::parse(&text).unwrap_err();
+        assert!(format!("{error}").contains("nothing says how"));
+    }
+
+    #[test]
+    fn a_fetched_corpus_with_a_generator_is_refused() {
+        let text = generated("").replace("\"generate\"", "\"fetch\"");
+        let error = Manifest::parse(&text).unwrap_err();
+        assert!(format!("{error}").contains("two different answers"));
+    }
+
+    #[test]
+    fn a_generator_that_cannot_be_asked_its_version_is_refused() {
+        let text = generated("version_arguments = []");
+        let error = Manifest::parse(&text).unwrap_err();
+        assert!(format!("{error}").contains("cannot be checked"));
+    }
+
+    #[test]
+    fn the_environment_a_generator_needs_is_read() {
+        let text = generated("[generator.environment]\nOUT = \"{output}\"");
+        let parsed = Manifest::parse(&text).unwrap();
+        assert_eq!(
+            parsed.generator.unwrap().environment.get("OUT").unwrap(),
+            "{output}"
         );
     }
 

--- a/crates/bench-corpus/src/progress.rs
+++ b/crates/bench-corpus/src/progress.rs
@@ -1,0 +1,93 @@
+//! Saying how far along something long is.
+//!
+//! A corpus is tens of gigabytes whether it arrives over a link or comes out of a generator, and
+//! the two paths report the same way because they are the same wait from the outside. Nothing here
+//! decides how a report is displayed, only when one is due.
+
+use std::io::{self, Read};
+
+/// How often to report, in bytes.
+///
+/// Small enough that a stalled transfer is visible within a few seconds on any link worth using,
+/// large enough that the reporting is not itself measurable next to the hashing.
+pub(crate) const REPORT_EVERY: u64 = 64 << 20;
+
+/// How far along one file is.
+#[derive(Clone, Copy, Debug)]
+pub struct Progress<'a> {
+    /// The path inside the corpus.
+    pub path: &'a str,
+    /// How many bytes have gone through.
+    pub done: u64,
+    /// How many the manifest says there are.
+    pub total: u64,
+}
+
+/// A reader that counts what goes through it and says so every so often.
+pub(crate) struct Counting<'a, R> {
+    /// The reader the bytes are actually coming from.
+    pub(crate) inner: R,
+    /// How many have gone through.
+    pub(crate) seen: u64,
+    /// The count at which to report next.
+    pub(crate) next: u64,
+    /// Which file, for the report.
+    pub(crate) path: &'a str,
+    /// How many bytes the manifest says there are, for the report.
+    pub(crate) total: u64,
+    /// Who to tell.
+    pub(crate) watch: &'a mut dyn FnMut(Progress<'_>),
+}
+
+impl<'a, R> Counting<'a, R> {
+    /// Wraps a reader, with the first report due once `REPORT_EVERY` bytes have gone through.
+    pub(crate) fn new(
+        inner: R,
+        path: &'a str,
+        total: u64,
+        watch: &'a mut dyn FnMut(Progress<'_>),
+    ) -> Self {
+        Self {
+            inner,
+            seen: 0,
+            next: REPORT_EVERY,
+            path,
+            total,
+            watch,
+        }
+    }
+}
+
+impl<R: Read> Read for Counting<'_, R> {
+    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        let read = self.inner.read(buffer)?;
+        self.seen += read as u64;
+        if self.seen >= self.next || read == 0 {
+            self.next = self.seen + REPORT_EVERY;
+            (self.watch)(Progress {
+                path: self.path,
+                done: self.seen,
+                total: self.total,
+            });
+        }
+        Ok(read)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_short_read_reports_once_at_the_end() {
+        let mut seen = Vec::new();
+        let mut watch = |progress: Progress<'_>| seen.push(progress.done);
+        let mut counting = Counting::new(&b"twelve bytes"[..], "example", 12, &mut watch);
+        let mut sink = Vec::new();
+        counting.read_to_end(&mut sink).unwrap();
+        // Two reads: one that gets everything and one that gets nothing and ends it. The report is
+        // due on the second because a zero read is the end, not because a threshold was crossed.
+        assert_eq!(sink, b"twelve bytes");
+        assert_eq!(seen, vec![12]);
+    }
+}

--- a/crates/bench-report/src/lib.rs
+++ b/crates/bench-report/src/lib.rs
@@ -5,8 +5,17 @@
 //! no measurable difference. A geometric mean never appears without its per
 //! query table on the same page. Failed queries are shown rather than dropped.
 //!
-//! Nothing is implemented yet. See the milestone that owns this crate in
-//! `docs/ROADMAP.md`.
+//! What is implemented so far is the wording rules for workloads derived from a
+//! specification somebody else owns, which `docs/LICENSING.md` states in prose
+//! and [`tpc`] states as code. Those came first because they are the rules where
+//! getting it wrong is not a rendering bug. The rest is the milestone that owns
+//! this crate in `docs/ROADMAP.md`.
+
+pub mod page;
+pub mod tpc;
+
+pub use page::{Page, Row};
+pub use tpc::{Cited, Family, WordingError};
 
 /// The version of this crate, as reported by build metadata.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/crates/bench-report/src/page.rs
+++ b/crates/bench-report/src/page.rs
@@ -1,0 +1,269 @@
+//! A page of numbers, and the notices it is not allowed to be rendered without.
+//!
+//! The rule this shape exists for is that the trademark attribution appears on every page carrying
+//! a TPC number. Written as a rule, somebody has to remember it on every page. Written as a
+//! [`Page`] that collects its notices from the rows it was given, there is no page that carries one
+//! of those numbers and does not carry the notice, because the same call produces both.
+//!
+//! What a value is here is a string. The measurement types, the intervals and the comparison rules
+//! belong to the milestone that owns this crate. What had to exist first is the part that decides
+//! what a number may be called, because that is the part where getting it wrong is not a rendering
+//! bug.
+
+use std::fmt::Write as _;
+
+use crate::tpc::{self, Cited, Family, WordingError};
+
+/// One measurement on a page.
+#[derive(Clone, Debug)]
+pub struct Row {
+    /// Which workload, as the identifier the corpus and the result files use.
+    pub workload: String,
+    /// Which system produced the number.
+    pub system: String,
+    /// The number, already rendered.
+    pub value: String,
+    /// Which family the workload belongs to, worked out from its name rather than declared.
+    family: Family,
+    /// Where the number came from, when it is not one of ours.
+    origin: Option<String>,
+}
+
+impl Row {
+    /// A number this harness measured.
+    ///
+    /// # Errors
+    ///
+    /// If the workload names a TPC family and a skew, which is a different benchmark and needs a
+    /// different name.
+    pub fn measured(
+        workload: impl Into<String>,
+        system: impl Into<String>,
+        value: impl Into<String>,
+    ) -> Result<Self, WordingError> {
+        let workload = workload.into();
+        let family = tpc::check(&workload)?;
+        Ok(Self {
+            workload,
+            system: system.into(),
+            value: value.into(),
+            family,
+            origin: None,
+        })
+    }
+
+    /// A number somebody else published.
+    ///
+    /// # Errors
+    ///
+    /// If the workload names a TPC family and a skew, or if what is being cited is an official TPC
+    /// Result, which may not appear next to a number from here.
+    pub fn cited(
+        workload: impl Into<String>,
+        system: impl Into<String>,
+        value: impl Into<String>,
+        cited: Cited,
+    ) -> Result<Self, WordingError> {
+        let workload = workload.into();
+        let family = tpc::check(&workload)?;
+        let origin = match cited {
+            Cited::Published { origin } => origin,
+            Cited::OfficialTpcResult { origin } => {
+                return Err(WordingError::OfficialTpcResult { workload, origin });
+            }
+        };
+        Ok(Self {
+            workload,
+            system: system.into(),
+            value: value.into(),
+            family,
+            origin: Some(origin),
+        })
+    }
+
+    /// What has to be said about this row next to the number rather than under the table.
+    ///
+    /// A scale factor the specification does not define is the case this exists for. A reader
+    /// scanning a column of TPC-H numbers should be able to see which of them is at a size TPC
+    /// never defined without going to a footnote, because a footnote is the part that does not get
+    /// copied along with the number.
+    #[must_use]
+    pub fn note(&self) -> String {
+        let mut parts = Vec::new();
+        if let Some(scale) = tpc::scale_of(&self.workload)
+            && !self.family.scale_is_compliant(scale)
+        {
+            parts.push(format!(
+                "scale factor {scale} is not a compliant scale factor, so this is a deviation"
+            ));
+        }
+        if let Some(origin) = self.origin.as_ref() {
+            parts.push(format!("reported by {origin}, not measured here"));
+        }
+        parts.join("; ")
+    }
+
+    /// How this row's workload is named in output.
+    #[must_use]
+    pub fn label(&self) -> String {
+        match self.family.label() {
+            "" => self.workload.clone(),
+            qualified => format!("{} ({qualified})", self.workload),
+        }
+    }
+}
+
+/// A table of rows and everything that has to be printed with them.
+#[derive(Clone, Debug, Default)]
+pub struct Page {
+    /// What the table is about.
+    pub title: String,
+    /// The rows, in the order they were added.
+    rows: Vec<Row>,
+}
+
+impl Page {
+    /// An empty page.
+    #[must_use]
+    pub fn new(title: impl Into<String>) -> Self {
+        Self {
+            title: title.into(),
+            rows: Vec::new(),
+        }
+    }
+
+    /// Adds a row.
+    pub fn push(&mut self, row: Row) {
+        self.rows.push(row);
+    }
+
+    /// Every notice this page's rows require, once each and in a stable order.
+    #[must_use]
+    pub fn notices(&self) -> Vec<&'static str> {
+        let mut notices: Vec<&'static str> = Vec::new();
+        for row in &self.rows {
+            if let Some(notice) = row.family.notice()
+                && !notices.contains(&notice)
+            {
+                notices.push(notice);
+            }
+        }
+        notices
+    }
+
+    /// The page as text, with its notices under it.
+    ///
+    /// There is no way to get the table without the notices, which is the whole reason this returns
+    /// a page rather than a table.
+    #[must_use]
+    pub fn render(&self) -> String {
+        let mut out = String::new();
+        if !self.title.is_empty() {
+            out.push_str(&self.title);
+            out.push_str("\n\n");
+        }
+        for row in &self.rows {
+            let note = row.note();
+            let _ = write!(out, "{}  {}  {}", row.label(), row.system, row.value);
+            if !note.is_empty() {
+                let _ = write!(out, "  [{note}]");
+            }
+            out.push('\n');
+        }
+        for notice in self.notices() {
+            out.push('\n');
+            out.push_str(notice);
+            out.push('\n');
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_page_carrying_a_tpc_number_carries_the_notice() {
+        let mut page = Page::new("Scan rates");
+        page.push(Row::measured("tpch-sf1", "iris", "1.2 GB/s").unwrap());
+        let rendered = page.render();
+        assert!(rendered.contains("derived from TPC-H"));
+        assert!(rendered.contains("trademarks of the Transaction Processing Performance Council"));
+    }
+
+    #[test]
+    fn a_page_of_nobody_elses_numbers_carries_nothing_extra() {
+        let mut page = Page::new("Scan rates");
+        page.push(Row::measured("clickbench-hits", "iris", "1.2 GB/s").unwrap());
+        assert!(page.notices().is_empty());
+        assert!(!page.render().contains("Transaction Processing"));
+    }
+
+    #[test]
+    fn the_notice_appears_once_however_many_rows_need_it() {
+        let mut page = Page::new("Scan rates");
+        page.push(Row::measured("tpch-sf1", "iris", "1.2 GB/s").unwrap());
+        page.push(Row::measured("tpch-sf20", "iris", "1.1 GB/s").unwrap());
+        page.push(Row::measured("tpcds-sf1000", "iris", "0.9 GB/s").unwrap());
+        assert_eq!(page.notices().len(), 1);
+    }
+
+    #[test]
+    fn a_non_compliant_scale_factor_is_marked_in_the_row_and_not_in_a_footnote() {
+        let row = Row::measured("tpch-sf20", "iris", "1.1 GB/s").unwrap();
+        assert!(row.note().contains("not a compliant scale factor"));
+
+        let mut page = Page::new("Scan rates");
+        page.push(row);
+        let rendered = page.render();
+        let table = rendered
+            .lines()
+            .find(|line| line.contains("tpch-sf20"))
+            .unwrap();
+        assert!(table.contains("deviation"));
+    }
+
+    #[test]
+    fn a_compliant_scale_factor_is_not_marked() {
+        assert!(
+            Row::measured("tpch-sf1", "iris", "1.2 GB/s")
+                .unwrap()
+                .note()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn an_official_tpc_result_cannot_be_put_on_a_page() {
+        let error = Row::cited(
+            "tpch-sf1000",
+            "some appliance",
+            "4 000 000 QphH",
+            Cited::OfficialTpcResult {
+                origin: "the TPC results list".to_owned(),
+            },
+        )
+        .unwrap_err();
+        assert!(matches!(error, WordingError::OfficialTpcResult { .. }));
+    }
+
+    #[test]
+    fn a_number_from_somewhere_else_says_so_in_its_row() {
+        let row = Row::cited(
+            "clickbench-hits",
+            "some engine",
+            "12.3",
+            Cited::Published {
+                origin: "the ClickBench leaderboard".to_owned(),
+            },
+        )
+        .unwrap();
+        assert!(row.note().contains("not measured here"));
+    }
+
+    #[test]
+    fn a_skewed_generator_cannot_be_filed_under_a_tpc_name() {
+        assert!(Row::measured("tpch-skew-sf1", "iris", "1.2 GB/s").is_err());
+    }
+}

--- a/crates/bench-report/src/tpc.rs
+++ b/crates/bench-report/src/tpc.rs
@@ -1,0 +1,247 @@
+//! What may and may not be said about a number measured on somebody else's specification.
+//!
+//! TPC-H and TPC-DS are trademarks of the Transaction Processing Performance Council, and the rules
+//! for using them outside an audited run are specific. `docs/LICENSING.md` states them in prose.
+//! This module is the same rules as code, because a rule that lives only in prose is a rule that
+//! holds until the week somebody is in a hurry.
+//!
+//! The distinction the whole thing rests on: an unaudited run of a query set derived from a public
+//! specification is a legitimate and common thing to publish, and calling it a TPC-H Result is not.
+//! The two are one sentence apart and the sentence is load bearing. So there is no way to get the
+//! wrong sentence out of this module. [`Family::label`] is the only name a TPC workload has here,
+//! and it already contains the qualifier.
+
+/// Which benchmark family a number came from, which is what decides how it may be described.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Family {
+    /// Derived from the TPC-H specification.
+    TpcH,
+    /// Derived from the TPC-DS specification.
+    TpcDs,
+    /// Anything whose name nobody else owns.
+    Independent,
+}
+
+/// The scale factors the TPC-H specification defines. Anything else is a deviation.
+const TPCH_SCALES: [u32; 10] = [1, 10, 30, 100, 300, 1_000, 3_000, 10_000, 30_000, 100_000];
+
+/// The scale factors the TPC-DS specification defines, which start where TPC-H's stop mattering.
+const TPCDS_SCALES: [u32; 5] = [1_000, 3_000, 10_000, 30_000, 100_000];
+
+/// The notice that has to appear on any page carrying a number from either TPC family.
+const TPC_NOTICE: &str = "TPC, TPC-H and TPC-DS are trademarks of the Transaction Processing \
+                          Performance Council. The numbers here are derived from the published \
+                          specifications, are not audited, and are not TPC Results.";
+
+impl Family {
+    /// The family a workload identifier belongs to.
+    ///
+    /// Worked out from the identifier rather than declared alongside it, because a declaration is a
+    /// thing somebody has to remember and this is exactly the rule that must not depend on
+    /// remembering. Name a corpus `tpch-sf20` and it carries the TPC rules from that moment on,
+    /// with nothing else to fill in.
+    #[must_use]
+    pub fn of(workload: &str) -> Self {
+        let squashed: String = workload
+            .chars()
+            .filter(char::is_ascii_alphanumeric)
+            .flat_map(char::to_lowercase)
+            .collect();
+        if squashed.starts_with("tpcds") {
+            Self::TpcDs
+        } else if squashed.starts_with("tpch") {
+            Self::TpcH
+        } else {
+            Self::Independent
+        }
+    }
+
+    /// How a result from this family is named in output.
+    ///
+    /// For a TPC family this is the only name available, and it is not the trademark on its own.
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::TpcH => "derived from TPC-H",
+            Self::TpcDs => "derived from TPC-DS",
+            Self::Independent => "",
+        }
+    }
+
+    /// The notice that must appear on any page carrying one of these numbers.
+    #[must_use]
+    pub const fn notice(self) -> Option<&'static str> {
+        match self {
+            Self::TpcH | Self::TpcDs => Some(TPC_NOTICE),
+            Self::Independent => None,
+        }
+    }
+
+    /// Whether a scale factor is one the specification defines.
+    ///
+    /// Scale factor 20 is not, and is used here anyway because it is the size that stops fitting
+    /// comfortably in cache on the workstation class. That is a good reason to run it and no reason
+    /// at all to let it pass as a compliant scale factor, so it is marked.
+    #[must_use]
+    pub fn scale_is_compliant(self, scale: u32) -> bool {
+        match self {
+            Self::TpcH => TPCH_SCALES.contains(&scale),
+            Self::TpcDs => TPCDS_SCALES.contains(&scale),
+            // Nobody else's specification says which sizes are allowed, so nothing is a deviation.
+            Self::Independent => true,
+        }
+    }
+}
+
+/// The scale factor a workload identifier names, if it names one.
+///
+/// Reads the digits after `sf`, which is how every corpus and every result file in this repository
+/// spells it.
+#[must_use]
+pub fn scale_of(workload: &str) -> Option<u32> {
+    let lowered = workload.to_ascii_lowercase();
+    let after = lowered.split("sf").nth(1)?;
+    let digits: String = after.chars().take_while(char::is_ascii_digit).collect();
+    digits.parse().ok()
+}
+
+/// What a number that this harness did not measure came from.
+///
+/// Split into these two rather than left as a string, so that citing a TPC Result is something
+/// somebody has to write down in as many words. Having written it down, they are refused. There is
+/// no third case where an official result arrives without being called one.
+#[derive(Clone, Debug)]
+pub enum Cited {
+    /// A number from a paper, a vendor post, or a leaderboard that is not TPC's.
+    Published {
+        /// Where it was published, for the citation.
+        origin: String,
+    },
+    /// A number from TPC's own list of audited results.
+    OfficialTpcResult {
+        /// Where it was published, which does not help because this may not be used.
+        origin: String,
+    },
+}
+
+/// Why a row may not go on a page.
+#[derive(Debug, thiserror::Error)]
+pub enum WordingError {
+    /// Somebody tried to put an audited TPC Result next to a number from here.
+    #[error(
+        "{workload}: {origin} is an official TPC Result, and a number from this harness may not be \
+         compared against one. That is prohibited by TPC and by us, and it is prohibited because \
+         an unaudited run and an audited one are not the same measurement however similar the \
+         query text is"
+    )]
+    OfficialTpcResult {
+        /// Which workload the row was for.
+        workload: String,
+        /// What was being cited.
+        origin: String,
+    },
+    /// Somebody tried to file a skewed generator's output under the TPC numbers.
+    #[error(
+        "{workload} names a TPC family and a skew, and a skewed generator is a different benchmark. \
+         Give it its own name, so that nothing merges its numbers into the TPC-H ones by matching \
+         on a prefix"
+    )]
+    Skewed {
+        /// Which workload the row was for.
+        workload: String,
+    },
+}
+
+/// The markers that make a workload a skewed one rather than the specification's own generator.
+const SKEWS: [&str; 3] = ["skew", "zipf", "correlated"];
+
+/// Checks a workload identifier against the rules that apply before a number is even attached.
+///
+/// # Errors
+///
+/// If the identifier names a TPC family and a skew, which is a different benchmark under a name
+/// that would let it be merged into the TPC numbers.
+pub fn check(workload: &str) -> Result<Family, WordingError> {
+    let family = Family::of(workload);
+    let lowered = workload.to_ascii_lowercase();
+    if family != Family::Independent && SKEWS.iter().any(|skew| lowered.contains(skew)) {
+        return Err(WordingError::Skewed {
+            workload: workload.to_owned(),
+        });
+    }
+    Ok(family)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_corpus_name_is_enough_to_carry_the_rules() {
+        assert_eq!(Family::of("tpch-sf20"), Family::TpcH);
+        assert_eq!(Family::of("TPC-H"), Family::TpcH);
+        assert_eq!(Family::of("tpcds-sf1000"), Family::TpcDs);
+        assert_eq!(Family::of("clickbench-hits"), Family::Independent);
+    }
+
+    #[test]
+    fn tpc_ds_is_not_read_as_tpc_h_because_it_starts_the_same_way() {
+        // The obvious implementation checks for `tpch` first and gets this wrong, since `tpcds`
+        // does not begin with `tpch` but a sloppier match on `tpc` would put both in one family.
+        assert_eq!(Family::of("tpcds-sf1000"), Family::TpcDs);
+        assert_ne!(Family::of("tpcds-sf1000"), Family::TpcH);
+    }
+
+    #[test]
+    fn a_tpc_workload_has_no_name_that_is_only_the_trademark() {
+        // The point of the whole module in one assertion. There is no accessor that returns
+        // "TPC-H" on its own, so no caller can render one by accident.
+        assert_eq!(Family::TpcH.label(), "derived from TPC-H");
+        assert!(Family::TpcH.label().starts_with("derived from"));
+        assert!(Family::TpcDs.label().starts_with("derived from"));
+    }
+
+    #[test]
+    fn a_tpc_number_carries_a_notice_and_an_independent_one_does_not() {
+        assert!(Family::TpcH.notice().is_some());
+        assert!(Family::TpcDs.notice().is_some());
+        assert!(Family::Independent.notice().is_none());
+    }
+
+    #[test]
+    fn scale_factor_twenty_is_a_deviation_and_scale_factor_one_is_not() {
+        assert!(Family::TpcH.scale_is_compliant(1));
+        assert!(!Family::TpcH.scale_is_compliant(20));
+        // The corpora this repository actually has, so the rule is exercised by its own data.
+        assert_eq!(scale_of("tpch-sf1"), Some(1));
+        assert_eq!(scale_of("tpch-sf20"), Some(20));
+        assert_eq!(scale_of("clickbench-hits"), None);
+    }
+
+    #[test]
+    fn tpc_ds_has_its_own_list_of_scale_factors() {
+        // Scale factor 1 is a compliant TPC-H size and is not a compliant TPC-DS one, so a single
+        // shared list would quietly pass a deviation on one of the two.
+        assert!(Family::TpcH.scale_is_compliant(1));
+        assert!(!Family::TpcDs.scale_is_compliant(1));
+        assert!(Family::TpcDs.scale_is_compliant(1_000));
+    }
+
+    #[test]
+    fn nothing_is_a_deviation_for_a_benchmark_nobody_else_specifies() {
+        assert!(Family::Independent.scale_is_compliant(20));
+    }
+
+    #[test]
+    fn a_skewed_generator_under_a_tpc_name_is_refused() {
+        let error = check("tpch-skew-sf1").unwrap_err();
+        assert!(matches!(error, WordingError::Skewed { .. }));
+        // Under its own name it is simply a different benchmark and none of this applies.
+        assert_eq!(check("myskew-sf1").unwrap(), Family::Independent);
+    }
+
+    #[test]
+    fn an_ordinary_tpc_workload_passes_the_check() {
+        assert_eq!(check("tpch-sf20").unwrap(), Family::TpcH);
+    }
+}

--- a/docs/CORPORA.md
+++ b/docs/CORPORA.md
@@ -40,6 +40,12 @@ columns = 105
 
 An entry may also carry `url`, and almost none do. Without it the file's URL is its path resolved against the corpus `source` in the ordinary way, meaning everything after the last slash of `source` is replaced by the path. For a single file corpus whose source is the file itself that resolves back to the source unchanged, which is why the common case needs nothing written down. For a corpus of many files under one prefix, `source` names the directory with a trailing slash and each path is appended. `url` exists for the case where one corpus is assembled from files that are not under a common prefix, which happens often enough in published datasets that a format with no answer for it would mean forking a corpus rather than describing it.
 
+`[generator]` says what produces a generated corpus, and only a generated corpus may have one. A manifest carrying both a generator and a download location is making two claims about one set of bytes, and the second of those is the one that goes unread. It has a `program` to run, `arguments` to pass it, a `version` that must appear in what the program says about itself, `version_arguments` that make it say so, and an `environment` table for anything the program needs to be told through the environment rather than on the command line. The working directory is the output directory, and two placeholders are substituted into environment values: `{output}` is where the files should land and `{program_directory}` is where the program itself was found.
+
+The version is part of the pin and is checked before generation starts. The bytes a generator writes are a property of the generator, so a manifest pinned against one build of `dbgen` says nothing about another, and a digest mismatch on twenty gigabytes of output has nothing in it to suggest that the cause is a release two versions along. One process start buys that sentence.
+
+The generator itself is never in this repository. TPC's tools are downloaded under TPC's own end user agreement by whoever runs the generation, which is why `--generator` exists on `iris-bench corpus` and why the error when the program is absent says where to get one rather than what a missing file is.
+
 `[assertions]` is optional and is checked after the corpus loads rather than after it downloads. ClickBench is 99,997,497 rows across 105 columns or the manifest is wrong, and an assertion catches that far more cheaply than a number that looks slightly off six weeks later. Both fields are optional because not every corpus is tabular, and a corpus that asserts neither gets told so on every fetch rather than passing quietly.
 
 Rows are summed across the files of a corpus and columns have to agree between them, because a corpus split across files is one table and files with different schemas are not one table however they are named. Both counts come out of the Parquet footer, which is a seek and a few kilobytes rather than a pass over the data, and that is what makes it affordable to check before every measurement instead of once when the corpus was added.
@@ -67,6 +73,34 @@ The digest is computed in the same pass that writes the file rather than by read
 A file the store already has is never requested. That is not a cache, it is what content addressing means: the manifest already said which bytes it wants, and the store either has those bytes or it does not. Fetching ClickBench a second time on a machine that already has it takes 56 milliseconds including reading the footer and checking the assertions.
 
 The first fetch of ClickBench on the i9-13900K under Linux took about twenty minutes for 13.8 GiB, arrived at the digest pinned in the manifest, and reported 99,997,497 rows across 105 columns. Those numbers were pinned before the fetch ran, from a separate download hashed with `b3sum` and from the ClickBench documentation, so this was the manifest being checked rather than written.
+
+## Generating
+
+`iris-bench corpus <name> --generator <path>` is the same command with the bytes produced locally instead of downloaded. The order is the same and so is what it buys: the manifest is validated, the store is asked what it already has, the generator's version is checked, the scratch directory is emptied, the generator runs, and only then is each declared file digested and inserted.
+
+The dedup check comes before the generator starts rather than before each file, which is the one place the generated path differs from the fetched one and the difference is not cosmetic. Fetching is per file, so skipping a file that is already present skips the download of that file. A generator writes its whole output in one run, so the question worth asking is whether the entire corpus is already in the store, and asking it early is what turns a second `tpch-sf20` on a machine that already has it from three minutes into nothing.
+
+The scratch directory is emptied rather than written into. A generator that fails halfway through leaves a short file behind, and a short file with the right name is exactly the input that makes the next run's digest mismatch look like a generator bug.
+
+The version probe runs the generator with `version_arguments`, reads stdout and stderr together, and ignores the exit status. A program printing its usage commonly exits non zero, and `dbgen -h` does, so treating that as a failure would mean no version could ever be checked. What matters is whether the pinned version string appears in what came back.
+
+Two placeholders are substituted into the environment values. `{output}` is the scratch directory, which is where the files are expected to land. `{program_directory}` is the directory the generator was found in, which `dbgen` needs because it reads its column distributions from `dists.dss` sitting beside the binary rather than from anywhere a package manager would put it. Both of those are facts about `dbgen` and they live in its manifest, so the code that runs a generator knows nothing about any particular one.
+
+A generated corpus carries no `[assertions]` block, and that is a rule about what an assertion is for rather than an omission. ClickBench asserts its shape because its digest is a claim about a file on somebody else's server, so a second check that arrives at the same number by a different route is worth having. For a corpus generated and pinned file by file, 6,001,215 lineitem rows is what those bytes are, not something they could fail to be, and a row count asserted next to a digest that already implies it reads on the page like two things are being verified.
+
+TPC-H is generated with `dbgen` 2.17.3, which is not in this repository. TPC's own tools are downloaded under TPC's end user agreement by whoever runs the generation. On macOS the build is `make CC=cc DATABASE=POSTGRESQL MACHINE=MACOS WORKLOAD=TPCH`, and on Linux with gcc 15 it needs `CC="cc -std=gnu17"` because gnu23 is now the default and the K&R prototypes in that source do not survive it.
+
+Scale factor 1 is 1,092,031,885 bytes across eight files and 8,661,245 rows. It generates in 12.75 seconds on the i9-13900K under Linux and in 2 minutes 20 on the Apple silicon laptop. It exists so a change can be tried in under a minute.
+
+Scale factor 20 is 22,459,651,466 bytes and 173,194,638 rows, and generates in 196.33 seconds on the i9-13900K under Linux. 20 is deliberately not a compliant TPC-H scale factor. It is the size that stops fitting comfortably in cache on the workstation class, and a benchmark that fits in cache measures the cache. Every published row carrying one of these numbers is marked as a deviation by `bench_report` rather than in a footnote somebody writes.
+
+`nation.tbl` and `region.tbl` are byte for byte identical between the two scale factors, because those two tables do not scale. The store holds them once across both corpora, which is the content addressing doing what it was built for rather than a case anybody handled.
+
+All eight scale factor 1 digests are identical on macOS on Apple silicon and on Linux on x86-64, so what is pinned is stable across a different operating system on a different architecture rather than across two runs on one machine.
+
+Scale factor 20 was generated twice on unrelated machines, on the i9-13900K under Ubuntu 25.10 with gcc 15.2 and on a 4 vCPU AMD EPYC guest under Ubuntu 24.04, and all eight digests and all eight row counts came out the same. Different CPU vendor, different distribution, different compiler. The EPYC guest took about eighteen minutes against 196.33 seconds on the workstation, which is a fact about the guest rather than about `dbgen`.
+
+Scale factor 20 has not been generated on arm64 Linux, because no machine in the fleet has 22 GiB of free disk on that architecture. That is a gap in the evidence and it is written here rather than left to be inferred from what the table does not say.
 
 ## The store
 

--- a/docs/LICENSING.md
+++ b/docs/LICENSING.md
@@ -26,6 +26,10 @@ What we do:
 
 The distinction that matters: an unaudited run of a query set derived from a public specification is a legitimate and common thing to publish. Calling it a TPC-H Result is not. The two are one sentence apart and the sentence is load bearing.
 
+Five of those rules are code rather than intentions, in `crates/bench-report/src/tpc.rs` and `crates/bench-report/src/page.rs`. `Family::of` reads the family off the workload identifier, so a TPC workload is recognised as one without anybody remembering to mark it. `Family::label` is the only name the report layer can print for such a workload and it already contains "derived from", so there is no spelling of `tpch-sf1` that a page can render as a bare TPC-H. `Page::render` collects the trademark notice from its own rows, so a page carrying a TPC number and a page carrying the attribution are the same page. `Row::cited` refuses an official TPC Result as a comparison rather than accepting it and flagging it later. `Row::note` marks a non-compliant scale factor in the row itself, which is what scale factor 20 is and why it says so. `tpc::check` refuses a workload whose name claims both a TPC family and a skew, because that is the merge this page forbids.
+
+The rules that are not code are the ones with no shape to check: whether a sentence in a blog post describes a number honestly is not something a type can hold. The ones above were picked because each of them is a mistake somebody makes while being careful, rather than while being careless.
+
 ## ClickBench
 
 ClickBench's data and query set are published by ClickHouse under the Apache License 2.0. The benchmark's own rules are followed exactly when running under its protocol: all 43 queries, three runs, the second and third used, the geometric mean reported, and the combined score computed the way the leaderboard computes it, from load time, storage size, cold runs and hot runs.


### PR DESCRIPTION
Closes #9.

TPC-H at scale factor 1 and scale factor 20, generated with dbgen and never redistributed, plus the wording rules moved out of `docs/LICENSING.md` and into `bench-report` where they run.

## Generating

The generate category has meant something since B0 and now has a code path. `iris-bench corpus <name> --generator <path>` is the fetch command with the network replaced: validate the manifest, ask the store what it has, check the generator's version, empty the scratch directory, run it, then digest and insert each declared file.

The manifest gains a `[generator]` block naming the program, its arguments, the version it must be, the arguments that make it say so, and the environment it needs. Only a generate corpus may have one. A manifest naming both a generator and a download location is making two claims about one set of bytes and the second is the one that goes unread, so it is refused in both validators.

The version is checked before a byte is produced. A different dbgen writes different bytes, so a digest mismatch on twenty gigabytes has nothing in it to say whether the cause is a corrupt run or a release two versions along. One process start buys that sentence. The probe reads stdout and stderr together and ignores the exit status, because `dbgen -h` prints its banner and exits non zero, and treating that as failure would mean no version could ever be checked.

The dedup check moved ahead of the generator rather than sitting per file the way fetching does. Fetching is per file so skipping a present file skips a download. A generator writes its whole output in one run, so the question worth asking is whether the whole corpus is in the store, and asking it early turns a second sf20 on a machine that already has it from eighteen minutes into nothing.

The scratch directory is emptied rather than written into. A generator that fails halfway leaves a short file behind whose name still asserts its content, and that is exactly the input that makes the next run's mismatch look like a generator bug.

Two placeholders go into the environment values. `{output}` is where files should land and `{program_directory}` is where the program was found, which dbgen needs because it reads `dists.dss` from beside the binary rather than from anywhere a package manager would put it. Those are facts about dbgen, so they live in dbgen's manifest and the code that runs a generator knows nothing about any particular one.

## The numbers

Scale factor 1 is 1,092,031,885 bytes across eight files and 8,661,245 rows. 12.75 seconds on the i9-13900K under Linux, 2 minutes 20 on the Apple silicon laptop. All eight digests are identical on both, so the pin is stable across a different operating system on a different architecture rather than across two runs on one machine.

Scale factor 20 is 22,459,651,466 bytes and 173,194,638 rows. It was generated twice on unrelated machines, the i9-13900K under Ubuntu 25.10 with gcc 15.2 and a 4 vCPU AMD EPYC guest under Ubuntu 24.04, and all eight digests and all eight row counts agreed. Different CPU vendor, different distribution, different compiler. The guest took about eighteen minutes against 196.33 seconds, which is a fact about the guest.

20 is deliberately not a compliant TPC-H scale factor. It is the size that stops fitting comfortably in cache on the workstation class, and a benchmark that fits in cache measures the cache.

`nation.tbl` and `region.tbl` are byte for byte identical between the two scale factors because those tables do not scale, so the store holds them once across both corpora. That is the content addressing working rather than a case anybody handled.

Neither corpus carries an `[assertions]` block, and that is a rule about what an assertion is for. ClickBench asserts its shape because its digest is a claim about a file on somebody else's server, so a second check arriving at the same number by a different route is worth having. For bytes generated and pinned file by file, 6,001,215 lineitem rows is what they are rather than something they could fail to be, and a row count next to a digest that already implies it reads on the page like two things are being verified.

## The wording rules

Six of them are code now, in `crates/bench-report/src/tpc.rs` and `crates/bench-report/src/page.rs`.

`Family::of` reads the family off the workload identifier, so a TPC workload is recognised as one without anybody remembering to mark it. `Family::label` is the only name the report layer can print for such a workload and it already contains "derived from", so there is no spelling of `tpch-sf1` that a page renders as a bare TPC-H. `Page::render` collects the trademark notice from its own rows, so a page carrying a TPC number and a page carrying the attribution are the same page. `Row::cited` refuses an official TPC Result as a comparison rather than accepting it and flagging it later. `Row::note` marks a non-compliant scale factor in the row itself. `tpc::check` refuses a workload whose name claims both a TPC family and a skew, because that is the merge `docs/LICENSING.md` forbids.

The rules that stayed prose are the ones with no shape to check. Whether a sentence in a write-up describes a number honestly is not something a type can hold. The six above were picked because each is a mistake somebody makes while being careful.

## Provenance of dbgen

The official TPC 3.0.1 tools download is behind a click-through form asking for an email address, which is not something to submit on somebody's behalf. dbgen 2.17.3 came from `github.com/gregrahn/tpch-kit` at commit 852ad0a5ee31ebefeed884cea4188781dd9613a3 instead. It is not vendored here and never will be. TPC's tools are downloaded under TPC's own end user agreement by whoever runs the generation, which is why `--generator` takes a path and why the error when it is absent says where to get one.

Building it needs `CC="cc -std=gnu17"` on Linux with gcc 15, because gnu23 is the default now and the K&R prototypes in that source do not survive it.

## Also here

`Progress` and the counting reader moved out of `fetch.rs` into `progress.rs`, so generating and fetching report the same way rather than nearly the same way.

Both validators learned the generator rules, and `ci/test_discipline.py` gained eight cases covering them: a clean generated manifest, no generator, a fetched corpus with one anyway, a generated corpus whose source is a download, an unprobeable version, no version, an unknown field, and a non-string environment value.

## Gate

Local gate is green: fmt, clippy with `-D warnings`, both discipline runs, rustdoc with `-D warnings`, 154 tests across the workspace, and `cargo check --locked`.

The end to end run on macOS produced all eight sf1 files and matched every pinned digest in 1 minute 34.
