### PR TITLE
Pin Public BI as two corpora and make a row say which one it used

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Pre-alpha. B0 is done as of `v0.1.0`, so the measuring apparatus exists and the 
 
 What B0 established is in `docs/ROADMAP.md` under that milestone, and the short version is that this fleet can measure, on one machine, for ratios always and for durations under a gate. The noise floor is 1.05% on the one eligible role and over two percent everywhere else, and the harness adds 41.1 ns to a sample, which is under one percent of anything longer than 4.1 microseconds. `iris-bench check`, `noise`, `overhead`, `resident` and `corpus` run today. Nothing else does.
 
-B1 is in progress and is the corpora. ClickBench, TPC-H at scale factor 1 and TPC-H at scale factor 20 are pinned and reproduce, the first by download and the other two from `dbgen`.
+B1 is in progress and is the corpora. ClickBench, TPC-H at scale factor 1 and 20, and Public BI in both the full 206 table set and the 36 table subset are pinned and reproduce, some by download and the TPC-H pair from `dbgen`.
 
 B0 through B4 need no `iris` code to exist, which is deliberate. If `iris` is never built, the reproduction of the published figures and the storage tier study still stand on their own.
 

--- a/ci/discipline.py
+++ b/ci/discipline.py
@@ -61,6 +61,7 @@ MANIFEST_FIELDS = {
         "licence",
         "category",
         "licence_note",
+        "part_of",
     },
     "files": {"path", "blake3", "bytes", "url"},
     "generator": {
@@ -132,12 +133,52 @@ def check_corpora() -> None:
     corpora = ROOT / "corpora"
     if not corpora.exists():
         return
+    parsed: dict[str, dict] = {}
     for directory in sorted(p for p in corpora.iterdir() if p.is_dir()):
         manifest_path = directory / "manifest.toml"
         if not manifest_path.exists():
             fail(f"corpus {directory.name}: no manifest.toml")
             continue
         check_manifest(manifest_path)
+        try:
+            parsed[directory.name] = tomllib.loads(manifest_path.read_text(encoding="utf-8"))
+        except tomllib.TOMLDecodeError:
+            pass
+    check_parts(parsed)
+
+
+def check_parts(manifests: dict[str, dict]) -> None:
+    """Checks that a corpus claiming to be part of another really is one.
+
+    Public BI is the case. The 36 table subset much of the encoding literature
+    measures is only meaningful if it is provably 36 of the 206, and a subset
+    that has quietly drifted from the set it names is worse than no subset at
+    all, because every number labelled with it is then a number about something
+    nobody can reconstruct.
+    """
+    for name, manifest in sorted(manifests.items()):
+        whole_name = str(manifest.get("corpus", {}).get("part_of", "")).strip()
+        if not whole_name:
+            continue
+        if whole_name == name:
+            fail(f"corpus {name}: says it is part of itself")
+            continue
+        whole = manifests.get(whole_name)
+        if whole is None:
+            fail(f"corpus {name}: says it is part of '{whole_name}', which is not in corpora/")
+            continue
+        held = {
+            entry.get("path"): (entry.get("blake3"), entry.get("bytes"))
+            for entry in whole.get("files", [])
+        }
+        for entry in manifest.get("files", []):
+            path = entry.get("path")
+            if path not in held:
+                fail(f"corpus {name}: pins '{path}', which is not in '{whole_name}'")
+            elif held[path] != (entry.get("blake3"), entry.get("bytes")):
+                fail(f"corpus {name}: pins '{path}' differently from '{whole_name}'")
+        if len(manifest.get("files", [])) >= len(whole.get("files", [])):
+            fail(f"corpus {name}: is not smaller than '{whole_name}', so it is not a part of it")
 
 
 def check_fields(name: str, table: str, values: dict, allowed: set[str]) -> None:

--- a/ci/test_discipline.py
+++ b/ci/test_discipline.py
@@ -86,8 +86,58 @@ def expect_complaint(name: str, text: str, phrase: str, directory: str = "exampl
         failures.append(f"{name}: expected a complaint containing {phrase!r} and got {said}")
 
 
+def parts(manifests: dict[str, str]) -> list[str]:
+    """Runs the subset check over a set of manifests and returns what it said."""
+    import tomllib
+
+    before = list(discipline.failures)
+    discipline.failures.clear()
+    try:
+        discipline.check_parts({name: tomllib.loads(text) for name, text in manifests.items()})
+        return list(discipline.failures)
+    finally:
+        discipline.failures[:] = before
+
+
+def check_parts_cases() -> None:
+    whole = GOOD.replace('"example"', '"whole"') + (
+        '\n[[files]]\npath = "other.parquet"\n'
+        'blake3 = "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3263"\n'
+        "bytes = 2048\n"
+    )
+    part = GOOD.replace('category = "fetch"', 'category = "fetch"\npart_of = "whole"')
+
+    said = parts({"whole": whole, "example": part})
+    if said:
+        failures.append(f"a real subset: expected no complaint and got {said}")
+
+    said = parts({"example": part})
+    if not any("not in corpora/" in one for one in said):
+        failures.append(f"a subset of nothing: expected a complaint and got {said}")
+
+    strayed = part.replace("example.parquet", "elsewhere.parquet")
+    said = parts({"whole": whole, "example": strayed})
+    if not any("which is not in 'whole'" in one for one in said):
+        failures.append(f"a subset naming a file the whole lacks: got {said}")
+
+    drifted = part.replace("bytes = 1024", "bytes = 4096")
+    said = parts({"whole": whole, "example": drifted})
+    if not any("differently from 'whole'" in one for one in said):
+        failures.append(f"a subset pinning a file differently: got {said}")
+
+    said = parts({"whole": GOOD.replace('"example"', '"whole"'), "example": part})
+    if not any("is not smaller" in one for one in said):
+        failures.append(f"a subset the size of the whole: got {said}")
+
+    circular = GOOD.replace('category = "fetch"', 'category = "fetch"\npart_of = "example"')
+    said = parts({"example": circular})
+    if not any("part of itself" in one for one in said):
+        failures.append(f"a subset of itself: got {said}")
+
+
 def main() -> int:
     expect_clean("a complete manifest passes", GOOD)
+    check_parts_cases()
 
     expect_complaint(
         "a manifest that disagrees with its directory",

--- a/corpora/public-bi-36/manifest.toml
+++ b/corpora/public-bi-36/manifest.toml
@@ -1,0 +1,203 @@
+# The 36 table Public BI subset, which is what much of the encoding literature actually measures.
+# Without it those results cannot be reproduced at all, and with it labelled as plain Public BI they
+# would be compared against numbers over the full 206 tables, which measure different data.
+#
+# The 36 are one table per workbook for 36 of the 46 workbooks, as listed in FastLanes at
+# data/include/data/public_bi.hpp. Nine of the ten workbooks left out are second or third variants
+# of a workbook that is already in, and IUBLibrary is the one that is not, so the selection is not a
+# rule that can be recomputed and is pinned here table by table instead.
+#
+# TrainsUK1 contributes its second table rather than its first. That is what the published list
+# says, it is the sort of detail that gets tidied up by somebody being helpful, and tidying it up
+# would silently change what every number labelled with this subset was measured over.
+#
+# part_of makes the claim checkable. CI reads both manifests and refuses a table here that is not in
+# public-bi at the same digest and the same size, so this cannot drift from the set it names.
+
+[corpus]
+name = "public-bi-36"
+description = "The 36 table Public BI subset the encoding literature measures, one table per workbook"
+source = "https://event.cwi.nl/da/PublicBIbenchmark/"
+licence = "Tableau Public workbook data, redistribution not asserted"
+category = "fetch"
+part_of = "public-bi"
+
+[[files]]
+path = "Arade/Arade_1.csv.bz2"
+blake3 = "0f648d1daacd26a97367e6b71bf9e1c298c91470c72326608c008b46b5c59e77"
+bytes = 162560322
+
+[[files]]
+path = "Bimbo/Bimbo_1.csv.bz2"
+blake3 = "1b84b0b206e4ea7124d98404535a43069731bcb4138daa3cae37d653de57a67c"
+bytes = 394724736
+
+[[files]]
+path = "CMSprovider/CMSprovider_1.csv.bz2"
+blake3 = "bf2af1ebf2cfc9aa1a00d7180357f8537e121db2f32b7192bc521468ba28a2cb"
+bytes = 321093709
+
+[[files]]
+path = "CityMaxCapita/CityMaxCapita_1.csv.bz2"
+blake3 = "f800c62d43ef5cf3268e7b13c1ab34202091a6dc7ab2a5284939930a37e8e303"
+bytes = 87308542
+
+[[files]]
+path = "CommonGovernment/CommonGovernment_1.csv.bz2"
+blake3 = "e98da8ebda28958df4507cf416b65b03ec99f8b6dbc62ba4ddba7fb56c5298c7"
+bytes = 378224148
+
+[[files]]
+path = "Corporations/Corporations_1.csv.bz2"
+blake3 = "f6dc3d0c410fb88dab33120d155776ecb507cc983044b109adfb8ac66174518e"
+bytes = 37406370
+
+[[files]]
+path = "Eixo/Eixo_1.csv.bz2"
+blake3 = "f10c05dc05644d01dd513706b1a1f8002df4f41151ee3fcac069ca5d0beec24d"
+bytes = 403957418
+
+[[files]]
+path = "Euro2016/Euro2016_1.csv.bz2"
+blake3 = "b9856f8e6132ab1be732f6a01888331d3d87aaabc437666d19449140992282b9"
+bytes = 97474419
+
+[[files]]
+path = "Food/Food_1.csv.bz2"
+blake3 = "6b124fed148898880e65d628328a0495c4b92c045bae60dd764d16098c0ac4e3"
+bytes = 38466097
+
+[[files]]
+path = "Generico/Generico_1.csv.bz2"
+blake3 = "14fcb889336e6d795b4fa17d9bf18101f0fa7e6778cbfd5acf2ec10ef304eb16"
+bytes = 588230250
+
+[[files]]
+path = "HashTags/HashTags_1.csv.bz2"
+blake3 = "552d124c40a80388e44ec787534258e8b78d62be2b694495cb1c5c9ab48a4f61"
+bytes = 98582105
+
+[[files]]
+path = "Hatred/Hatred_1.csv.bz2"
+blake3 = "5f89285f6deabbe6d7a9d4dc81453532bee3d3863fd7e77f334e01e58d1b619e"
+bytes = 86463927
+
+[[files]]
+path = "IGlocations1/IGlocations1_1.csv.bz2"
+blake3 = "d70c5cff36b36b0581bca97917af50589c27a818d911df31a13c93437ff27f64"
+bytes = 1586852
+
+[[files]]
+path = "MLB/MLB_1.csv.bz2"
+blake3 = "c591279ef8281341083e34c101d9d03bebf08f767129ade51a4d8c6a01451972"
+bytes = 2657601
+
+[[files]]
+path = "MedPayment1/MedPayment1_1.csv.bz2"
+blake3 = "36efef347c7094c737a29a0762b497225285b5dead5b7700ce5e498e33fc05dd"
+bytes = 324099266
+
+[[files]]
+path = "Medicare1/Medicare1_1.csv.bz2"
+blake3 = "ad1d5cd68705ddf857ad64fe83a83d1d708de7f9d02d9a573789f8bad741abab"
+bytes = 360397215
+
+[[files]]
+path = "Motos/Motos_1.csv.bz2"
+blake3 = "0b0496a2fab1cb8da5da76a840d8b6d957ca96b9c961f9354b2757860082be56"
+bytes = 398792220
+
+[[files]]
+path = "MulheresMil/MulheresMil_1.csv.bz2"
+blake3 = "e7c73854f5b5553841fd22dbeec35b1ce5e71a509bc4bab3a056721f0af74225"
+bytes = 406006611
+
+[[files]]
+path = "NYC/NYC_1.csv.bz2"
+blake3 = "197d6eaf0f80ff2dd4597dee5612431be0237769d7384a6bc817c083ef401fe3"
+bytes = 358999365
+
+[[files]]
+path = "PanCreactomy1/PanCreactomy1_1.csv.bz2"
+blake3 = "47e9fa48cfa739cd2118a7dea7049283b6fd1e063f79f8ed367e85236ab6f5a0"
+bytes = 338973914
+
+[[files]]
+path = "Physicians/Physicians_1.csv.bz2"
+blake3 = "0f141192615f17ebd5e397c7b3a86732157754ec11ef3069efa70da55458f1da"
+bytes = 323986936
+
+[[files]]
+path = "Provider/Provider_1.csv.bz2"
+blake3 = "0f2217a36e3eba9430efb3ca588abf93042e8f4f5ec87f97c1ed24ac78f91447"
+bytes = 323342180
+
+[[files]]
+path = "RealEstate1/RealEstate1_1.csv.bz2"
+blake3 = "1e79cddfc4ea35b55d3187f12c2441d0b5a2996417ca9bc76fb52d92cd2927b4"
+bytes = 1112896530
+
+[[files]]
+path = "Redfin1/Redfin1_1.csv.bz2"
+blake3 = "cfa31d04ef3bbd21d6c350f65f414f095ed280cb47ca7653aded8df31791f538"
+bytes = 369564432
+
+[[files]]
+path = "Rentabilidad/Rentabilidad_1.csv.bz2"
+blake3 = "ccc3e367c0178507c37baed0e1dcf71609c81a8b0f8a9aa2ff1c53a8971f6b5a"
+bytes = 74010404
+
+[[files]]
+path = "Romance/Romance_1.csv.bz2"
+blake3 = "9feec1328260bfc822d5d57276e80d6b19e802e72b840e53d885a92180fbcf58"
+bytes = 134950511
+
+[[files]]
+path = "SalariesFrance/SalariesFrance_1.csv.bz2"
+blake3 = "9cfde096030132e4c17c73ac4202d0849123d0d30a75e28162f19e9fa8b82f88"
+bytes = 194093473
+
+[[files]]
+path = "TableroSistemaPenal/TableroSistemaPenal_1.csv.bz2"
+blake3 = "94478bc1f15bd34d6782b4d8fda2fcbfd77f7aba7e88462bd8b0680b94e20b13"
+bytes = 17463053
+
+[[files]]
+path = "Taxpayer/Taxpayer_1.csv.bz2"
+blake3 = "10ef09b3c3dc3826a0239a42854c825281e556b67f743c1e6c7eec6d802cc9e5"
+bytes = 323177199
+
+[[files]]
+path = "Telco/Telco_1.csv.bz2"
+blake3 = "9f8038dba2dbe790f78c5eb95849a5e926e333bfd93c5b1f4b73e4d3ef886280"
+bytes = 726757905
+
+[[files]]
+path = "TrainsUK1/TrainsUK1_2.csv.bz2"
+blake3 = "f4c7926653c5da92430519686fd2033607299b4a5cab29c172a0a0d87cab85b8"
+bytes = 175555047
+
+[[files]]
+path = "TrainsUK2/TrainsUK2_1.csv.bz2"
+blake3 = "d8c34aadb46591507526519ba72bdceb3905c0f699aef3618b9b97899f41d894"
+bytes = 568463724
+
+[[files]]
+path = "USCensus/USCensus_1.csv.bz2"
+blake3 = "acafdd3c7b5a8a591517798afcaa6c99027c266f8868abcba74e2c6593362347"
+bytes = 768182889
+
+[[files]]
+path = "Uberlandia/Uberlandia_1.csv.bz2"
+blake3 = "1a5690988afd745c78cbf74f4ada9d614a5e1d1e1c8943d5a07712362ac7c86a"
+bytes = 405669478
+
+[[files]]
+path = "Wins/Wins_1.csv.bz2"
+blake3 = "b9800987062a7ce9628c9cfe94842fbc9b2f277a516ab32cbc1db715314ff390"
+bytes = 131362720
+
+[[files]]
+path = "YaleLanguages/YaleLanguages_1.csv.bz2"
+blake3 = "f4fd638205dca30417a02402928c4abfe7200cb8bf05be5edcaac84c2b292756"
+bytes = 12421515

--- a/corpora/public-bi/manifest.toml
+++ b/corpora/public-bi/manifest.toml
@@ -1,0 +1,1058 @@
+# The Public BI benchmark, all 206 tables across 46 Tableau Public workbooks. Real data and real
+# queries rather than anything generated, which is the reason this corpus is the one the encoding
+# literature settled on and the reason it is worth being careful about.
+#
+# Fetched from the location the benchmark publishes and never redistributed here. The workbooks are
+# public and the derived .csv files are the benchmark authors' work, so the bytes stay where they
+# are and this repository holds only the digests.
+#
+# 43,334,957,146 bytes as fetched, which is bzip2 compressed CSV, and about 386 GB once
+# decompressed. corpora/public-bi-36 is the 36 table subset most published encoding numbers are
+# taken over, and it is a part of this one rather than a separate download, so a machine holding
+# both stores the shared tables once.
+#
+# 206 declared files, 180 distinct objects. Twenty six of the MLB tables are byte for byte a
+# duplicate of another MLB table, because Tableau extracted that workbook several ways and some of
+# the extracts came out identical. The store notices without being told, which is what addressing by
+# content is for, and the corpus still declares all 206 because the benchmark does.
+#
+# There is no [assertions] block. These are bzip2 compressed CSV rather than Parquet, so there is no
+# footer to read a shape out of, and asserting a row count would mean decompressing 386 GiB to check
+# something the digests already fix.
+
+[corpus]
+name = "public-bi"
+description = "The Public BI benchmark, all 206 tables from 46 Tableau Public workbooks"
+source = "https://event.cwi.nl/da/PublicBIbenchmark/"
+licence = "Tableau Public workbook data, redistribution not asserted"
+category = "fetch"
+
+[[files]]
+path = "Arade/Arade_1.csv.bz2"
+blake3 = "0f648d1daacd26a97367e6b71bf9e1c298c91470c72326608c008b46b5c59e77"
+bytes = 162560322
+
+[[files]]
+path = "Bimbo/Bimbo_1.csv.bz2"
+blake3 = "1b84b0b206e4ea7124d98404535a43069731bcb4138daa3cae37d653de57a67c"
+bytes = 394724736
+
+[[files]]
+path = "CMSprovider/CMSprovider_1.csv.bz2"
+blake3 = "bf2af1ebf2cfc9aa1a00d7180357f8537e121db2f32b7192bc521468ba28a2cb"
+bytes = 321093709
+
+[[files]]
+path = "CMSprovider/CMSprovider_2.csv.bz2"
+blake3 = "294a24d12f3095bbbb3e4e8f51577b221291778f4d23ba704e4d176752f71ce7"
+bytes = 321142586
+
+[[files]]
+path = "CityMaxCapita/CityMaxCapita_1.csv.bz2"
+blake3 = "f800c62d43ef5cf3268e7b13c1ab34202091a6dc7ab2a5284939930a37e8e303"
+bytes = 87308542
+
+[[files]]
+path = "CommonGovernment/CommonGovernment_1.csv.bz2"
+blake3 = "e98da8ebda28958df4507cf416b65b03ec99f8b6dbc62ba4ddba7fb56c5298c7"
+bytes = 378224148
+
+[[files]]
+path = "CommonGovernment/CommonGovernment_10.csv.bz2"
+blake3 = "c2fb05a5dbeb7559a6192e36b65bcf644f95dc22182d628a600f01c8f25392ad"
+bytes = 355518467
+
+[[files]]
+path = "CommonGovernment/CommonGovernment_11.csv.bz2"
+blake3 = "5fbb937fe0175859091c320a2ec8a91c8e1b1efc49d8cd12d1a7b8edaa16f5bc"
+bytes = 354249333
+
+[[files]]
+path = "CommonGovernment/CommonGovernment_12.csv.bz2"
+blake3 = "dddbb494aa1fad0f854e0b16e5cd8ead191f60b052c6a7f1f8967ed65a37eab7"
+bytes = 350380379
+
+[[files]]
+path = "CommonGovernment/CommonGovernment_13.csv.bz2"
+blake3 = "ec3c7a1c089494f1034203a4bbbcedf48f0d91e26a7bc74cd774ef76ce3d1a4d"
+bytes = 351982494
+
+[[files]]
+path = "CommonGovernment/CommonGovernment_2.csv.bz2"
+blake3 = "a91510ab697d96c689d76c373f18b68a691fb2866f7a5a7c29e3b8e892213d1c"
+bytes = 378351793
+
+[[files]]
+path = "CommonGovernment/CommonGovernment_3.csv.bz2"
+blake3 = "7f41af5144b47a3b7895825a14a67074364e22ae952dced17413089e1b2ebba1"
+bytes = 378478940
+
+[[files]]
+path = "CommonGovernment/CommonGovernment_4.csv.bz2"
+blake3 = "38d8eef452818272f62e3b1497d5993c09e07eb57cec3dbe26fb35e60cfe8936"
+bytes = 370370399
+
+[[files]]
+path = "CommonGovernment/CommonGovernment_5.csv.bz2"
+blake3 = "5709d830f7c0f29caf36862374b115bbc47a6713e696eed6a88144f4f24dd4d8"
+bytes = 351810942
+
+[[files]]
+path = "CommonGovernment/CommonGovernment_6.csv.bz2"
+blake3 = "5d78263d4b04bdbf4d119d8b262e9d74119e4e3854372e5979919a487518db2a"
+bytes = 356180156
+
+[[files]]
+path = "CommonGovernment/CommonGovernment_7.csv.bz2"
+blake3 = "8f6a603b2deadb06242427d87a30034046fb64a5d1693df919d03109f4dff4b8"
+bytes = 350570453
+
+[[files]]
+path = "CommonGovernment/CommonGovernment_8.csv.bz2"
+blake3 = "cd09e62095d3c00ffd32774bae14a710d8b265c4d844370d80453527e90fdde5"
+bytes = 350110423
+
+[[files]]
+path = "CommonGovernment/CommonGovernment_9.csv.bz2"
+blake3 = "192953dcfc8bfd6b5e75d620738922792498ac5f1565ace238a8d8b51a0f73cc"
+bytes = 355434340
+
+[[files]]
+path = "Corporations/Corporations_1.csv.bz2"
+blake3 = "f6dc3d0c410fb88dab33120d155776ecb507cc983044b109adfb8ac66174518e"
+bytes = 37406370
+
+[[files]]
+path = "Eixo/Eixo_1.csv.bz2"
+blake3 = "f10c05dc05644d01dd513706b1a1f8002df4f41151ee3fcac069ca5d0beec24d"
+bytes = 403957418
+
+[[files]]
+path = "Euro2016/Euro2016_1.csv.bz2"
+blake3 = "b9856f8e6132ab1be732f6a01888331d3d87aaabc437666d19449140992282b9"
+bytes = 97474419
+
+[[files]]
+path = "Food/Food_1.csv.bz2"
+blake3 = "6b124fed148898880e65d628328a0495c4b92c045bae60dd764d16098c0ac4e3"
+bytes = 38466097
+
+[[files]]
+path = "Generico/Generico_1.csv.bz2"
+blake3 = "14fcb889336e6d795b4fa17d9bf18101f0fa7e6778cbfd5acf2ec10ef304eb16"
+bytes = 588230250
+
+[[files]]
+path = "Generico/Generico_2.csv.bz2"
+blake3 = "d62afb626d11cbfa4975b37fb63f1b320c179a638eff2db38ab09502535afde4"
+bytes = 655930743
+
+[[files]]
+path = "Generico/Generico_3.csv.bz2"
+blake3 = "bb2b1ffdb4a78782a72b16d23efc66b941dba0868ad5fb38d5cbc85c4c61456f"
+bytes = 656255581
+
+[[files]]
+path = "Generico/Generico_4.csv.bz2"
+blake3 = "25ed1ec4802769fb7507016143a2ed32ce6364ca0d5608f5ca27fe3e4f15c149"
+bytes = 656179711
+
+[[files]]
+path = "Generico/Generico_5.csv.bz2"
+blake3 = "76c33f294d17451824817015da34aa52ce58fbf178ae6ffdd3e33a1272e969eb"
+bytes = 656299789
+
+[[files]]
+path = "HashTags/HashTags_1.csv.bz2"
+blake3 = "552d124c40a80388e44ec787534258e8b78d62be2b694495cb1c5c9ab48a4f61"
+bytes = 98582105
+
+[[files]]
+path = "Hatred/Hatred_1.csv.bz2"
+blake3 = "5f89285f6deabbe6d7a9d4dc81453532bee3d3863fd7e77f334e01e58d1b619e"
+bytes = 86463927
+
+[[files]]
+path = "IGlocations1/IGlocations1_1.csv.bz2"
+blake3 = "d70c5cff36b36b0581bca97917af50589c27a818d911df31a13c93437ff27f64"
+bytes = 1586852
+
+[[files]]
+path = "IGlocations2/IGlocations2_1.csv.bz2"
+blake3 = "1151e5a2fe00fb1e8898d46285b7ff800095c66ac218f5ef6448344b896c4e37"
+bytes = 208875374
+
+[[files]]
+path = "IGlocations2/IGlocations2_2.csv.bz2"
+blake3 = "8af5024b03c95b59a6f53c36214d01514cf6751af2e4f54cbd0c9fc10442cc98"
+bytes = 208802058
+
+[[files]]
+path = "IUBLibrary/IUBLibrary_1.csv.bz2"
+blake3 = "a84eadfcc9f74b7e2be3a48770f4a828b8b17091497c98a45f634122e69680de"
+bytes = 136544
+
+[[files]]
+path = "MLB/MLB_1.csv.bz2"
+blake3 = "c591279ef8281341083e34c101d9d03bebf08f767129ade51a4d8c6a01451972"
+bytes = 2657601
+
+[[files]]
+path = "MLB/MLB_10.csv.bz2"
+blake3 = "fb6fc4080fbc366f7839ec90d789315b60fecccf2a3d9d0f060c25424618eecf"
+bytes = 4034749
+
+[[files]]
+path = "MLB/MLB_11.csv.bz2"
+blake3 = "44fc2445cd7dc8e272c461a514e688bf6813ab99c5f71253c8cce1f34d53aada"
+bytes = 4058754
+
+[[files]]
+path = "MLB/MLB_12.csv.bz2"
+blake3 = "c591279ef8281341083e34c101d9d03bebf08f767129ade51a4d8c6a01451972"
+bytes = 2657601
+
+[[files]]
+path = "MLB/MLB_13.csv.bz2"
+blake3 = "c591279ef8281341083e34c101d9d03bebf08f767129ade51a4d8c6a01451972"
+bytes = 2657601
+
+[[files]]
+path = "MLB/MLB_14.csv.bz2"
+blake3 = "c591279ef8281341083e34c101d9d03bebf08f767129ade51a4d8c6a01451972"
+bytes = 2657601
+
+[[files]]
+path = "MLB/MLB_15.csv.bz2"
+blake3 = "f5aa6f2959be1c698a4b6896374a1f26f8e07b145a0ac611c3773a4814aec7fa"
+bytes = 9017668
+
+[[files]]
+path = "MLB/MLB_16.csv.bz2"
+blake3 = "0b2fbbf56204218816f8ae06b03634723aab4b9a9c7ca8b7ba0655d2f8d7ecc3"
+bytes = 9018074
+
+[[files]]
+path = "MLB/MLB_17.csv.bz2"
+blake3 = "ac770425d79b7be599e6c13244476f3128e0085038b5bafd56fd7926efdd068d"
+bytes = 9033268
+
+[[files]]
+path = "MLB/MLB_18.csv.bz2"
+blake3 = "964d0e55a6cf4b451dbdbe49f320ccfdff019ca843c774c51f39728ad7c4e8dd"
+bytes = 9026989
+
+[[files]]
+path = "MLB/MLB_19.csv.bz2"
+blake3 = "a2065b896380c456ea55c9fe0d35bf1532607d49cc8e68c0caf86273dc2f4385"
+bytes = 4319855
+
+[[files]]
+path = "MLB/MLB_2.csv.bz2"
+blake3 = "190a5469fc0c5470985032710d18c0f74b6470fd14843878057639d4da8d4a81"
+bytes = 105308340
+
+[[files]]
+path = "MLB/MLB_20.csv.bz2"
+blake3 = "a2065b896380c456ea55c9fe0d35bf1532607d49cc8e68c0caf86273dc2f4385"
+bytes = 4319855
+
+[[files]]
+path = "MLB/MLB_21.csv.bz2"
+blake3 = "a2065b896380c456ea55c9fe0d35bf1532607d49cc8e68c0caf86273dc2f4385"
+bytes = 4319855
+
+[[files]]
+path = "MLB/MLB_22.csv.bz2"
+blake3 = "7497e883565acc65867098177695a3eda34c04a17a0d55a19ae30e55ce6ea5e3"
+bytes = 9879815
+
+[[files]]
+path = "MLB/MLB_23.csv.bz2"
+blake3 = "277dbdb0b46223c44157568123b55292fed2c27cb1a08296f22b7c7d822b0b44"
+bytes = 9851244
+
+[[files]]
+path = "MLB/MLB_24.csv.bz2"
+blake3 = "e437a477441ca329e6935900cb95f49a55500ae05e95e6dc8793b29ca40b4558"
+bytes = 9877242
+
+[[files]]
+path = "MLB/MLB_25.csv.bz2"
+blake3 = "3ada8f3e43948d53dffc3350a1fceafc3478a9d0d10575845b4751c13c87d3ca"
+bytes = 7571607
+
+[[files]]
+path = "MLB/MLB_26.csv.bz2"
+blake3 = "34430d2af041c6c09af398f9a0c7060ed54c2ab0c29708ece662b14a4c88031f"
+bytes = 7592575
+
+[[files]]
+path = "MLB/MLB_27.csv.bz2"
+blake3 = "84c29992e1c538fb4676ac94c629c4586711144610f4c0ffabcd5a99df300bf4"
+bytes = 7564985
+
+[[files]]
+path = "MLB/MLB_28.csv.bz2"
+blake3 = "40117c342cfc7f593137bc8d010c53e344a81e4be916112719b2a9b3ea2669a6"
+bytes = 7580332
+
+[[files]]
+path = "MLB/MLB_29.csv.bz2"
+blake3 = "a01a1ee99e777e115551931e2d88790d7227ce412b54b62e87ac3a854323edae"
+bytes = 7576060
+
+[[files]]
+path = "MLB/MLB_3.csv.bz2"
+blake3 = "544c8f6bc847a5eb86ca407eece52ee31c06e366d448480fdfbba3119d1677e5"
+bytes = 105530932
+
+[[files]]
+path = "MLB/MLB_30.csv.bz2"
+blake3 = "0b6e514e293ee5727f02ae4e864913bed01118905131caff96fbc67067f28fb5"
+bytes = 7583047
+
+[[files]]
+path = "MLB/MLB_31.csv.bz2"
+blake3 = "98c6f138eff3e99cb5ccf5a5ac6411485cb59bb24cdcd28d68b1f87a737c4834"
+bytes = 4382861
+
+[[files]]
+path = "MLB/MLB_32.csv.bz2"
+blake3 = "98c6f138eff3e99cb5ccf5a5ac6411485cb59bb24cdcd28d68b1f87a737c4834"
+bytes = 4382861
+
+[[files]]
+path = "MLB/MLB_33.csv.bz2"
+blake3 = "98c6f138eff3e99cb5ccf5a5ac6411485cb59bb24cdcd28d68b1f87a737c4834"
+bytes = 4382861
+
+[[files]]
+path = "MLB/MLB_34.csv.bz2"
+blake3 = "98c6f138eff3e99cb5ccf5a5ac6411485cb59bb24cdcd28d68b1f87a737c4834"
+bytes = 4382861
+
+[[files]]
+path = "MLB/MLB_35.csv.bz2"
+blake3 = "98c6f138eff3e99cb5ccf5a5ac6411485cb59bb24cdcd28d68b1f87a737c4834"
+bytes = 4382861
+
+[[files]]
+path = "MLB/MLB_36.csv.bz2"
+blake3 = "98c6f138eff3e99cb5ccf5a5ac6411485cb59bb24cdcd28d68b1f87a737c4834"
+bytes = 4382861
+
+[[files]]
+path = "MLB/MLB_37.csv.bz2"
+blake3 = "98c6f138eff3e99cb5ccf5a5ac6411485cb59bb24cdcd28d68b1f87a737c4834"
+bytes = 4382861
+
+[[files]]
+path = "MLB/MLB_38.csv.bz2"
+blake3 = "393af16036a8028ef98919857108811be6fdf02a3574a821b320a99db1aa1a65"
+bytes = 6050443
+
+[[files]]
+path = "MLB/MLB_39.csv.bz2"
+blake3 = "8c08a410fdeacf5d04bde601e2712583535fb1d06a8b2b3f724667bb2fc37fc3"
+bytes = 6049978
+
+[[files]]
+path = "MLB/MLB_4.csv.bz2"
+blake3 = "85c9c7b4475568821f276d6478f7831a0b2bbe4990c07bdde0368bee4e392033"
+bytes = 105404288
+
+[[files]]
+path = "MLB/MLB_40.csv.bz2"
+blake3 = "09d8865ad2eb1284df770bac65ff303cb794646aa5cdc4add3cb3836c9504871"
+bytes = 6049677
+
+[[files]]
+path = "MLB/MLB_41.csv.bz2"
+blake3 = "0c2c7c62dd6637f5070576fafb1ee1bcbc2acd65e2fe370ca0f626cb712dbdf3"
+bytes = 3144447
+
+[[files]]
+path = "MLB/MLB_42.csv.bz2"
+blake3 = "0c2c7c62dd6637f5070576fafb1ee1bcbc2acd65e2fe370ca0f626cb712dbdf3"
+bytes = 3144447
+
+[[files]]
+path = "MLB/MLB_43.csv.bz2"
+blake3 = "0c2c7c62dd6637f5070576fafb1ee1bcbc2acd65e2fe370ca0f626cb712dbdf3"
+bytes = 3144447
+
+[[files]]
+path = "MLB/MLB_44.csv.bz2"
+blake3 = "0c2c7c62dd6637f5070576fafb1ee1bcbc2acd65e2fe370ca0f626cb712dbdf3"
+bytes = 3144447
+
+[[files]]
+path = "MLB/MLB_45.csv.bz2"
+blake3 = "aa0ee308678cc46ee90f1f0411fb5d90cf3bc4582d7e7d90c212e909974344e6"
+bytes = 3232166
+
+[[files]]
+path = "MLB/MLB_46.csv.bz2"
+blake3 = "aa0ee308678cc46ee90f1f0411fb5d90cf3bc4582d7e7d90c212e909974344e6"
+bytes = 3232166
+
+[[files]]
+path = "MLB/MLB_47.csv.bz2"
+blake3 = "aa0ee308678cc46ee90f1f0411fb5d90cf3bc4582d7e7d90c212e909974344e6"
+bytes = 3232166
+
+[[files]]
+path = "MLB/MLB_48.csv.bz2"
+blake3 = "aa0ee308678cc46ee90f1f0411fb5d90cf3bc4582d7e7d90c212e909974344e6"
+bytes = 3232166
+
+[[files]]
+path = "MLB/MLB_49.csv.bz2"
+blake3 = "633552eccbe6d23c456a42285adbef0aa915a5de0a7dcbfac7d5bdbee56b1942"
+bytes = 3142381
+
+[[files]]
+path = "MLB/MLB_5.csv.bz2"
+blake3 = "d140f8f55e49e6d6d4893fcfd8cf531d8f5a7ed3444b01683917b7f0baa98961"
+bytes = 125231524
+
+[[files]]
+path = "MLB/MLB_50.csv.bz2"
+blake3 = "633552eccbe6d23c456a42285adbef0aa915a5de0a7dcbfac7d5bdbee56b1942"
+bytes = 3142381
+
+[[files]]
+path = "MLB/MLB_51.csv.bz2"
+blake3 = "633552eccbe6d23c456a42285adbef0aa915a5de0a7dcbfac7d5bdbee56b1942"
+bytes = 3142381
+
+[[files]]
+path = "MLB/MLB_52.csv.bz2"
+blake3 = "d4e428a9a7c8947fe1c3fb9df2587d799dba6f820c35a3e76907b8c1938b9ae2"
+bytes = 33438
+
+[[files]]
+path = "MLB/MLB_53.csv.bz2"
+blake3 = "eeebb285029f26ad4014cbdd0aeb0541e8248e101342e46d77cc543fe1349075"
+bytes = 5310442
+
+[[files]]
+path = "MLB/MLB_54.csv.bz2"
+blake3 = "eeebb285029f26ad4014cbdd0aeb0541e8248e101342e46d77cc543fe1349075"
+bytes = 5310442
+
+[[files]]
+path = "MLB/MLB_55.csv.bz2"
+blake3 = "eeebb285029f26ad4014cbdd0aeb0541e8248e101342e46d77cc543fe1349075"
+bytes = 5310442
+
+[[files]]
+path = "MLB/MLB_56.csv.bz2"
+blake3 = "eeebb285029f26ad4014cbdd0aeb0541e8248e101342e46d77cc543fe1349075"
+bytes = 5310442
+
+[[files]]
+path = "MLB/MLB_57.csv.bz2"
+blake3 = "148c20d6eeb23094261d10be6e8b5c67b9e6e476e2ef21bfd363e40693ed3850"
+bytes = 2480
+
+[[files]]
+path = "MLB/MLB_58.csv.bz2"
+blake3 = "4f38434c4e5271de506f637f956cf73fb287b210f77a4b7310171972d82caf2c"
+bytes = 2084225
+
+[[files]]
+path = "MLB/MLB_59.csv.bz2"
+blake3 = "4f38434c4e5271de506f637f956cf73fb287b210f77a4b7310171972d82caf2c"
+bytes = 2084225
+
+[[files]]
+path = "MLB/MLB_6.csv.bz2"
+blake3 = "1aedf15dc9ee3a7ba0b48ca9b0e61502c402af20159897103ce23842b75cdb2b"
+bytes = 125247900
+
+[[files]]
+path = "MLB/MLB_60.csv.bz2"
+blake3 = "4f38434c4e5271de506f637f956cf73fb287b210f77a4b7310171972d82caf2c"
+bytes = 2084225
+
+[[files]]
+path = "MLB/MLB_61.csv.bz2"
+blake3 = "4f38434c4e5271de506f637f956cf73fb287b210f77a4b7310171972d82caf2c"
+bytes = 2084225
+
+[[files]]
+path = "MLB/MLB_62.csv.bz2"
+blake3 = "4f38434c4e5271de506f637f956cf73fb287b210f77a4b7310171972d82caf2c"
+bytes = 2084225
+
+[[files]]
+path = "MLB/MLB_63.csv.bz2"
+blake3 = "5d0bab3e61700abde1caeb44844ad7e3dfa9db2f6fb7fccb978a93f2816e5395"
+bytes = 22251745
+
+[[files]]
+path = "MLB/MLB_64.csv.bz2"
+blake3 = "c7d80939fb95cba0fd4bbbd71a57b669104d9e8742525425bc4b3fcf67398312"
+bytes = 22290064
+
+[[files]]
+path = "MLB/MLB_65.csv.bz2"
+blake3 = "35c3253c85cc76f5aa7f91e6f83c351955b81779887e901fbd252fc937ce4650"
+bytes = 22276898
+
+[[files]]
+path = "MLB/MLB_66.csv.bz2"
+blake3 = "0e255e6524b606727a566252ef683a20d20032b18695504b31c13a7d230c8c5a"
+bytes = 128282772
+
+[[files]]
+path = "MLB/MLB_67.csv.bz2"
+blake3 = "4563db376dad6f4b0914b74ff6cb15746a4a8b973e1356355414062f88f29c4c"
+bytes = 105392162
+
+[[files]]
+path = "MLB/MLB_68.csv.bz2"
+blake3 = "315fe4db3ac9b43fd355ff2d3061eae211aba3389780122a22d61c563ef81b16"
+bytes = 125264995
+
+[[files]]
+path = "MLB/MLB_7.csv.bz2"
+blake3 = "143913c835d83d7d5a5d49e9090b6486c9df7bcd63710b4567ef15e087c43cce"
+bytes = 4071683
+
+[[files]]
+path = "MLB/MLB_8.csv.bz2"
+blake3 = "66eb660bb10e8b3e530d3560bb572961e27afc6567eae21f483b1d92a70b6642"
+bytes = 4044422
+
+[[files]]
+path = "MLB/MLB_9.csv.bz2"
+blake3 = "75bf5768009452aaed1fb2f5dd80f1902662f6ccd62f314153164707bec27e2f"
+bytes = 4061004
+
+[[files]]
+path = "MedPayment1/MedPayment1_1.csv.bz2"
+blake3 = "36efef347c7094c737a29a0762b497225285b5dead5b7700ce5e498e33fc05dd"
+bytes = 324099266
+
+[[files]]
+path = "MedPayment2/MedPayment2_1.csv.bz2"
+blake3 = "76ce34ffd54c01c128d037d592165364775a7b1cbd6bb8be8002437bcb2d2058"
+bytes = 358574114
+
+[[files]]
+path = "Medicare1/Medicare1_1.csv.bz2"
+blake3 = "ad1d5cd68705ddf857ad64fe83a83d1d708de7f9d02d9a573789f8bad741abab"
+bytes = 360397215
+
+[[files]]
+path = "Medicare1/Medicare1_2.csv.bz2"
+blake3 = "da5b0e43d0dad0f97fa8dc99c8fc5eb0f6f4cad823e14487b3674c429380f1b1"
+bytes = 360650624
+
+[[files]]
+path = "Medicare2/Medicare2_1.csv.bz2"
+blake3 = "c9ec759da7d7a3670ebb59c9fdeebaff66494c3d5c6514de6264f332e5276808"
+bytes = 323112620
+
+[[files]]
+path = "Medicare2/Medicare2_2.csv.bz2"
+blake3 = "7dbb143a1de5bc58a19560a07485188a14dbb0b539035e37cd23f560104ec1e5"
+bytes = 323237525
+
+[[files]]
+path = "Medicare3/Medicare3_1.csv.bz2"
+blake3 = "368e390d1e31ab25e8800f8b6a666cf5d57c1474288251eacee1c502ca7d2a3a"
+bytes = 360515739
+
+[[files]]
+path = "Motos/Motos_1.csv.bz2"
+blake3 = "0b0496a2fab1cb8da5da76a840d8b6d957ca96b9c961f9354b2757860082be56"
+bytes = 398792220
+
+[[files]]
+path = "Motos/Motos_2.csv.bz2"
+blake3 = "ae2ab8e1617af5029c255f4e589e51afbe502839a3ede243213b2b3df2527574"
+bytes = 403047597
+
+[[files]]
+path = "MulheresMil/MulheresMil_1.csv.bz2"
+blake3 = "e7c73854f5b5553841fd22dbeec35b1ce5e71a509bc4bab3a056721f0af74225"
+bytes = 406006611
+
+[[files]]
+path = "NYC/NYC_1.csv.bz2"
+blake3 = "197d6eaf0f80ff2dd4597dee5612431be0237769d7384a6bc817c083ef401fe3"
+bytes = 358999365
+
+[[files]]
+path = "NYC/NYC_2.csv.bz2"
+blake3 = "1914e3f2b7115053ff2ec2f8fa6ad2c55e22d007e36b0dfc931baa564bfc5c9b"
+bytes = 358924812
+
+[[files]]
+path = "PanCreactomy1/PanCreactomy1_1.csv.bz2"
+blake3 = "47e9fa48cfa739cd2118a7dea7049283b6fd1e063f79f8ed367e85236ab6f5a0"
+bytes = 338973914
+
+[[files]]
+path = "PanCreactomy2/PanCreactomy2_1.csv.bz2"
+blake3 = "99ef1a4c8b552b805b130f8486e535ee0f994101e9b9574e7afed15d7542bb39"
+bytes = 338958698
+
+[[files]]
+path = "PanCreactomy2/PanCreactomy2_2.csv.bz2"
+blake3 = "c9ba2f311c37690e1b254c0447f294eb4ea2a4cce678df1abb924ed1e1648a96"
+bytes = 338877143
+
+[[files]]
+path = "Physicians/Physicians_1.csv.bz2"
+blake3 = "0f141192615f17ebd5e397c7b3a86732157754ec11ef3069efa70da55458f1da"
+bytes = 323986936
+
+[[files]]
+path = "Provider/Provider_1.csv.bz2"
+blake3 = "0f2217a36e3eba9430efb3ca588abf93042e8f4f5ec87f97c1ed24ac78f91447"
+bytes = 323342180
+
+[[files]]
+path = "Provider/Provider_2.csv.bz2"
+blake3 = "da8775fd2c2f54c862a010752f59891acd4c27c57a6426b9b409d5a96007b850"
+bytes = 323006755
+
+[[files]]
+path = "Provider/Provider_3.csv.bz2"
+blake3 = "008abd1f9dece271982517f43ef7af24418b9c1ccb7ce6eaa3477f1983e3025e"
+bytes = 323002782
+
+[[files]]
+path = "Provider/Provider_4.csv.bz2"
+blake3 = "9f05fe059dd7a811f3a06538a1490884751c7694298d141e69e9f4ebb692c47e"
+bytes = 323237841
+
+[[files]]
+path = "Provider/Provider_5.csv.bz2"
+blake3 = "f55bd484b29b0624258463c976506b123cdcb35e2f55c5bc95b2c3a5d3021a60"
+bytes = 323200336
+
+[[files]]
+path = "Provider/Provider_6.csv.bz2"
+blake3 = "3390ca207923579153c2ca95b89405237ac666fb13da39f6b962dc4ff3f8a830"
+bytes = 323269696
+
+[[files]]
+path = "Provider/Provider_7.csv.bz2"
+blake3 = "82936978c405fdfc0e20d92676510a62aa0b51c56fb4e7b9e59cb85c0f753cf4"
+bytes = 323511268
+
+[[files]]
+path = "Provider/Provider_8.csv.bz2"
+blake3 = "81100699fb519abf10e8d232e32d9d2f4f155e32bcf59b0d9561b6d92d9a867c"
+bytes = 323228400
+
+[[files]]
+path = "RealEstate1/RealEstate1_1.csv.bz2"
+blake3 = "1e79cddfc4ea35b55d3187f12c2441d0b5a2996417ca9bc76fb52d92cd2927b4"
+bytes = 1112896530
+
+[[files]]
+path = "RealEstate1/RealEstate1_2.csv.bz2"
+blake3 = "62a7bc3536726426eb82ffa2e30e5530f087718ce7b2e23ba3d8863734098ca4"
+bytes = 1112999474
+
+[[files]]
+path = "RealEstate2/RealEstate2_1.csv.bz2"
+blake3 = "3a835d1208db6c126b3ae32655fadc242399c18669cc4374538f013f96150aec"
+bytes = 680226560
+
+[[files]]
+path = "RealEstate2/RealEstate2_2.csv.bz2"
+blake3 = "2c03af8c847273d186fe0e84f598b0353a4dda56310444a8efd0af71c6589809"
+bytes = 680171248
+
+[[files]]
+path = "RealEstate2/RealEstate2_3.csv.bz2"
+blake3 = "1d6df2aec3746d134f795d90640c0d97b2fe63c3afa6e5dd1a824a3499179e6d"
+bytes = 680292376
+
+[[files]]
+path = "RealEstate2/RealEstate2_4.csv.bz2"
+blake3 = "65f7eb78dc81db9e38739a9b5ec1f0fd111d0dd16f14029865f529d1babe93f5"
+bytes = 680339517
+
+[[files]]
+path = "RealEstate2/RealEstate2_5.csv.bz2"
+blake3 = "f08e5edca69598adc844086c4dee21240a1b2d683c6128aec6c2f128ffb45a70"
+bytes = 680215180
+
+[[files]]
+path = "RealEstate2/RealEstate2_6.csv.bz2"
+blake3 = "938fa4767d1afd26caa108e3f171b8ba1af05c98101f424d8c3591c229da6d58"
+bytes = 680138679
+
+[[files]]
+path = "RealEstate2/RealEstate2_7.csv.bz2"
+blake3 = "99e7021758d78ea205a01cfbeafa36af20c7b21198d8356ffe3a09f88ebbbfff"
+bytes = 680188446
+
+[[files]]
+path = "Redfin1/Redfin1_1.csv.bz2"
+blake3 = "cfa31d04ef3bbd21d6c350f65f414f095ed280cb47ca7653aded8df31791f538"
+bytes = 369564432
+
+[[files]]
+path = "Redfin1/Redfin1_2.csv.bz2"
+blake3 = "992514caf7236c8197024023c5a7ad7defb88f72b5dbcc1eedf0c9985b3e8a29"
+bytes = 369475706
+
+[[files]]
+path = "Redfin1/Redfin1_3.csv.bz2"
+blake3 = "062786df96fbb170d7a8ac6e1c7d9b838a9afca490e627fed342fb2f90247677"
+bytes = 369567690
+
+[[files]]
+path = "Redfin1/Redfin1_4.csv.bz2"
+blake3 = "d051529948af0ec016c2ee8b182f55c6fc1516cf340fca6eba41fadb430fa951"
+bytes = 369581961
+
+[[files]]
+path = "Redfin2/Redfin2_1.csv.bz2"
+blake3 = "c75277587b0f2666d35cef52d88571c00a678976bf1c92ccfedb31d422022c86"
+bytes = 369547968
+
+[[files]]
+path = "Redfin2/Redfin2_2.csv.bz2"
+blake3 = "5c0001eeb43a698269dbecd8bd51500bf13ddf8c05e68f3cae58d9d334dfdb70"
+bytes = 369565172
+
+[[files]]
+path = "Redfin2/Redfin2_3.csv.bz2"
+blake3 = "fff495bfde0e4a1760010416d4f6b07dab8daa6a2c0fccf74f93934ffe63a20c"
+bytes = 369532045
+
+[[files]]
+path = "Redfin3/Redfin3_1.csv.bz2"
+blake3 = "8677a5ed4dbb6f313c18c7ad79aa428eb8b410ae4786c41386b761e5072a07d2"
+bytes = 401428879
+
+[[files]]
+path = "Redfin3/Redfin3_2.csv.bz2"
+blake3 = "d35f172351a4b85500065487cc5a09d06379caddf98988ff7d41dbffd8ebf42a"
+bytes = 401445727
+
+[[files]]
+path = "Redfin4/Redfin4_1.csv.bz2"
+blake3 = "77458003461f1f3b21a5ec82cb5cfec50a8b5e935ad3ea2fd82a994885ae3f0c"
+bytes = 413467463
+
+[[files]]
+path = "Rentabilidad/Rentabilidad_1.csv.bz2"
+blake3 = "ccc3e367c0178507c37baed0e1dcf71609c81a8b0f8a9aa2ff1c53a8971f6b5a"
+bytes = 74010404
+
+[[files]]
+path = "Rentabilidad/Rentabilidad_2.csv.bz2"
+blake3 = "d26e3cd4c5125118074b2b7b6e116d1d651cc54e91a24e911a406f303ba8c6c7"
+bytes = 74185498
+
+[[files]]
+path = "Rentabilidad/Rentabilidad_3.csv.bz2"
+blake3 = "c13562040afa629b9f429756ac8b60558c7f35ef1ced5787ac5c5e34b010ca74"
+bytes = 74068667
+
+[[files]]
+path = "Rentabilidad/Rentabilidad_4.csv.bz2"
+blake3 = "1653ec5045b9ee06f7bf675f2be65c354e3b914e3991448217207d2cb4c96aa4"
+bytes = 74076010
+
+[[files]]
+path = "Rentabilidad/Rentabilidad_5.csv.bz2"
+blake3 = "5ba630337fa71da40d36573ba5d4707fe4c5c357339a7d0ecbf5b65aafd84320"
+bytes = 74002598
+
+[[files]]
+path = "Rentabilidad/Rentabilidad_6.csv.bz2"
+blake3 = "cdee349ce2a7baf8e19990347d0e262c27420f2f569a5e52b8e0e0f93051040e"
+bytes = 74044412
+
+[[files]]
+path = "Rentabilidad/Rentabilidad_7.csv.bz2"
+blake3 = "04845810650b7bfb0df28a0afef4969b660ecac3f7a4e2e635a29397100bf315"
+bytes = 74054565
+
+[[files]]
+path = "Rentabilidad/Rentabilidad_8.csv.bz2"
+blake3 = "cbf490e746c87593d05928d889c6335fa7f6b85ac5d7b2e046419038d54a4d05"
+bytes = 74021821
+
+[[files]]
+path = "Rentabilidad/Rentabilidad_9.csv.bz2"
+blake3 = "33ba7e575671fffb7974f681395c20ec7e08f60b3ce4725c858b0196aa60e021"
+bytes = 74010482
+
+[[files]]
+path = "Romance/Romance_1.csv.bz2"
+blake3 = "9feec1328260bfc822d5d57276e80d6b19e802e72b840e53d885a92180fbcf58"
+bytes = 134950511
+
+[[files]]
+path = "Romance/Romance_2.csv.bz2"
+blake3 = "f83e619508e325444d086e63539ee795a505340e84997e8faa0c955a4361376e"
+bytes = 135009422
+
+[[files]]
+path = "SalariesFrance/SalariesFrance_1.csv.bz2"
+blake3 = "9cfde096030132e4c17c73ac4202d0849123d0d30a75e28162f19e9fa8b82f88"
+bytes = 194093473
+
+[[files]]
+path = "SalariesFrance/SalariesFrance_10.csv.bz2"
+blake3 = "dea4310181d8779e457636634a3805adbbea3a0422bd5f6c0d22b8513aea7c43"
+bytes = 194161572
+
+[[files]]
+path = "SalariesFrance/SalariesFrance_11.csv.bz2"
+blake3 = "9fd942897718195fd9bd7ccd1b64d48f4243780dde5bfaef7d0d559c6cc57029"
+bytes = 194179494
+
+[[files]]
+path = "SalariesFrance/SalariesFrance_12.csv.bz2"
+blake3 = "f4f86b80e94e9e7fa9a24946d39844f8da6c3d16ed8456329a87269d16285890"
+bytes = 194197469
+
+[[files]]
+path = "SalariesFrance/SalariesFrance_13.csv.bz2"
+blake3 = "62544167c2039f15a17cf10b1eaed38ebebced76966f0cf4dc7d064f492279ef"
+bytes = 194157453
+
+[[files]]
+path = "SalariesFrance/SalariesFrance_2.csv.bz2"
+blake3 = "d14cbcc86d9903ec677db2a36c7b965a6d0039d62e7f383c5d98817a46c82505"
+bytes = 1094613
+
+[[files]]
+path = "SalariesFrance/SalariesFrance_3.csv.bz2"
+blake3 = "70e70fc60c1f94fc4134972db69f1fcb29c9263c3766d6b14888ea6ec6273fad"
+bytes = 194151519
+
+[[files]]
+path = "SalariesFrance/SalariesFrance_4.csv.bz2"
+blake3 = "835daefcefecad5aaa7d7ed944a4199d4acbe30584acab149451fe39f9f90598"
+bytes = 194169234
+
+[[files]]
+path = "SalariesFrance/SalariesFrance_5.csv.bz2"
+blake3 = "8fc2a0e391cdd75819a4ca375ca562e5ef3f8be3828f14e3a1c81da2a8e6cf26"
+bytes = 194146060
+
+[[files]]
+path = "SalariesFrance/SalariesFrance_6.csv.bz2"
+blake3 = "6ea7bec5a030fb36f615112b55d8a3c87c90e0aabd0d816ca7825779f5184efc"
+bytes = 194066744
+
+[[files]]
+path = "SalariesFrance/SalariesFrance_7.csv.bz2"
+blake3 = "bc8c6a7dffb651c14d9d758abdc17c3f17b36eae00c53f302b6364de99f2b7c6"
+bytes = 194126899
+
+[[files]]
+path = "SalariesFrance/SalariesFrance_8.csv.bz2"
+blake3 = "6241ef5dc3683c1e4e053eda8f0e80439ddd0d59251ed692e5a3e3e2096bf21e"
+bytes = 194207757
+
+[[files]]
+path = "SalariesFrance/SalariesFrance_9.csv.bz2"
+blake3 = "e5a57b047d55eefdf2068788c9602230fa6fa44ca8ae56d0a375ab21687f18c2"
+bytes = 194136614
+
+[[files]]
+path = "TableroSistemaPenal/TableroSistemaPenal_1.csv.bz2"
+blake3 = "94478bc1f15bd34d6782b4d8fda2fcbfd77f7aba7e88462bd8b0680b94e20b13"
+bytes = 17463053
+
+[[files]]
+path = "TableroSistemaPenal/TableroSistemaPenal_2.csv.bz2"
+blake3 = "18da94853346a7f495ead7e2035ed0c715818544bcf50437c3d7c7427b2f4bea"
+bytes = 33208524
+
+[[files]]
+path = "TableroSistemaPenal/TableroSistemaPenal_3.csv.bz2"
+blake3 = "d87a39fb000498b4f4694b70dfdc145ebb5c01033af4ebcdd4b4c8594d987a5b"
+bytes = 35405375
+
+[[files]]
+path = "TableroSistemaPenal/TableroSistemaPenal_4.csv.bz2"
+blake3 = "78dd09cb9b9dfcbbc4366ce458a28a3816d3038117a955fb974036d3c567d80a"
+bytes = 35406383
+
+[[files]]
+path = "TableroSistemaPenal/TableroSistemaPenal_5.csv.bz2"
+blake3 = "4e23fdab790126eba1364d48a8c3b81f869584d526aca3669ed3bc908968d49a"
+bytes = 35404151
+
+[[files]]
+path = "TableroSistemaPenal/TableroSistemaPenal_6.csv.bz2"
+blake3 = "711b9f04e24455e4133047f2124004d847918bb486e480739e6e89f272b52ede"
+bytes = 61841763
+
+[[files]]
+path = "TableroSistemaPenal/TableroSistemaPenal_7.csv.bz2"
+blake3 = "c6feec4b25767ecb9e102442fc67b5eaa73c147982ab4f2b9e899a49f859572b"
+bytes = 17463717
+
+[[files]]
+path = "TableroSistemaPenal/TableroSistemaPenal_8.csv.bz2"
+blake3 = "f88f4e2019dc46552306d596ca3cfc6ef48a37c0408e92b6be450099602ea993"
+bytes = 35143625
+
+[[files]]
+path = "Taxpayer/Taxpayer_1.csv.bz2"
+blake3 = "10ef09b3c3dc3826a0239a42854c825281e556b67f743c1e6c7eec6d802cc9e5"
+bytes = 323177199
+
+[[files]]
+path = "Taxpayer/Taxpayer_10.csv.bz2"
+blake3 = "7a5c9c76e7df71dbc728f37603a3eba93390a08402b6f871f75411da78ca45b0"
+bytes = 323302769
+
+[[files]]
+path = "Taxpayer/Taxpayer_2.csv.bz2"
+blake3 = "fef9fdc952569b96f2021dc90f2d8060b42efa262019064cdedd7be3f4201caa"
+bytes = 323071280
+
+[[files]]
+path = "Taxpayer/Taxpayer_3.csv.bz2"
+blake3 = "99863a33ab891cc83303c23989674e37a70b3e5065053564e9eed283eedc9ccf"
+bytes = 323012542
+
+[[files]]
+path = "Taxpayer/Taxpayer_4.csv.bz2"
+blake3 = "096c66ab7b11102ed168ac476415f50f69941238b351abb39dd033797bcf39fb"
+bytes = 323242836
+
+[[files]]
+path = "Taxpayer/Taxpayer_5.csv.bz2"
+blake3 = "0705dae4bea4dc0cb76900c1d79fa3465e856432ac3fdcac9eb4598dd298fe35"
+bytes = 323223574
+
+[[files]]
+path = "Taxpayer/Taxpayer_6.csv.bz2"
+blake3 = "d63d918bfa2748f531926dbc70eee044033d32d4eb3d1e3444a9cfa9bac22824"
+bytes = 323404927
+
+[[files]]
+path = "Taxpayer/Taxpayer_7.csv.bz2"
+blake3 = "b05d406164f5c1ecf8006218a91b3fe10526da26f01b970471e9c1141a3d8678"
+bytes = 323243179
+
+[[files]]
+path = "Taxpayer/Taxpayer_8.csv.bz2"
+blake3 = "ed148814c555bc21ef66308abb3321e3ccbf533704c3105ce1b9188d5604dfd1"
+bytes = 323144015
+
+[[files]]
+path = "Taxpayer/Taxpayer_9.csv.bz2"
+blake3 = "cf8fab0a87bf0b8b4b1caed584b54d66e705316d93a495eb228c9634236b4794"
+bytes = 323066424
+
+[[files]]
+path = "Telco/Telco_1.csv.bz2"
+blake3 = "9f8038dba2dbe790f78c5eb95849a5e926e333bfd93c5b1f4b73e4d3ef886280"
+bytes = 726757905
+
+[[files]]
+path = "TrainsUK1/TrainsUK1_1.csv.bz2"
+blake3 = "062df480633be4b8f3a4e08dcff744ef81e9b0b34e4be81e387d7317eebfdbe4"
+bytes = 51
+
+[[files]]
+path = "TrainsUK1/TrainsUK1_2.csv.bz2"
+blake3 = "f4c7926653c5da92430519686fd2033607299b4a5cab29c172a0a0d87cab85b8"
+bytes = 175555047
+
+[[files]]
+path = "TrainsUK1/TrainsUK1_3.csv.bz2"
+blake3 = "4abff0f88f1582812eef67f2737a3ff66dbc0a5704c2a621e1ac340555d43e5d"
+bytes = 175757838
+
+[[files]]
+path = "TrainsUK1/TrainsUK1_4.csv.bz2"
+blake3 = "1b55cab94bdf53367eb9067dacbd591fe249b8873f395379dbfa71ba10db32db"
+bytes = 175586745
+
+[[files]]
+path = "TrainsUK2/TrainsUK2_1.csv.bz2"
+blake3 = "d8c34aadb46591507526519ba72bdceb3905c0f699aef3618b9b97899f41d894"
+bytes = 568463724
+
+[[files]]
+path = "TrainsUK2/TrainsUK2_2.csv.bz2"
+blake3 = "0a45c27c406566fdaced9f953bcb0c3a3beab26f3730e595822dd867f73e7778"
+bytes = 568222095
+
+[[files]]
+path = "USCensus/USCensus_1.csv.bz2"
+blake3 = "acafdd3c7b5a8a591517798afcaa6c99027c266f8868abcba74e2c6593362347"
+bytes = 768182889
+
+[[files]]
+path = "USCensus/USCensus_2.csv.bz2"
+blake3 = "2039049d90b8935052b0e7d4addf78f317cf895c8ebefe43f54d5a62742ddbf4"
+bytes = 768050239
+
+[[files]]
+path = "USCensus/USCensus_3.csv.bz2"
+blake3 = "1aa8d606e6e110b9636c321b23a16a3468b217f7892dac5078de8076c7d13ab6"
+bytes = 768045771
+
+[[files]]
+path = "Uberlandia/Uberlandia_1.csv.bz2"
+blake3 = "1a5690988afd745c78cbf74f4ada9d614a5e1d1e1c8943d5a07712362ac7c86a"
+bytes = 405669478
+
+[[files]]
+path = "Wins/Wins_1.csv.bz2"
+blake3 = "b9800987062a7ce9628c9cfe94842fbc9b2f277a516ab32cbc1db715314ff390"
+bytes = 131362720
+
+[[files]]
+path = "Wins/Wins_2.csv.bz2"
+blake3 = "486a6f79a303fc0be0915d239ec148c3f3028c2ff1c27f71954107cba4abf121"
+bytes = 189996123
+
+[[files]]
+path = "Wins/Wins_3.csv.bz2"
+blake3 = "d579076eeb597a48dc9d256bf6bb6a3b5de9e181aac73317ab45da320f507ea1"
+bytes = 190065449
+
+[[files]]
+path = "Wins/Wins_4.csv.bz2"
+blake3 = "f30f615e0a1060a9ccfcd8dda15d87a9b240af93cecb42599f69d605076013ec"
+bytes = 190096489
+
+[[files]]
+path = "YaleLanguages/YaleLanguages_1.csv.bz2"
+blake3 = "f4fd638205dca30417a02402928c4abfe7200cb8bf05be5edcaac84c2b292756"
+bytes = 12421515
+
+[[files]]
+path = "YaleLanguages/YaleLanguages_2.csv.bz2"
+blake3 = "243a5152ae91caede55ef8492da44eae92d23de48ecd02f4ef96eca01ffc3a6a"
+bytes = 12424548
+
+[[files]]
+path = "YaleLanguages/YaleLanguages_3.csv.bz2"
+blake3 = "fd0eb6cf570092257c60e37fbcf70850e4d3c8434145284d1a46e00f4e3b7fa6"
+bytes = 20565528
+
+[[files]]
+path = "YaleLanguages/YaleLanguages_4.csv.bz2"
+blake3 = "f82fab24949bfbd2e19eecf628dc15bf34befb090103e75cd30cad37037d1abc"
+bytes = 18736764
+
+[[files]]
+path = "YaleLanguages/YaleLanguages_5.csv.bz2"
+blake3 = "ce2495b786bd1ee9ecfbc01c3a2eee2c96887f77f318a5f796d965a5f951554c"
+bytes = 18731853

--- a/crates/bench-cli/src/corpus.rs
+++ b/crates/bench-cli/src/corpus.rs
@@ -63,6 +63,10 @@ pub(crate) fn run(
         if manifest.files.len() == 1 { "" } else { "s" }
     );
     println!("  from {}", manifest.corpus.source);
+    // The one value that says which corpus this is, contents and all. Printed before anything is
+    // fetched, because it is a property of the manifest rather than of the run, and it is what a
+    // result row carries so that "Public BI" in a table means one determinable set of tables.
+    println!("  is {}", manifest.identity());
 
     let store = Store::open(store.unwrap_or_else(|| PathBuf::from(DEFAULT_STORE)))
         .context("opening the corpus store")?;
@@ -107,6 +111,16 @@ pub(crate) fn run(
             } else {
                 ""
             }
+        );
+    }
+    // A corpus of two hundred files prints two hundred lines, and the thing somebody wants off the
+    // end of that is how much of it was already here.
+    let had = arrived.iter().filter(|file| file.deduplicated).count();
+    if arrived.len() > 1 {
+        println!(
+            "  {} of {} files were already in the store",
+            had,
+            arrived.len()
         );
     }
     println!();

--- a/crates/bench-corpus/src/manifest.rs
+++ b/crates/bench-corpus/src/manifest.rs
@@ -50,6 +50,9 @@ pub struct Corpus {
     /// What permits redistribution, which only a mirrored corpus needs and must have.
     #[serde(default)]
     pub licence_note: Option<String>,
+    /// The corpus this one is a selection from, for a corpus published in more than one part.
+    #[serde(default)]
+    pub part_of: Option<String>,
 }
 
 /// How this repository handles a corpus, per `docs/LICENSING.md`.
@@ -229,6 +232,59 @@ impl Manifest {
         Ok(manifest)
     }
 
+    /// The one digest that names this exact corpus, contents and all.
+    ///
+    /// Public BI is why this exists. The benchmark is published as 206 tables and much of the
+    /// encoding literature measures a 36 table subset, so a result labelled Public BI is ambiguous
+    /// about which Public BI, and a result labelled with the subset is ambiguous about which 36.
+    /// This is a single value that answers both, small enough to sit in a result row next to the
+    /// name and specific enough that no two selections share one.
+    ///
+    /// Taken over the name and then every entry's path, digest and size, sorted by path, so it does
+    /// not move when entries are reordered in the file and does move when any byte of the corpus
+    /// does. Deliberately not the digest of the manifest text: a comment rewritten is not a
+    /// different corpus, and a result row that changed because somebody fixed a typo would teach
+    /// everybody to ignore the field.
+    #[must_use]
+    pub fn identity(&self) -> Digest {
+        let mut entries: Vec<&Entry> = self.files.iter().collect();
+        entries.sort_by(|left, right| left.path.cmp(&right.path));
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(self.corpus.name.as_bytes());
+        hasher.update(b"\n");
+        for entry in entries {
+            hasher.update(entry.path.as_bytes());
+            hasher.update(b" ");
+            hasher.update(entry.blake3.to_hex().as_bytes());
+            hasher.update(b" ");
+            hasher.update(entry.bytes.to_string().as_bytes());
+            hasher.update(b"\n");
+        }
+        Digest::from_bytes(*hasher.finalize().as_bytes())
+    }
+
+    /// Whether this corpus really is a selection from the one it says it is part of.
+    ///
+    /// A subset is only worth naming if it is provably a subset. Public BI is published as 206
+    /// tables and much of the encoding literature measures 36 of them, and a 36 that has quietly
+    /// drifted from the 206 it names is worse than no subset at all, because every number labelled
+    /// with it is then about something nobody can reconstruct.
+    ///
+    /// Each entry has to be in the whole at the same path with the same digest and the same size,
+    /// and the part has to be smaller. Names are not compared here, so this answers the question
+    /// about the bytes and `part_of` answers the one about intent.
+    #[must_use]
+    pub fn is_part_of(&self, whole: &Self) -> bool {
+        self.files.len() < whole.files.len()
+            && self.files.iter().all(|entry| {
+                whole.files.iter().any(|held| {
+                    held.path == entry.path
+                        && held.blake3 == entry.blake3
+                        && held.bytes == entry.bytes
+                })
+            })
+    }
+
     /// Checks everything about a manifest that parsing does not.
     ///
     /// Parsing gets the shape right. This gets the meaning right, and the difference is that a
@@ -273,6 +329,20 @@ impl Manifest {
             return Err(invalid(
                 "mirrored without a licence note saying what permits it".to_owned(),
             ));
+        }
+
+        // Whether the entries really are a subset needs the other manifest and is checked where
+        // both are in hand, by `ci/discipline.py` over the tree and by `Self::is_part_of` at run
+        // time. What can be settled from one manifest alone is that the claim is not circular.
+        if let Some(whole) = self.corpus.part_of.as_ref() {
+            if whole.trim().is_empty() {
+                return Err(invalid(
+                    "says it is part of a corpus with no name".to_owned(),
+                ));
+            }
+            if whole == &self.corpus.name {
+                return Err(invalid("says it is part of itself".to_owned()));
+            }
         }
 
         // A generated corpus says what produces it and every other kind says where it is downloaded
@@ -433,6 +503,78 @@ mod tests {
             Manifest::parse(&text).unwrap().corpus.category,
             Category::Mirror
         );
+    }
+
+    /// A second file, so identity has something to be order independent about.
+    const SECOND: &str = "\n[[files]]\npath = \"other.parquet\"\nblake3 = \
+                          \"af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3263\"\n\
+                          bytes = 2048\n";
+
+    #[test]
+    fn the_identity_does_not_move_when_entries_are_reordered() {
+        let one = format!("{}{SECOND}", manifest(""));
+        let two = {
+            let base = manifest("");
+            let (head, files) = base.split_at(base.find("[[files]]").unwrap());
+            format!("{head}{}\n{files}", SECOND.trim_start())
+        };
+        assert_eq!(
+            Manifest::parse(&one).unwrap().identity(),
+            Manifest::parse(&two).unwrap().identity()
+        );
+    }
+
+    #[test]
+    fn the_identity_moves_when_the_corpus_does() {
+        let base = Manifest::parse(&manifest("")).unwrap().identity();
+        let more = Manifest::parse(&format!("{}{SECOND}", manifest("")))
+            .unwrap()
+            .identity();
+        assert_ne!(base, more);
+
+        // A different corpus made of the same bytes is a different corpus, because a result row
+        // carrying only the identity still has to say which selection it was.
+        let mut parsed = Manifest::parse(&manifest("")).unwrap();
+        parsed.corpus.name = "example-36".to_owned();
+        assert_ne!(parsed.identity(), base);
+    }
+
+    #[test]
+    fn the_identity_does_not_move_when_a_comment_does() {
+        // Deliberate. A rewritten comment is not a different corpus, and an identity that changed
+        // for one would teach everybody to ignore the field.
+        let commented = format!("# a note somebody added later\n{}", manifest(""));
+        assert_eq!(
+            Manifest::parse(&commented).unwrap().identity(),
+            Manifest::parse(&manifest("")).unwrap().identity()
+        );
+    }
+
+    #[test]
+    fn a_corpus_that_says_it_is_part_of_itself_is_refused() {
+        let text = manifest("part_of = \"example\"");
+        let error = Manifest::parse(&text).unwrap_err();
+        assert!(format!("{error}").contains("part of itself"));
+    }
+
+    #[test]
+    fn a_part_has_to_be_some_of_the_whole_and_not_just_smaller() {
+        let whole = Manifest::parse(&format!("{}{SECOND}", manifest(""))).unwrap();
+        let part = Manifest::parse(&manifest("part_of = \"bigger\"")).unwrap();
+        assert!(part.is_part_of(&whole));
+
+        // Same path, different bytes. This is the drift the check exists for, and it is the one
+        // that looks fine in a diff because the path is what a reader compares.
+        let moved =
+            Manifest::parse(&manifest("part_of = \"bigger\"").replace("1024", "2048")).unwrap();
+        assert!(!moved.is_part_of(&whole));
+    }
+
+    #[test]
+    fn a_part_the_same_size_as_the_whole_is_not_a_part() {
+        let whole = Manifest::parse(&manifest("")).unwrap();
+        let part = Manifest::parse(&manifest("part_of = \"bigger\"")).unwrap();
+        assert!(!part.is_part_of(&whole));
     }
 
     /// A generate manifest, which needs a different source and a generator to go with it.

--- a/crates/bench-report/src/lib.rs
+++ b/crates/bench-report/src/lib.rs
@@ -5,16 +5,22 @@
 //! no measurable difference. A geometric mean never appears without its per
 //! query table on the same page. Failed queries are shown rather than dropped.
 //!
-//! What is implemented so far is the wording rules for workloads derived from a
-//! specification somebody else owns, which `docs/LICENSING.md` states in prose
-//! and [`tpc`] states as code. Those came first because they are the rules where
-//! getting it wrong is not a rendering bug. The rest is the milestone that owns
-//! this crate in `docs/ROADMAP.md`.
+//! What is implemented so far is the naming rules, which `docs/LICENSING.md`
+//! states in prose and [`tpc`] and [`selection`] state as code. Those came first
+//! because they are the rules where getting it wrong is not a rendering bug. The
+//! rest is the milestone that owns this crate in `docs/ROADMAP.md`.
+//!
+//! [`tpc`] covers workloads derived from a specification somebody else owns.
+//! [`selection`] covers corpora published in more than one part, where two
+//! numbers can both be honestly labelled with the benchmark name and mean
+//! different things.
 
 pub mod page;
+pub mod selection;
 pub mod tpc;
 
 pub use page::{Page, Row};
+pub use selection::Selection;
 pub use tpc::{Cited, Family, WordingError};
 
 /// The version of this crate, as reported by build metadata.

--- a/crates/bench-report/src/page.rs
+++ b/crates/bench-report/src/page.rs
@@ -12,6 +12,7 @@
 
 use std::fmt::Write as _;
 
+use crate::selection::Selection;
 use crate::tpc::{self, Cited, Family, WordingError};
 
 /// One measurement on a page.
@@ -25,6 +26,8 @@ pub struct Row {
     pub value: String,
     /// Which family the workload belongs to, worked out from its name rather than declared.
     family: Family,
+    /// Which part of its corpus it was measured over, for the corpora that have parts.
+    selection: Selection,
     /// Where the number came from, when it is not one of ours.
     origin: Option<String>,
 }
@@ -43,11 +46,13 @@ impl Row {
     ) -> Result<Self, WordingError> {
         let workload = workload.into();
         let family = tpc::check(&workload)?;
+        let selection = Selection::of(&workload);
         Ok(Self {
             workload,
             system: system.into(),
             value: value.into(),
             family,
+            selection,
             origin: None,
         })
     }
@@ -72,11 +77,13 @@ impl Row {
                 return Err(WordingError::OfficialTpcResult { workload, origin });
             }
         };
+        let selection = Selection::of(&workload);
         Ok(Self {
             workload,
             system: system.into(),
             value: value.into(),
             family,
+            selection,
             origin: Some(origin),
         })
     }
@@ -104,11 +111,22 @@ impl Row {
     }
 
     /// How this row's workload is named in output.
+    ///
+    /// Whatever qualifies the workload is inside the name rather than beside it. A TPC workload is
+    /// named as derived from its specification and a corpus that comes in parts is named with the
+    /// part, so a name lifted out of this table and pasted somewhere else takes its qualifiers
+    /// along. That is the failure the qualifiers exist to prevent, and a column heading does not
+    /// survive being quoted.
     #[must_use]
     pub fn label(&self) -> String {
-        match self.family.label() {
-            "" => self.workload.clone(),
-            qualified => format!("{} ({qualified})", self.workload),
+        let qualifiers: Vec<&str> = [self.family.label(), self.selection.label()]
+            .into_iter()
+            .filter(|part| !part.is_empty())
+            .collect();
+        if qualifiers.is_empty() {
+            self.workload.clone()
+        } else {
+            format!("{} ({})", self.workload, qualifiers.join(", "))
         }
     }
 }
@@ -138,6 +156,9 @@ impl Page {
     }
 
     /// Every notice this page's rows require, once each and in a stable order.
+    ///
+    /// Gathered from the rows rather than set on the page, so a notice is a consequence of what is
+    /// on the page instead of something whoever built it had to think of.
     #[must_use]
     pub fn notices(&self) -> Vec<&'static str> {
         let mut notices: Vec<&'static str> = Vec::new();
@@ -148,7 +169,25 @@ impl Page {
                 notices.push(notice);
             }
         }
+        if self.mixes_parts() {
+            notices.push(Selection::mixed_notice());
+        }
         notices
+    }
+
+    /// Whether two rows here were measured over different parts of the same corpus.
+    ///
+    /// A compression ratio over the Public BI subset and one over the full set can sit next to each
+    /// other legitimately, and a reader will still read the pair as a comparison unless told
+    /// otherwise. So they are allowed on one page and the page says what they are.
+    fn mixes_parts(&self) -> bool {
+        self.rows.iter().any(|row| {
+            row.selection.corpus().is_some_and(|corpus| {
+                self.rows.iter().any(|other| {
+                    other.selection.corpus() == Some(corpus) && other.selection != row.selection
+                })
+            })
+        })
     }
 
     /// The page as text, with its notices under it.
@@ -182,6 +221,38 @@ impl Page {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn a_public_bi_row_says_which_public_bi_it_is() {
+        let row = Row::measured("public-bi-36", "iris", "4.1x").unwrap();
+        assert_eq!(row.label(), "public-bi-36 (36 table subset)");
+        let whole = Row::measured("public-bi", "iris", "3.8x").unwrap();
+        assert_eq!(whole.label(), "public-bi (all 206 tables)");
+    }
+
+    #[test]
+    fn a_page_holding_both_parts_says_they_are_not_comparable() {
+        let mut page = Page::new("Compression ratio");
+        page.push(Row::measured("public-bi", "iris", "3.8x").unwrap());
+        page.push(Row::measured("public-bi-36", "iris", "4.1x").unwrap());
+        assert!(page.render().contains("not comparable"));
+    }
+
+    #[test]
+    fn a_page_holding_one_part_twice_says_nothing_extra() {
+        let mut page = Page::new("Compression ratio");
+        page.push(Row::measured("public-bi-36", "iris", "4.1x").unwrap());
+        page.push(Row::measured("public-bi-36", "parquet", "2.9x").unwrap());
+        assert!(page.notices().is_empty());
+    }
+
+    #[test]
+    fn a_row_can_carry_a_family_and_a_part_at_once() {
+        // Neither qualifier is allowed to displace the other, because each of them is the answer to
+        // a different question a reader would otherwise get wrong.
+        let row = Row::measured("tpch-sf20", "iris", "1.1 GB/s").unwrap();
+        assert!(row.label().contains("derived from TPC-H"));
+    }
 
     #[test]
     fn a_page_carrying_a_tpc_number_carries_the_notice() {

--- a/crates/bench-report/src/selection.rs
+++ b/crates/bench-report/src/selection.rs
@@ -1,0 +1,168 @@
+//! Which part of a corpus a number was taken from, for the corpora that come in more than one.
+//!
+//! Public BI is the case this exists for. The full benchmark is 206 tables and much of the encoding
+//! literature measures a 36 table subset, so two numbers can both be honestly labelled Public BI
+//! and mean different things. A compression ratio over the subset is not a compression ratio over
+//! the full set, and the gap between them is large enough to reverse an ordering.
+//!
+//! So a row never says only Public BI. [`Selection::of`] reads which part from the workload
+//! identifier, [`Selection::label`] is the only name available and it always names the part, and a
+//! page carrying rows from two parts of one corpus says in as many words that they are not
+//! comparable. None of that depends on whoever writes the page knowing about any of it.
+
+/// Which part of a corpus that is published in more than one part a number came from.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Selection {
+    /// The whole of a corpus that also has a named part in circulation.
+    Whole {
+        /// The corpus, as it is written when the part is not being named.
+        corpus: &'static str,
+        /// How many members the whole has, which is the thing that distinguishes it.
+        members: &'static str,
+    },
+    /// A named part of such a corpus.
+    Part {
+        /// The corpus the part belongs to, which is what makes two parts comparable or not.
+        corpus: &'static str,
+        /// The part, named the way it is named in the work that uses it.
+        name: &'static str,
+    },
+    /// A corpus that is not published in parts, which is nearly all of them.
+    Undivided,
+}
+
+/// The notice a page carrying two parts of one corpus has to print.
+const MIXED_NOTICE: &str = "This page carries numbers from more than one part of the same corpus. \
+                            They are not comparable with each other, because they were measured \
+                            over different data, and no row here is a comparison against another.";
+
+impl Selection {
+    /// Which part a workload identifier names.
+    ///
+    /// Read from the identifier rather than declared beside it, for the same reason the TPC family
+    /// is. A declaration is a thing somebody has to remember, and the case worth catching is the
+    /// one where a number was labelled in a hurry.
+    #[must_use]
+    pub fn of(workload: &str) -> Self {
+        let squashed: String = workload
+            .chars()
+            .filter(char::is_ascii_alphanumeric)
+            .flat_map(char::to_lowercase)
+            .collect();
+        if !squashed.starts_with("publicbi") {
+            return Self::Undivided;
+        }
+        // The subset is named for the 36 tables in it, so the identifier ends in the count. Checked
+        // before the bare name, because the bare name is a prefix of it.
+        if squashed.ends_with("36") {
+            Self::Part {
+                corpus: "Public BI",
+                name: "36 table subset",
+            }
+        } else {
+            Self::Whole {
+                corpus: "Public BI",
+                members: "all 206 tables",
+            }
+        }
+    }
+
+    /// The corpus this selection belongs to, when it belongs to one that has parts.
+    ///
+    /// Two selections sharing this are two measurements of the same benchmark over different data,
+    /// which is the pair that must never be read as a comparison.
+    #[must_use]
+    pub const fn corpus(self) -> Option<&'static str> {
+        match self {
+            Self::Whole { corpus, .. } | Self::Part { corpus, .. } => Some(corpus),
+            Self::Undivided => None,
+        }
+    }
+
+    /// How this selection is named in output.
+    ///
+    /// Empty for a corpus that has no parts, so the workload identifier stands on its own. For one
+    /// that does, this is the only name available and it names the part, so there is no spelling
+    /// that reads as the whole benchmark when it is not.
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Whole { members, .. } => members,
+            Self::Part { name, .. } => name,
+            Self::Undivided => "",
+        }
+    }
+
+    /// The notice a page has to carry once it holds two different parts of one corpus.
+    #[must_use]
+    pub const fn mixed_notice() -> &'static str {
+        MIXED_NOTICE
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_subset_is_read_off_the_name() {
+        assert_eq!(
+            Selection::of("public-bi-36"),
+            Selection::Part {
+                corpus: "Public BI",
+                name: "36 table subset",
+            }
+        );
+    }
+
+    #[test]
+    fn the_full_set_is_read_off_the_name() {
+        assert_eq!(
+            Selection::of("public-bi"),
+            Selection::Whole {
+                corpus: "Public BI",
+                members: "all 206 tables",
+            }
+        );
+    }
+
+    #[test]
+    fn the_bare_name_is_a_prefix_of_the_subset_and_is_not_taken_for_it() {
+        // `public-bi` starts `public-bi-36`, so reading the prefix first would make every subset
+        // number look like a full set number, which is the exact confusion this module is for.
+        assert_ne!(Selection::of("public-bi"), Selection::of("public-bi-36"));
+    }
+
+    #[test]
+    fn spelling_and_punctuation_do_not_change_what_it_is() {
+        assert_eq!(Selection::of("PublicBI_36"), Selection::of("public-bi-36"));
+        assert_eq!(Selection::of("public_bi"), Selection::of("public-bi"));
+    }
+
+    #[test]
+    fn a_corpus_with_no_parts_is_left_alone() {
+        assert_eq!(Selection::of("clickbench-hits"), Selection::Undivided);
+        assert_eq!(Selection::of("tpch-sf1"), Selection::Undivided);
+        assert!(Selection::of("clickbench-hits").label().is_empty());
+    }
+
+    #[test]
+    fn both_parts_of_one_corpus_name_the_same_corpus() {
+        assert_eq!(
+            Selection::of("public-bi").corpus(),
+            Selection::of("public-bi-36").corpus()
+        );
+        assert_eq!(Selection::of("silesia").corpus(), None);
+    }
+
+    #[test]
+    fn neither_part_has_a_name_that_is_only_the_benchmark() {
+        // The point of the type. There is no way to print a Public BI number that does not say
+        // which Public BI it is.
+        for workload in ["public-bi", "public-bi-36"] {
+            let label = Selection::of(workload).label();
+            assert!(!label.is_empty(), "{workload} has no part in its name");
+            assert_ne!(label, "Public BI");
+        }
+    }
+}

--- a/docs/CORPORA.md
+++ b/docs/CORPORA.md
@@ -40,6 +40,10 @@ columns = 105
 
 An entry may also carry `url`, and almost none do. Without it the file's URL is its path resolved against the corpus `source` in the ordinary way, meaning everything after the last slash of `source` is replaced by the path. For a single file corpus whose source is the file itself that resolves back to the source unchanged, which is why the common case needs nothing written down. For a corpus of many files under one prefix, `source` names the directory with a trailing slash and each path is appended. `url` exists for the case where one corpus is assembled from files that are not under a common prefix, which happens often enough in published datasets that a format with no answer for it would mean forking a corpus rather than describing it.
 
+`part_of` names the corpus this one is a selection from, and only a corpus that really is one may carry it. Public BI is why it exists. The benchmark is published as 206 tables, much of the encoding literature measures a subset of 36 of them, and a number labelled Public BI is ambiguous about which of those two it is. So both are corpora here, `public-bi` and `public-bi-36`, and the second says which set it is drawn from.
+
+That claim is checked rather than believed. Every entry in a part has to appear in the whole at the same path with the same digest and the same size, and the part has to be smaller. A subset that has quietly drifted from the set it names is worse than no subset at all, because every number labelled with it is then about something nobody can reconstruct. The check needs both manifests in hand, so it runs in `ci/discipline.py` over the tree and in `Manifest::is_part_of` at run time, while the parts of the claim that can be settled from one manifest alone, that the name is not empty and not the corpus itself, are checked where every other field is.
+
 `[generator]` says what produces a generated corpus, and only a generated corpus may have one. A manifest carrying both a generator and a download location is making two claims about one set of bytes, and the second of those is the one that goes unread. It has a `program` to run, `arguments` to pass it, a `version` that must appear in what the program says about itself, `version_arguments` that make it say so, and an `environment` table for anything the program needs to be told through the environment rather than on the command line. The working directory is the output directory, and two placeholders are substituted into environment values: `{output}` is where the files should land and `{program_directory}` is where the program itself was found.
 
 The version is part of the pin and is checked before generation starts. The bytes a generator writes are a property of the generator, so a manifest pinned against one build of `dbgen` says nothing about another, and a digest mismatch on twenty gigabytes of output has nothing in it to suggest that the cause is a release two versions along. One process start buys that sentence.
@@ -53,6 +57,14 @@ Rows are summed across the files of a corpus and columns have to agree between t
 Only files whose declared path ends in `.parquet` are read for a shape, and that is decided from the manifest rather than from the bytes because the manifest is this repository's own statement about what a file is. Silesia and enwik8 are compressed text with no rows or columns at all, and for them the shape check does not apply rather than fails. A file named `.parquet` that turns out not to be Parquet is still a hard error, and a manifest that asserts a shape for a corpus where nothing can carry one is refused, because an assertion nothing checks against is worse than no assertion: on the page it reads like something is being verified.
 
 Unknown fields are an error rather than being ignored. The field most worth typing wrongly is `licence_note`, and a typo that silently does nothing would defeat the one check on this page that has legal weight.
+
+## The corpus identity
+
+A corpus has one digest of its own, printed by `iris-bench corpus` before anything is fetched and computed by `Manifest::identity`. It is taken over the corpus name and then every entry's path, digest and size, sorted by path.
+
+It exists so that a result row can say which corpus it used in one value. `public-bi` and `public-bi-36` are both honestly called Public BI, and even within one of those, a corpus can gain or lose a table between one measurement and the next. A name does not distinguish those cases and the identity does.
+
+Sorted by path, so reordering entries in the file does not move it. Taken over the entries rather than over the manifest text, so a rewritten comment does not move it either. That second one is deliberate: a comment is not a corpus, and an identity that changed when somebody fixed a typo would teach everybody to ignore the field, which costs more than the precision it buys.
 
 ## Digests
 
@@ -71,6 +83,12 @@ The size is checked as well as the digest, even though the digest would catch an
 The digest is computed in the same pass that writes the file rather than by reading it back afterwards. That is not only about speed on a fifteen gigabyte download, although it is that too. It means a file that does not match is deleted rather than left sitting under a name that asserts its own content, so the store's one invariant holds even when a fetch fails halfway.
 
 A file the store already has is never requested. That is not a cache, it is what content addressing means: the manifest already said which bytes it wants, and the store either has those bytes or it does not. Fetching ClickBench a second time on a machine that already has it takes 56 milliseconds including reading the footer and checking the assertions.
+
+Public BI is the largest corpus here by file count rather than by size. The full set is 206 tables across 46 workbooks and 43,334,957,146 bytes of bzip2 compressed CSV, about 386 GB once decompressed. The 36 table subset is 10,547,903,083 bytes. On the 4 vCPU AMD EPYC guest the subset fetched and verified in 19 minutes 16 seconds and the second run took 0.53 seconds, and peak resident memory across the 9.8 GiB fetch was 7.8 MB, because the digest is computed on the bytes as they stream past rather than on a file read back afterwards.
+
+The full set then fetched on the same machine in 45 minutes 6 seconds, at a peak of 8.7 MB, and reported that 62 of its 206 files were already in the store. That number is the whole argument for content addressing in one line. 36 of the 62 were there because the subset had already been fetched, and the other 26 were never downloaded at all, because they are duplicates of tables that arrived earlier in the same run.
+
+206 declared files come to 180 distinct objects. Twenty six of the MLB tables are byte for byte a duplicate of another MLB table, because Tableau extracted that workbook several ways and some of the extracts came out identical. Nothing was written to handle that. The store is addressed by content, so the duplicates collapse on the way in and the corpus still declares all 206 because the benchmark does.
 
 The first fetch of ClickBench on the i9-13900K under Linux took about twenty minutes for 13.8 GiB, arrived at the digest pinned in the manifest, and reported 99,997,497 rows across 105 columns. Those numbers were pinned before the fetch ran, from a separate download hashed with `b3sum` and from the ClickBench documentation, so this was the manifest being checked rather than written.
 

--- a/docs/LICENSING.md
+++ b/docs/LICENSING.md
@@ -46,7 +46,11 @@ Silesia is public domain for benchmarking purposes and is mirrored. The enwik8 a
 
 ## Public BI
 
-The Public BI benchmark's data comes from Tableau Public workbooks. It is fetched from the published location and not redistributed. The 36 dataset subset used by the encoding literature is defined as a subset object with its own digest, so that a result labelled with that subset is unambiguous about which 36.
+The Public BI benchmark's data comes from Tableau Public workbooks. It is fetched from the published location and not redistributed. The 36 dataset subset used by the encoding literature is its own corpus with its own identity digest, so that a result labelled with that subset is unambiguous about which 36.
+
+The two are `public-bi`, which is all 206 tables across the 46 workbooks, and `public-bi-36`, which is the 36 tables FastLanes measures, one from each of 36 workbooks. `public-bi-36` declares itself part of `public-bi` and CI checks that every one of its tables is in the full set at the same digest, so the subset cannot drift from the set it names without the build saying so.
+
+Neither may be reported as the other, and that is code rather than a rule. `bench_report::Selection` reads which of the two a workload is from its identifier, and the name it produces always says which, so there is no row that reads as Public BI without saying which Public BI. A page holding rows from both prints, under the table, that they are not comparable with each other. The gap between a ratio over the subset and one over the full set is large enough to reverse an ordering, and the subset is the one most of the published numbers in this area are taken over.
 
 ## Publishing
 


### PR DESCRIPTION
Closes #10.

The Public BI benchmark is published as 206 tables across 46 Tableau Public workbooks. Much of the compression literature measures a subset of 36 of them, so both have to be available separately or those results cannot be reproduced at all. A number from one is not comparable with a number from the other, and the gap is large enough to reverse an ordering, so this adds both as separate corpora and makes a result row say which one it used.

## The two manifests

`corpora/public-bi` pins all 206 files, 43,334,957,146 bytes as fetched, about 386 GB decompressed. `corpora/public-bi-36` pins the 36 and declares `part_of = "public-bi"`.

The subset is pinned table by table rather than derived from a rule. Nine of the ten omitted workbooks are numbered variants of an included one and IUBLibrary is not, so there is nothing to recompute. TrainsUK1 also contributes its second table rather than its first, which looks like an oversight in the FastLanes list. Tidying that up would silently change what every published number labelled with the subset was measured over, so it is pinned as it is and the manifest says why.

Neither carries an `[assertions]` block, because bzip2 CSV has no footer and asserting a row count would mean decompressing 386 GB on every fetch.

## Checking that the subset is a subset

`part_of` is checked twice. `check_parts` in `ci/discipline.py` reads every manifest in `corpora/` and refuses a part that names a corpus that is not there, names a file the whole does not have, pins a shared file differently, is not smaller than the whole, or is a part of itself. `Manifest::is_part_of` does the same against a manifest already in hand at run time. Six cases in `ci/test_discipline.py` and three in `bench-corpus` cover it.

## The corpus identity

`Manifest::identity` is one digest over the corpus name and every path, digest and size in sorted order. It is what a result row carries, so that Public BI in a table means one determinable set of tables rather than a name. Reordering entries or moving a comment does not change it, renaming the corpus does. `iris-bench corpus` prints it before it fetches anything.

## Which one a row used

`bench_report::Selection` reads which of the two a workload is from its identifier, the same way `Family::of` reads a TPC family. `Row::label` always includes it, so there is no spelling of a Public BI workload that a page can render as a bare Public BI. `Page::notices` adds a not comparable notice when one page holds rows from both parts. Seven tests in `selection.rs` and four in `page.rs`.

## Verification

Both were fetched end to end on the 4 vCPU AMD EPYC guest through the real command rather than by hand.

The subset fetched and verified in 19 minutes 16 seconds with all 36 digests matching, and the second run took 0.53 seconds with 36 of 36 already in the store. The full set fetched in 45 minutes 6 seconds and reported 62 of its 206 files already in the store. That 62 is the argument for content addressing in one number: 36 of them were there because the subset had already been fetched, and the other 26 were never downloaded at all, because 26 of the MLB tables are byte for byte duplicates of other MLB tables. Tableau extracted that workbook several ways and some of the extracts came out identical. Nothing was written to handle that. 206 declared files come to 180 distinct objects and the corpus still declares all 206, because the benchmark does.

Peak resident memory was 8.7 MB across a 40.4 GiB fetch, because the digest is computed on the bytes as they stream past rather than on a file read back afterwards.

## Also

`iris-bench corpus` now prints the source URL and the identity before fetching, and a one line summary of how many files were already in the store after, because a corpus of two hundred files prints two hundred lines and that is the thing somebody wants off the end of it.

Local gate green: fmt, clippy with `-D warnings`, 13 test binaries, doc build with `-D warnings`, `python3 ci/discipline.py`, `python3 ci/test_discipline.py`, `cargo check --locked`.
