### PR TITLE
Cut v0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,7 +193,7 @@ checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "bench-core"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "bench-corpus"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "blake3",
  "camino",
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "bench-driver"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bench-core",
  "serde",
@@ -229,7 +229,7 @@ dependencies = [
 
 [[package]]
 name = "bench-env"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bench-core",
  "blake3",
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "bench-report"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bench-core",
  "bench-store",
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "bench-run"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bench-core",
  "bench-corpus",
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "bench-store"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -514,7 +514,7 @@ dependencies = [
 
 [[package]]
 name = "driver-null"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bench-driver",
 ]
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "iris-bench-cli"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "bench-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*", "drivers/*"]
 
 [workspace.package]
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 rust-version = "1.98"
 license = "Apache-2.0"
@@ -16,13 +16,13 @@ readme = "README.md"
 publish = false
 
 [workspace.dependencies]
-bench-core = { path = "crates/bench-core", version = "0.1.2" }
-bench-corpus = { path = "crates/bench-corpus", version = "0.1.2" }
-bench-driver = { path = "crates/bench-driver", version = "0.1.2" }
-bench-env = { path = "crates/bench-env", version = "0.1.2" }
-bench-report = { path = "crates/bench-report", version = "0.1.2" }
-bench-run = { path = "crates/bench-run", version = "0.1.2" }
-bench-store = { path = "crates/bench-store", version = "0.1.2" }
+bench-core = { path = "crates/bench-core", version = "0.1.3" }
+bench-corpus = { path = "crates/bench-corpus", version = "0.1.3" }
+bench-driver = { path = "crates/bench-driver", version = "0.1.3" }
+bench-env = { path = "crates/bench-env", version = "0.1.3" }
+bench-report = { path = "crates/bench-report", version = "0.1.3" }
+bench-run = { path = "crates/bench-run", version = "0.1.3" }
+bench-store = { path = "crates/bench-store", version = "0.1.3" }
 
 anyhow = "1.0.104"
 arrow-array = "59.3.0"


### PR DESCRIPTION
A patch release over v0.1.2. Version and lockfile only, per `docs/RELEASING.md`.

What landed since v0.1.2:

- #81, Public BI as two corpora. `public-bi` is all 206 tables across 46 workbooks, `public-bi-36` is the 36 the encoding literature measures and declares itself part of the full set. CI checks that claim against the tree and `Manifest::is_part_of` checks it at run time. `Manifest::identity` gives each corpus one digest of its own, and `bench_report::Selection` makes a result row say which of the two it used, so no page can render a Public BI number without saying which Public BI.

Nothing publishes to crates.io. A release here is a tag and notes.
