### PR TITLE
Release v0.2.0, which is B1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,7 +193,7 @@ checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "bench-core"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "bench-corpus"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "blake3",
  "camino",
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "bench-driver"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "bench-core",
  "serde",
@@ -229,7 +229,7 @@ dependencies = [
 
 [[package]]
 name = "bench-env"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "bench-core",
  "blake3",
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "bench-report"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "bench-core",
  "bench-store",
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "bench-run"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "bench-core",
  "bench-corpus",
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "bench-store"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -514,7 +514,7 @@ dependencies = [
 
 [[package]]
 name = "driver-null"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "bench-driver",
 ]
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "iris-bench-cli"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bench-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*", "drivers/*"]
 
 [workspace.package]
-version = "0.1.3"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.98"
 license = "Apache-2.0"
@@ -16,13 +16,13 @@ readme = "README.md"
 publish = false
 
 [workspace.dependencies]
-bench-core = { path = "crates/bench-core", version = "0.1.3" }
-bench-corpus = { path = "crates/bench-corpus", version = "0.1.3" }
-bench-driver = { path = "crates/bench-driver", version = "0.1.3" }
-bench-env = { path = "crates/bench-env", version = "0.1.3" }
-bench-report = { path = "crates/bench-report", version = "0.1.3" }
-bench-run = { path = "crates/bench-run", version = "0.1.3" }
-bench-store = { path = "crates/bench-store", version = "0.1.3" }
+bench-core = { path = "crates/bench-core", version = "0.2.0" }
+bench-corpus = { path = "crates/bench-corpus", version = "0.2.0" }
+bench-driver = { path = "crates/bench-driver", version = "0.2.0" }
+bench-env = { path = "crates/bench-env", version = "0.2.0" }
+bench-report = { path = "crates/bench-report", version = "0.2.0" }
+bench-run = { path = "crates/bench-run", version = "0.2.0" }
+bench-store = { path = "crates/bench-store", version = "0.2.0" }
 
 anyhow = "1.0.104"
 arrow-array = "59.3.0"

--- a/README.md
+++ b/README.md
@@ -30,11 +30,13 @@ Public BI has been both the design input and the evaluation set for six years of
 
 ## Status
 
-Pre-alpha. B0 is done as of `v0.1.0`, so the measuring apparatus exists and the benchmarks do not. Milestones B0 through B8 are [public](https://github.com/tamnd/iris-bench/milestones) with one issue per exit gate.
+Pre-alpha. B0 is done as of `v0.1.0` and B1 as of `v0.2.0`, so the measuring apparatus and the data exist and the benchmarks do not. Milestones B0 through B8 are [public](https://github.com/tamnd/iris-bench/milestones) with one issue per exit gate.
 
 What B0 established is in `docs/ROADMAP.md` under that milestone, and the short version is that this fleet can measure, on one machine, for ratios always and for durations under a gate. The noise floor is 1.05% on the one eligible role and over two percent everywhere else, and the harness adds 41.1 ns to a sample, which is under one percent of anything longer than 4.1 microseconds. `iris-bench check`, `noise`, `overhead`, `resident` and `corpus` run today. Nothing else does.
 
-B1 is in progress and is the corpora. ClickBench, TPC-H at scale factor 1 and 20, Public BI in both the full 206 table set and the 36 table subset, and Silesia and enwik8 are pinned and reproduce, some by download, the TPC-H pair from `dbgen`, and the last two from a mirror because their original hosting has moved more than once.
+B1 is done and is the corpora. ClickBench, TPC-H at scale factor 1 and 20, Public BI in both the full 206 table set and the 36 table subset, and Silesia and enwik8 are pinned and reproduce, some by download, the TPC-H pair from `dbgen`, and the last two from a mirror because their original hosting has moved more than once. Every one of them was fetched or generated end to end through the real command rather than checked on paper, which is 43 GB of Public BI and 22 GB of TPC-H among other things.
+
+A digest mismatch is a hard failure with no override, and the absence of an override is enforced by a check that reads the four files a corpus's bytes pass through rather than left as an intention. Generated corpora are pinned to the platforms they have actually been produced on, and generating anywhere else is refused with a reason instead of attempted.
 
 B0 through B4 need no `iris` code to exist, which is deliberate. If `iris` is never built, the reproduction of the published figures and the storage tier study still stand on their own.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -32,6 +32,18 @@ Manifests, fetching, generation, verification and the content addressed store.
 
 **Gate.** ClickBench `hits`, TPC-H at scale factors 1 and 20, Public BI in both the 36 dataset subset and the full set, Silesia and enwik8 all fetch or generate to matching digests. The assertions in the manifests pass, so ClickBench is 99,997,497 rows across 105 columns or the manifest is wrong. Generated corpora produce identical digests on Linux x86-64, Linux arm64 and macOS, or the divergence is documented and the corpus is redefined as platform pinned. Every mirrored corpus has a licence note and CI enforces it. A digest mismatch on fetch is a hard failure that prints both digests.
 
+### The B1 outcome
+
+Every gate above is met, and three of them turned out to be worth more than they read like on paper. Measured facts are in `CORPORA.md`, this is what follows from them.
+
+**Every corpus was fetched or generated end to end rather than checked on paper.** That is 43,334,957,146 bytes of Public BI across 206 files, 22.5 GB of TPC-H at scale factor 20, 13.8 GiB of ClickBench, and Silesia and enwik8 from the mirror. The reason to say it out loud is that a manifest whose digests were transcribed from somewhere else is a manifest that has never been tested, and the failure mode of one is that it looks exactly like a manifest that has. Public BI paid this back immediately: 62 of its 206 files were already in the store when the full set was fetched, 36 from the subset and 26 as duplicates of tables arriving earlier in the same run, which is the content addressing doing what it was built for rather than a case anybody handled.
+
+**Three platforms produce identical digests and the fourth cannot, for a reason in the tool.** TPC-H scale factor 1 comes out byte for byte the same on macOS on Apple silicon, Linux on x86-64 and Linux on arm64. On Windows it cannot, because `dbgen` opens its output with `fopen(path, "w")` and the C runtime there rewrites every newline. So the corpus is platform pinned, as the gate allows, and `[generator] platforms` is the pin: a required list of the operating systems the bytes have actually been produced on, checked before the generator starts. It blocks the comparison at its source rather than at the report, because a machine that cannot produce the corpus cannot measure on it.
+
+**No override means a check that reads the source, not a rule somebody remembers.** A digest mismatch was already a hard failure and nothing skipped it, but that was true because the code happened to be written that way. `check_digest_is_not_overridable` now fails the build on an override name, a read of the environment, or an insert that does not name the pinned digest, anywhere in the four files a corpus's bytes pass through. The failure path is tested through a real HTTP server serving wrong bytes at the right length, and through the whole `iris-bench corpus` command against a generator that writes the wrong thing.
+
+**What is still not settled.** Scale factor 20 has not been generated on arm64 Linux, because no machine in this fleet has 22 GiB free on that architecture, so its cross-platform evidence is two platforms rather than three and the third is inferred from scale factor 1 rather than measured. enwik9 is not mirrored, because nothing measures it yet. And the mirror is a release on this repository, which makes a mirror that has stopped working and a repository that has stopped existing the same event, which is a property worth having and not the same thing as durability.
+
 ## B2, drivers and the first real comparison
 
 The runner, the store, and drivers for DuckDB, DataFusion and the arrow-rs Parquet reader. Still no `iris`.


### PR DESCRIPTION
B1 is 7 of 7, so this is the milestone version.

Manifests, the content addressed store, fetching, mirroring, generation and verification all exist. ClickBench, TPC-H at scale factors 1 and 20, Public BI in both the full 206 table set and the 36 table subset, and Silesia and enwik8 are pinned and reproduce. Every one of them was fetched or generated end to end through the real command rather than checked on paper, which is 43 GB of Public BI, 22.5 GB of TPC-H at scale factor 20, and 13.8 GiB of ClickBench among the rest.

The version moves in `[workspace.package]` and in the `version` field of each path dependency, then `cargo update -w`. Nothing publishes to crates.io.

The README now says B1 is done and adds the two facts from the last two gates, which are that a digest mismatch has no override and that the absence of one is enforced rather than intended, and that generated corpora are pinned to the platforms they have actually been produced on.

The ROADMAP gains a B1 outcome section in the same shape as the B0 one. Four paragraphs: every corpus was really fetched and what that bought, three platforms producing identical digests and why the fourth cannot, no override meaning a check that reads the source, and what is still not settled, which is scale factor 20 on arm64 Linux for want of 22 GiB free on that architecture, enwik9 not being mirrored because nothing measures it yet, and the mirror being a release on this repository, which is a property worth having and not the same thing as durability.