### PR TITLE
The Driver trait, with prepare, load and run kept separate

### DIFF
--- a/ci/discipline.py
+++ b/ci/discipline.py
@@ -80,6 +80,12 @@ MANIFEST_FIELDS = {
 # the single failure mode that would make every comparison here worthless.
 DRIVER_ALLOWED_INTERNAL_DEPS = {"bench-driver"}
 
+# A driver does not hold the clock. bench_driver::Session times the three phases
+# from the outside, and a driver that reached for a clock of its own would be
+# reporting a number nobody else checked, which is how load time ends up inside
+# preparation and preparation ends up in nobody's total.
+DRIVER_CLOCK = re.compile(r"\bInstant\b|\bSystemTime\b|\bclock_gettime\b|\bQueryPerformanceCounter\b")
+
 failures: list[str] = []
 
 
@@ -109,6 +115,40 @@ def check_drivers() -> None:
             if age > REVIEW_MAX_AGE_DAYS:
                 fail(f"{driver.name}: configuration last reviewed {age} days ago")
         check_driver_deps(driver)
+        check_driver_source(driver)
+
+
+def check_driver_source(driver: pathlib.Path) -> None:
+    """A driver implements the trait, and does not time itself.
+
+    The first half is what makes "every driver reports all three phases" true
+    rather than hoped for: a crate under drivers/ that implements nothing is a
+    system in the matrix that never gets measured. The second half is why the
+    phases mean anything, since a driver holding its own clock can report a
+    preparation that took no time and a load that happened somewhere else.
+    """
+    source = driver / "src" / "lib.rs"
+    if not source.exists():
+        fail(f"{driver.name}: no src/lib.rs")
+        return
+    text = source.read_text(encoding="utf-8")
+    if not re.search(r"^impl Driver for ", text, re.MULTILINE):
+        fail(f"{driver.name}: does not implement Driver, so nothing about it can be measured")
+
+    lines = text.splitlines()
+    end = next(
+        (number for number, line in enumerate(lines) if line.strip() == "#[cfg(test)]"),
+        len(lines),
+    )
+    for number, line in enumerate(lines[:end], 1):
+        if line.lstrip().startswith("//"):
+            continue
+        hit = DRIVER_CLOCK.search(line)
+        if hit:
+            fail(
+                f"{driver.name}:src/lib.rs:{number}: {hit.group()} is a clock, and the phases are"
+                f" timed by the session rather than by the driver"
+            )
 
 
 def check_driver_deps(driver: pathlib.Path) -> None:

--- a/ci/test_discipline.py
+++ b/ci/test_discipline.py
@@ -196,10 +196,84 @@ def check_override_cases() -> None:
         failures.append(f"a word that merely contains one: expected no complaint and got {said}")
 
 
+DRIVER = """
+use bench_driver::{Answer, Driver, DriverError, Load, Query, Rows, Setup};
+
+pub struct Example;
+
+impl Driver for Example {
+    fn name(&self) -> &'static str {
+        "example"
+    }
+
+    fn version(&self) -> String {
+        "1".to_owned()
+    }
+
+    fn prepare(&mut self, _setup: &Setup) -> Result<(), DriverError> {
+        Ok(())
+    }
+
+    fn load(&mut self, _load: &Load) -> Result<(), DriverError> {
+        Ok(())
+    }
+
+    fn run(&mut self, query: &Query) -> Result<Answer, DriverError> {
+        Ok(Rows::new().finish(query.ordered))
+    }
+}
+"""
+
+
+def driver_source(text: str | None) -> list[str]:
+    """Runs the driver source checks over one made up driver and returns what they said."""
+    before = list(discipline.failures)
+    discipline.failures.clear()
+    try:
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = pathlib.Path(temporary) / "driver-example"
+            (directory / "src").mkdir(parents=True)
+            if text is not None:
+                (directory / "src" / "lib.rs").write_text(text, encoding="utf-8")
+            discipline.check_driver_source(directory)
+            return list(discipline.failures)
+    finally:
+        discipline.failures[:] = before
+
+
+def check_driver_source_cases() -> None:
+    said = driver_source(DRIVER)
+    if said:
+        failures.append(f"a driver that implements the trait: expected no complaint and got {said}")
+
+    said = driver_source(DRIVER.replace("impl Driver for Example", "impl Example"))
+    if not any("does not implement Driver" in one for one in said):
+        failures.append(f"a crate under drivers/ that implements nothing: expected a complaint and got {said}")
+
+    said = driver_source(None)
+    if not any("no src/lib.rs" in one for one in said):
+        failures.append(f"a driver with no source: expected a complaint and got {said}")
+
+    for name, line in (
+        ("a driver timing itself", "        let started = std::time::Instant::now();\n"),
+        ("a driver reaching for the wall clock", "        let started = SystemTime::now();\n"),
+    ):
+        said = driver_source(DRIVER.replace("        Ok(())\n", line + "        Ok(())\n", 1))
+        if not any("is a clock" in one for one in said):
+            failures.append(f"{name}: expected a complaint and got {said}")
+
+    # A driver's own tests may time things, because a test that asserts a load
+    # took no time is a test and not a measurement.
+    said = driver_source(DRIVER + "#[cfg(test)]\nmod tests {\n    use std::time::Instant;\n}\n")
+    if said:
+        failures.append(f"a clock inside a test module: expected no complaint and got {said}")
+
+
 def main() -> int:
     expect_clean("a complete manifest passes", GOOD)
     check_parts_cases()
     check_override_cases()
+    check_driver_source_cases()
 
     expect_complaint(
         "a manifest that disagrees with its directory",

--- a/crates/bench-driver/README.md
+++ b/crates/bench-driver/README.md
@@ -2,8 +2,10 @@
 
 The trait every system under test implements.
 
-The prepare, load and run split is fixed here for everyone, so that no
+The prepare, load and run split is fixed here for everyone, so that no system can move work into an untimed phase that another system pays for. A driver implements three methods and none of them times itself. A session borrows the driver, calls the three methods, and holds the clock.
 
-system can move work into an untimed phase that another system pays for.
+Preparation is given no file paths, so a load cannot hide inside it and no index can be built there. A query cannot be answered before something has been loaded, because a system that could answer one read the data during preparation. Both of those are the mechanism rather than a convention.
+
+Result rendering is defined here too, once, so that no driver invents its own. Two of the rules in it cost something and `docs/METHODOLOGY.md` says what.
 
 Part of [iris-bench](https://github.com/tamnd/iris-bench). Licensed under Apache-2.0.

--- a/crates/bench-driver/src/answer.rs
+++ b/crates/bench-driver/src/answer.rs
@@ -1,0 +1,383 @@
+//! What a query produced, in a form two different systems can be compared on.
+//!
+//! A timing is only worth having if the two systems being timed answered the same question. The
+//! motivating example in the fair benchmarking literature is a prototype that was faster because it
+//! used hardcoded group counts, integer types too small to hold the aggregate, and unhandled
+//! overflow. It was, of course, faster. So every query here produces a digest of its canonicalised
+//! result and the digests are compared across systems, and a row whose result does not match is
+//! marked incorrect and excluded from every aggregate.
+//!
+//! Canonicalised is the load bearing word, and it is why this module exists rather than each driver
+//! rendering its own results. Three systems asked the same question return the same answer in three
+//! different shapes: different float formatting, different null spellings, different row order for a
+//! query that never specified one. None of those is a wrong answer and all of them are a different
+//! digest.
+//!
+//! # The two decisions with a real cost
+//!
+//! **Floats are rendered to six significant digits.** Two engines summing a hundred million values
+//! will not agree past that, because a parallel partial sum and a serial one add the same numbers in
+//! a different order. Six digits survives that and still catches the class of thing this check
+//! exists for, since a hardcoded group count or an overflowed accumulator is not a seventh digit
+//! difference. What it does not catch is a genuine small error, and that is the price. A digest
+//! cannot express a tolerance, so the tolerance has to be in the canonical form or nowhere.
+//!
+//! **Rows are sorted unless the query asked for an order.** A query with no `ORDER BY` has no
+//! defined row order, so comparing two engines on the order they happened to produce is comparing
+//! them on something neither was asked to do. When the query does specify an order, the rows are
+//! left alone and the order is part of what is checked.
+
+use std::fmt::Write as _;
+
+/// How many significant decimal digits a float is rendered to.
+///
+/// See the module documentation. This is the number that decides whether two engines that computed
+/// the same sum in a different order agree.
+const FLOAT_DIGITS: usize = 6;
+
+/// What separates two values on a row.
+const FIELD: char = '\t';
+
+/// One value in a result row.
+///
+/// Deliberately small. This is not a type system for query results, it is the set of shapes a
+/// `ClickBench` or TPC-H answer comes back in, and every one of them has an unambiguous rendering.
+#[derive(Clone, PartialEq, Debug)]
+pub enum Value {
+    /// No value. Rendered as `\N`, which is what a text of "\N" escapes away from.
+    Null,
+    /// A boolean, rendered as `true` or `false`.
+    Bool(bool),
+    /// A signed integer, rendered in decimal. Unsigned results widen into this, because no result
+    /// in any workload here exceeds an `i64` and a type that could hold more would need a rendering
+    /// that says which type it was.
+    Int(i64),
+    /// A floating point number, rendered to six significant digits.
+    Float(f64),
+    /// Text, rendered with backslash, tab and newline escaped.
+    Text(String),
+}
+
+impl Value {
+    /// Writes this value in the canonical form.
+    fn render(&self, into: &mut String) {
+        match self {
+            Self::Null => into.push_str("\\N"),
+            Self::Bool(value) => into.push_str(if *value { "true" } else { "false" }),
+            Self::Int(value) => {
+                let _ = write!(into, "{value}");
+            }
+            Self::Float(value) => into.push_str(&float(*value)),
+            Self::Text(value) => {
+                for character in value.chars() {
+                    match character {
+                        '\\' => into.push_str("\\\\"),
+                        '\t' => into.push_str("\\t"),
+                        '\n' => into.push_str("\\n"),
+                        '\r' => into.push_str("\\r"),
+                        other => into.push(other),
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// A float in the canonical form.
+///
+/// Not a straight `{:.6e}`, because that renders every integral value in exponent form and a result
+/// table full of `1.000000e0` is unreadable by the person who has to work out why two systems
+/// disagree. Values that round to something a person would write plainly are written plainly.
+fn float(value: f64) -> String {
+    if value.is_nan() {
+        return "NaN".to_owned();
+    }
+    if value.is_infinite() {
+        return if value.is_sign_negative() {
+            "-Infinity".to_owned()
+        } else {
+            "Infinity".to_owned()
+        };
+    }
+    // Negative zero and zero are the same number and two engines will disagree about which one a
+    // sum of nothing produced.
+    if value == 0.0 {
+        return "0".to_owned();
+    }
+
+    let magnitude = value.abs();
+    if !(1e-4..1e15).contains(&magnitude) {
+        return exponent(value);
+    }
+
+    let rounded = round_to_significant(value, FLOAT_DIGITS);
+    // Enough places after the point to carry six significant digits at this magnitude, then the
+    // trailing zeros the rounding produced are taken off so that 1.5 and 1.500000 are one string.
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "the magnitude is bounded above, so the exponent is a small integer"
+    )]
+    let places = FLOAT_DIGITS.saturating_sub(magnitude.log10().floor() as usize + 1);
+    let mut text = format!("{rounded:.places$}");
+    if text.contains('.') {
+        text = text.trim_end_matches('0').trim_end_matches('.').to_owned();
+    }
+    text
+}
+
+/// A very large or very small number, in exponent form.
+///
+/// Formatted straight to six significant digits rather than rounded first and then printed. At the
+/// far ends of the range the scaling factor that rounding needs is itself not representable, so a
+/// value that came back from rounding would carry a tail of digits that are an artefact of the
+/// rounding rather than anything the query computed.
+fn exponent(value: f64) -> String {
+    let text = format!("{:.*e}", FLOAT_DIGITS - 1, value);
+    let (mantissa, power) = text.split_once('e').unwrap_or((text.as_str(), "0"));
+    let mantissa = if mantissa.contains('.') {
+        mantissa.trim_end_matches('0').trim_end_matches('.')
+    } else {
+        mantissa
+    };
+    format!("{mantissa}e{power}")
+}
+
+/// Rounds to `digits` significant decimal digits.
+fn round_to_significant(value: f64, digits: usize) -> f64 {
+    if value == 0.0 || !value.is_finite() {
+        return value;
+    }
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_possible_wrap,
+        reason = "digits is six, and a decimal exponent of a finite f64 fits in an i32 with room"
+    )]
+    let exponent = digits as i32 - 1 - value.abs().log10().floor() as i32;
+    let scale = 10_f64.powi(exponent);
+    // A scale that overflowed or underflowed would turn the value into an infinity or a zero, which
+    // is a worse answer than not rounding it.
+    if scale.is_finite() && scale != 0.0 {
+        let scaled = value * scale;
+        if scaled.is_finite() {
+            return scaled.round() / scale;
+        }
+    }
+    value
+}
+
+/// A result being assembled, one row at a time.
+///
+/// Built rather than constructed, because the row count and the canonical body have to agree and a
+/// driver that reports one and produces the other is the failure this whole module exists to catch.
+#[derive(Clone, Debug)]
+pub struct Rows {
+    /// How many columns the first row had, which every later row has to match.
+    columns: Option<usize>,
+    /// Each row already rendered, kept separately so they can be sorted.
+    rows: Vec<String>,
+}
+
+impl Rows {
+    /// Starts an empty result.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            columns: None,
+            rows: Vec::new(),
+        }
+    }
+
+    /// Adds one row.
+    ///
+    /// # Errors
+    ///
+    /// If it does not have the same number of columns as the rows before it. A result whose rows
+    /// have different widths is not a table, and a driver that produced one has a bug that would
+    /// otherwise show up as a digest mismatch against every other system at once.
+    pub fn push(&mut self, values: impl IntoIterator<Item = Value>) -> Result<(), WidthError> {
+        let values: Vec<Value> = values.into_iter().collect();
+        match self.columns {
+            None => self.columns = Some(values.len()),
+            Some(columns) if columns != values.len() => {
+                return Err(WidthError {
+                    row: self.rows.len(),
+                    wanted: columns,
+                    found: values.len(),
+                });
+            }
+            Some(_) => {}
+        }
+
+        let mut line = String::new();
+        for (index, value) in values.iter().enumerate() {
+            if index > 0 {
+                line.push(FIELD);
+            }
+            value.render(&mut line);
+        }
+        self.rows.push(line);
+        Ok(())
+    }
+
+    /// Finishes the result.
+    ///
+    /// `ordered` says whether the query specified a row order. When it did not, the rows are sorted
+    /// here, so that two engines are not compared on something neither of them was asked to do.
+    #[must_use]
+    pub fn finish(mut self, ordered: bool) -> Answer {
+        if !ordered {
+            self.rows.sort_unstable();
+        }
+        let mut body = self.rows.join("\n");
+        if !body.is_empty() {
+            body.push('\n');
+        }
+        Answer {
+            rows: self.rows.len() as u64,
+            columns: self.columns.unwrap_or(0),
+            body,
+        }
+    }
+}
+
+impl Default for Rows {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A row that does not have the same number of columns as the ones before it.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, thiserror::Error)]
+#[error("row {row} has {found} columns and the rows before it have {wanted}")]
+pub struct WidthError {
+    /// Which row, counting from zero.
+    pub row: usize,
+    /// How many columns the result has.
+    pub wanted: usize,
+    /// How many this row had.
+    pub found: usize,
+}
+
+/// What a query produced, canonicalised.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct Answer {
+    /// How many rows came back.
+    pub rows: u64,
+    /// How many columns each row has, or zero for a result with no rows.
+    pub columns: usize,
+    /// The canonical rendering, one row per line, values separated by a tab.
+    ///
+    /// This is what gets digested and compared across systems. It is a `String` rather than a
+    /// digest because the digesting is not the driver's job: a driver that hashes its own results
+    /// is a driver that can agree with itself about a wrong answer.
+    pub body: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn one(value: Value) -> String {
+        let mut rows = Rows::new();
+        rows.push([value]).unwrap();
+        rows.finish(true).body
+    }
+
+    #[test]
+    fn a_float_is_rendered_the_way_a_person_would_write_it() {
+        assert_eq!(one(Value::Float(1.5)), "1.5\n");
+        assert_eq!(one(Value::Float(1.0)), "1\n");
+        assert_eq!(one(Value::Float(-2.25)), "-2.25\n");
+        assert_eq!(one(Value::Float(1234.5)), "1234.5\n");
+    }
+
+    #[test]
+    fn two_engines_that_summed_in_a_different_order_agree() {
+        // The seventh digit apart, which is what a parallel partial sum and a serial one differ by
+        // on a hundred million values, and not the kind of difference this check exists to catch.
+        assert_eq!(
+            one(Value::Float(1_234_567.0)),
+            one(Value::Float(1_234_568.0))
+        );
+        // The sixth, which is.
+        assert_ne!(
+            one(Value::Float(1_234_500.0)),
+            one(Value::Float(1_234_600.0))
+        );
+    }
+
+    #[test]
+    fn zero_has_one_spelling() {
+        assert_eq!(one(Value::Float(0.0)), "0\n");
+        assert_eq!(one(Value::Float(-0.0)), "0\n");
+    }
+
+    #[test]
+    fn a_number_too_large_or_too_small_to_write_plainly_gets_an_exponent() {
+        assert_eq!(one(Value::Float(1.5e300)), "1.5e300\n");
+        assert_eq!(one(Value::Float(2.5e-9)), "2.5e-9\n");
+    }
+
+    #[test]
+    fn what_is_not_a_number_says_so_rather_than_being_dropped() {
+        assert_eq!(one(Value::Float(f64::NAN)), "NaN\n");
+        assert_eq!(one(Value::Float(f64::INFINITY)), "Infinity\n");
+        assert_eq!(one(Value::Float(f64::NEG_INFINITY)), "-Infinity\n");
+    }
+
+    #[test]
+    fn text_that_contains_the_separators_is_escaped() {
+        assert_eq!(one(Value::Text("a\tb".to_owned())), "a\\tb\n");
+        assert_eq!(one(Value::Text("a\nb".to_owned())), "a\\nb\n");
+        assert_eq!(one(Value::Text("a\\b".to_owned())), "a\\\\b\n");
+    }
+
+    #[test]
+    fn text_that_spells_a_null_is_not_a_null() {
+        // Without the backslash escape these two would digest the same, and a driver returning the
+        // literal text would be indistinguishable from one returning nothing.
+        assert_ne!(one(Value::Text("\\N".to_owned())), one(Value::Null));
+    }
+
+    #[test]
+    fn a_query_that_asked_for_no_order_is_not_compared_on_one() {
+        let mut first = Rows::new();
+        first.push([Value::Int(2)]).unwrap();
+        first.push([Value::Int(1)]).unwrap();
+        let mut second = Rows::new();
+        second.push([Value::Int(1)]).unwrap();
+        second.push([Value::Int(2)]).unwrap();
+
+        assert_eq!(first.clone().finish(false), second.clone().finish(false));
+        assert_ne!(first.finish(true), second.finish(true));
+    }
+
+    #[test]
+    fn a_row_of_a_different_width_is_refused_rather_than_rendered() {
+        let mut rows = Rows::new();
+        rows.push([Value::Int(1), Value::Int(2)]).unwrap();
+        let error = rows.push([Value::Int(3)]).unwrap_err();
+        assert_eq!(error.wanted, 2);
+        assert_eq!(error.found, 1);
+    }
+
+    #[test]
+    fn an_empty_result_is_still_an_answer() {
+        let answer = Rows::new().finish(true);
+        assert_eq!(answer.rows, 0);
+        assert_eq!(answer.columns, 0);
+        assert!(answer.body.is_empty());
+    }
+
+    #[test]
+    fn the_row_count_and_the_body_cannot_disagree() {
+        let mut rows = Rows::new();
+        for value in 0..3 {
+            rows.push([Value::Int(value)]).unwrap();
+        }
+        let answer = rows.finish(true);
+        assert_eq!(answer.rows, 3);
+        assert_eq!(answer.body.lines().count(), 3);
+    }
+}

--- a/crates/bench-driver/src/driver.rs
+++ b/crates/bench-driver/src/driver.rs
@@ -1,0 +1,244 @@
+//! The trait every system under test implements, and what it gets told.
+
+use std::path::PathBuf;
+
+use crate::{Answer, Phase, WidthError};
+
+/// A system under test.
+///
+/// Three methods, in the order they happen, and none of them times itself. See [`crate::Session`]
+/// for why the clock lives outside.
+///
+/// Implementations go in `drivers/`, one crate per system, and each one carries a `CONFIG.md`
+/// saying where its configuration came from. A driver that had to guess at a setting records that
+/// it guessed, because a baseline configured by our own guesswork is the thing this whole
+/// repository was built to stop publishing.
+pub trait Driver {
+    /// What the system is called, in the results. Lowercase, no version in it.
+    ///
+    /// Static, because a name is a constant of the system rather than something a driver works out
+    /// from its own state, and a name that could vary between two calls is a name that could vary
+    /// between two rows of the same table.
+    fn name(&self) -> &'static str;
+
+    /// What version of the system this is, as the system itself reports it.
+    ///
+    /// Read from the system rather than from a constant in the driver, so that a machine running
+    /// something other than what the driver was written against says so.
+    fn version(&self) -> String;
+
+    /// Starts the system and applies its configuration.
+    ///
+    /// [`Setup`] carries no file paths, deliberately. See its documentation.
+    ///
+    /// # Errors
+    ///
+    /// If the system will not start or will not accept its configuration.
+    fn prepare(&mut self, setup: &Setup) -> Result<(), DriverError>;
+
+    /// Gets one table in, by whatever means this system gets tables in.
+    ///
+    /// Ingesting into a native format and registering a file where it lies are both correct answers
+    /// here. They are different systems making a different trade, and the load timing is where that
+    /// trade becomes visible.
+    ///
+    /// # Errors
+    ///
+    /// If the files cannot be read or the system will not take them.
+    fn load(&mut self, load: &Load) -> Result<(), DriverError>;
+
+    /// Answers one query.
+    ///
+    /// The [`Answer`] has to be materialised. A system with lazy evaluation that returns a plan
+    /// here has been timed on building a plan, and the comparison against a system that actually
+    /// computed the result is worthless.
+    ///
+    /// # Errors
+    ///
+    /// If the query fails, or if this system cannot express it. Use
+    /// [`DriverError::unsupported`] for the second, so that the query is recorded as unsupported
+    /// rather than as slow.
+    fn run(&mut self, query: &Query) -> Result<Answer, DriverError>;
+}
+
+/// What a system is told before it sees any data.
+///
+/// **There are no file paths here, and that is the whole design.** A driver that was handed the
+/// corpus at preparation time could read it, index it, convert it, or cache it, and all of that
+/// would land in a phase that the load timing is supposed to account for. Preparation gets a
+/// scratch directory, a thread count and a memory budget, and nothing that would let it start
+/// early.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct Setup {
+    /// A directory the system may write to. Empty when preparation starts, and removed after.
+    pub directory: PathBuf,
+    /// How many threads the system is allowed to use.
+    ///
+    /// Set from the machine class rather than left to the system's own default, because a default
+    /// that reads the host's core count makes every result a result about that host.
+    pub threads: usize,
+    /// How many bytes of memory the system is allowed to use.
+    pub memory: u64,
+}
+
+/// One table to get in.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct Load {
+    /// What the queries call this table.
+    pub table: String,
+    /// The files it is in, already verified against the corpus manifest and already on this
+    /// machine. A driver never fetches anything.
+    pub files: Vec<PathBuf>,
+    /// What is in those files.
+    pub format: Format,
+}
+
+/// What a corpus file is.
+///
+/// Small on purpose. Every corpus in scope is either Parquet or a text file with one row per line
+/// and a single separator character, and a format enum with more in it than that would be
+/// describing formats nothing here reads.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[non_exhaustive]
+pub enum Format {
+    /// Apache Parquet.
+    Parquet,
+    /// One row per line, fields separated by one character, with no header row. Covers the comma
+    /// separated `ClickBench` text, the tab separated variants, and the pipe separated tables
+    /// `dbgen` writes.
+    Separated {
+        /// The separator.
+        separator: char,
+    },
+}
+
+/// One query to answer.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct Query {
+    /// What the workload calls this query, such as `q23`. Goes in the result row.
+    pub id: String,
+    /// The SQL, already rewritten for this system if the workload's rules allow a rewrite. Any
+    /// rewrite is recorded in the driver's `CONFIG.md` under deviations.
+    pub sql: String,
+    /// Whether the query specifies its own row order.
+    ///
+    /// When it does not, the rows are sorted before the result is digested, because two systems
+    /// that returned the same rows in a different order both answered the question that was asked.
+    /// See [`crate::answer`].
+    pub ordered: bool,
+}
+
+/// What can go wrong in a driver.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum DriverError {
+    /// A phase was asked for before the phase it depends on.
+    #[error("{phase} was asked for before {wanted}")]
+    OutOfOrder {
+        /// What was asked for.
+        phase: Phase,
+        /// What has to happen first.
+        wanted: Phase,
+    },
+
+    /// A phase that happens once was asked for twice.
+    #[error("{phase} happens once and was asked for again")]
+    Repeated {
+        /// Which phase.
+        phase: Phase,
+    },
+
+    /// This system cannot express this query.
+    ///
+    /// Recorded as unsupported in the results rather than as a failure or, worse, as a fast time
+    /// against an empty answer.
+    #[error("{what} is not supported: {why}")]
+    Unsupported {
+        /// What could not be done, usually the query id.
+        what: String,
+        /// Why not, in enough detail that a reader can tell whether it is a limit of the system or
+        /// a limit of the driver.
+        why: String,
+    },
+
+    /// The rows a driver produced do not form a table.
+    #[error("the result is not a table")]
+    Answer(#[from] WidthError),
+
+    /// Anything the system itself reported.
+    #[error("{context}")]
+    System {
+        /// What was being attempted.
+        context: String,
+        /// What the system said.
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+}
+
+impl DriverError {
+    /// Says that this system cannot express something.
+    pub fn unsupported(what: impl Into<String>, why: impl Into<String>) -> Self {
+        Self::Unsupported {
+            what: what.into(),
+            why: why.into(),
+        }
+    }
+
+    /// Wraps whatever the system under test returned, with a note about what was being attempted.
+    pub fn system(
+        context: impl Into<String>,
+        source: impl Into<Box<dyn std::error::Error + Send + Sync>>,
+    ) -> Self {
+        Self::System {
+            context: context.into(),
+            source: source.into(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preparation_cannot_be_handed_the_data() {
+        // Written as a test rather than only as a comment, because the day someone adds a files
+        // field to Setup is the day loading stops being measurable, and a compile error is a
+        // better place to have that conversation than a review.
+        let setup = Setup {
+            directory: PathBuf::from("scratch"),
+            threads: 4,
+            memory: 1 << 30,
+        };
+        let rendered = format!("{setup:?}");
+        assert!(!rendered.contains("files"));
+        assert!(!rendered.contains("table"));
+    }
+
+    #[test]
+    fn an_unsupported_query_says_which_and_why() {
+        let error = DriverError::unsupported("q29", "no regexp_replace in this system");
+        assert_eq!(
+            error.to_string(),
+            "q29 is not supported: no regexp_replace in this system"
+        );
+    }
+
+    #[test]
+    fn a_system_error_keeps_what_the_system_said() {
+        let inner = std::io::Error::other("connection reset");
+        let error = DriverError::system("loading hits", inner);
+        assert_eq!(error.to_string(), "loading hits");
+        assert!(std::error::Error::source(&error).is_some());
+    }
+
+    #[test]
+    fn a_separator_is_a_character_rather_than_a_named_format() {
+        // The three text corpora in scope differ only in this character, and naming them Csv, Tsv
+        // and Tbl would mean adding a variant the next time a corpus picks a fourth one.
+        assert_ne!(
+            Format::Separated { separator: ',' },
+            Format::Separated { separator: '|' }
+        );
+    }
+}

--- a/crates/bench-driver/src/lib.rs
+++ b/crates/bench-driver/src/lib.rs
@@ -1,10 +1,86 @@
 //! The trait every system under test implements.
 //!
-//! The prepare, load and run split is fixed here for everyone, so that no
-//! system can move work into an untimed phase that another system pays for.
+//! The prepare, load and run split is fixed here for everyone, so that no system can move work into
+//! an untimed phase that another system pays for. A driver implements [`Driver`], and a [`Session`]
+//! drives it and holds the clock.
 //!
-//! Nothing is implemented yet. See the milestone that owns this crate in
-//! `docs/ROADMAP.md`.
+//! ```
+//! use bench_driver::{Answer, Driver, DriverError, Format, Load, Query, Rows, Session, Setup, Value};
+//!
+//! struct Counting {
+//!     rows: i64,
+//! }
+//!
+//! impl Driver for Counting {
+//!     fn name(&self) -> &'static str {
+//!         "counting"
+//!     }
+//!
+//!     fn version(&self) -> String {
+//!         "1".to_owned()
+//!     }
+//!
+//!     fn prepare(&mut self, _setup: &Setup) -> Result<(), DriverError> {
+//!         Ok(())
+//!     }
+//!
+//!     fn load(&mut self, load: &Load) -> Result<(), DriverError> {
+//!         self.rows += load.files.len() as i64;
+//!         Ok(())
+//!     }
+//!
+//!     fn run(&mut self, _query: &Query) -> Result<Answer, DriverError> {
+//!         let mut rows = Rows::new();
+//!         rows.push([Value::Int(self.rows)])?;
+//!         Ok(rows.finish(false))
+//!     }
+//! }
+//!
+//! let mut driver = Counting { rows: 0 };
+//! let mut session = Session::new(&mut driver);
+//!
+//! session.prepare(&Setup {
+//!     directory: std::path::PathBuf::from("scratch"),
+//!     threads: 1,
+//!     memory: 1 << 30,
+//! })?;
+//! session.load(&Load {
+//!     table: "hits".to_owned(),
+//!     files: vec![std::path::PathBuf::from("hits.parquet")],
+//!     format: Format::Parquet,
+//! })?;
+//! let (answer, _nanoseconds) = session.query(&Query {
+//!     id: "q0".to_owned(),
+//!     sql: "SELECT 1".to_owned(),
+//!     ordered: false,
+//! })?;
+//!
+//! assert_eq!(answer.body, "1\n");
+//!
+//! // All three, always, whatever the system did in each.
+//! let phases = session.phases();
+//! assert!(phases.prepare > 0.0 && phases.load > 0.0 && phases.run > 0.0);
+//! # Ok::<(), DriverError>(())
+//! ```
+//!
+//! # The two things a driver does not get to decide
+//!
+//! **Where one phase ends.** [`Setup`] carries no file paths, so a load cannot hide inside
+//! preparation and no index can be built there. [`Session`] refuses to answer a query before
+//! something has been loaded, so a system that read the data early has to say so.
+//!
+//! **What its results look like.** [`Answer`] is a canonical rendering built through [`Rows`], and
+//! [`crate::answer`] documents the two decisions in it that have a real cost. Drivers do not hash
+//! their own output, because a driver that hashes its own output can agree with itself about a
+//! wrong answer.
+
+pub mod answer;
+mod driver;
+mod phase;
+
+pub use answer::{Answer, Rows, Value, WidthError};
+pub use driver::{Driver, DriverError, Format, Load, Query, Setup};
+pub use phase::{Phase, Phases, Session};
 
 /// The version of this crate, as reported by build metadata.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/crates/bench-driver/src/phase.rs
+++ b/crates/bench-driver/src/phase.rs
@@ -1,0 +1,365 @@
+//! The three phases, and the only way to get a driver to do any of them.
+//!
+//! Conflating preparation, loading and querying is the most common way a benchmark accidentally
+//! measures the wrong thing. Load time charged to query time makes a system look slow. Index build
+//! time hidden inside preparation makes it look fast. Neither is usually deliberate, and both are
+//! easy to do by accident when each driver decides for itself where one phase ends and the next
+//! begins.
+//!
+//! So the driver does not decide, and the driver does not report its own timings either. A
+//! [`Session`] borrows the driver exclusively, calls the three methods itself, and times each call
+//! from the outside. While a session exists nothing else can reach the driver, so there is no
+//! second path by which work could happen untimed. A driver that wants to look fast has to actually
+//! be fast, because the clock is not in its hands.
+//!
+//! # What the ordering rule is for
+//!
+//! A session refuses to load before preparing and refuses to query before loading. The second of
+//! those is the one that earns its keep: a system that answered a query without ever being loaded
+//! read the data during preparation, and the whole point of the split is that this shows up rather
+//! than being absorbed into a phase nobody looks at.
+//!
+//! Preparation happens once. Loading can happen many times, because TPC-H is eight tables and
+//! `ClickBench` is one, and a driver should not have to pretend otherwise.
+
+use std::fmt;
+
+use crate::{Answer, Driver, DriverError, Load, Query, Setup};
+
+/// Which of the three phases.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Phase {
+    /// Starting the system and applying its configuration. No data is in sight yet.
+    Prepare,
+    /// Getting a table in. Whether that means ingesting it or registering a file where it lies is
+    /// the difference this phase exists to make visible.
+    Load,
+    /// Answering a query.
+    Run,
+}
+
+impl fmt::Display for Phase {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Prepare => "prepare",
+            Self::Load => "load",
+            Self::Run => "run",
+        })
+    }
+}
+
+/// What each phase cost, in nanoseconds.
+///
+/// Every driver reports all three, always. A driver that reads its files in place rather than
+/// ingesting them has a small load and a large run, one that builds a copy has the opposite, and
+/// both of those are true things about the system that a single total would hide.
+#[derive(Clone, Copy, PartialEq, Debug, Default, serde::Serialize, serde::Deserialize)]
+pub struct Phases {
+    /// Nanoseconds spent in [`Driver::prepare`].
+    pub prepare: f64,
+    /// Nanoseconds spent in [`Driver::load`], summed over every table.
+    pub load: f64,
+    /// Nanoseconds spent in [`Driver::run`], summed over every query.
+    pub run: f64,
+    /// How many tables were loaded.
+    pub tables: u32,
+    /// How many queries were answered.
+    pub queries: u32,
+}
+
+impl Phases {
+    /// Everything the driver was in, in nanoseconds.
+    ///
+    /// Reported alongside the three rather than instead of them. A total on its own is the number
+    /// this module exists to stop being the only one published.
+    #[must_use]
+    pub fn total(&self) -> f64 {
+        self.prepare + self.load + self.run
+    }
+}
+
+/// One driver, from preparation to the last query, with a clock on every phase.
+///
+/// Constructed with [`Session::new`], which takes the driver mutably for as long as the session
+/// lives.
+pub struct Session<'a> {
+    /// The driver being measured. Held mutably so that nothing else can call it while the session
+    /// is open, which is what makes "every phase is timed" a property rather than a convention.
+    driver: &'a mut dyn Driver,
+    /// What has been spent so far.
+    phases: Phases,
+    /// Whether preparation has happened.
+    prepared: bool,
+    /// Whether at least one table has been loaded.
+    loaded: bool,
+}
+
+impl fmt::Debug for Session<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Session")
+            .field("driver", &self.driver.name())
+            .field("phases", &self.phases)
+            .field("prepared", &self.prepared)
+            .field("loaded", &self.loaded)
+            .finish()
+    }
+}
+
+impl<'a> Session<'a> {
+    /// Takes the driver for the duration of a run.
+    pub fn new(driver: &'a mut dyn Driver) -> Self {
+        Self {
+            driver,
+            phases: Phases::default(),
+            prepared: false,
+            loaded: false,
+        }
+    }
+
+    /// Starts the system and applies its configuration, and returns what that cost in nanoseconds.
+    ///
+    /// # Errors
+    ///
+    /// If the driver fails, or if preparation has already happened.
+    pub fn prepare(&mut self, setup: &Setup) -> Result<f64, DriverError> {
+        if self.prepared {
+            return Err(DriverError::Repeated {
+                phase: Phase::Prepare,
+            });
+        }
+        let (result, elapsed) = bench_core::time(|| self.driver.prepare(setup));
+        result?;
+        self.prepared = true;
+        self.phases.prepare += elapsed;
+        Ok(elapsed)
+    }
+
+    /// Gets one table in, and returns what that cost in nanoseconds.
+    ///
+    /// # Errors
+    ///
+    /// If the driver fails, or if the system has not been prepared.
+    pub fn load(&mut self, load: &Load) -> Result<f64, DriverError> {
+        if !self.prepared {
+            return Err(DriverError::OutOfOrder {
+                phase: Phase::Load,
+                wanted: Phase::Prepare,
+            });
+        }
+        let (result, elapsed) = bench_core::time(|| self.driver.load(load));
+        result?;
+        self.loaded = true;
+        self.phases.load += elapsed;
+        self.phases.tables += 1;
+        Ok(elapsed)
+    }
+
+    /// Answers one query, and returns the answer along with what it cost in nanoseconds.
+    ///
+    /// # Errors
+    ///
+    /// If the driver fails, or if nothing has been loaded.
+    pub fn query(&mut self, query: &Query) -> Result<(Answer, f64), DriverError> {
+        if !self.loaded {
+            return Err(DriverError::OutOfOrder {
+                phase: Phase::Run,
+                wanted: Phase::Load,
+            });
+        }
+        let (result, elapsed) = bench_core::time(|| self.driver.run(query));
+        let answer = result?;
+        self.phases.run += elapsed;
+        self.phases.queries += 1;
+        Ok((answer, elapsed))
+    }
+
+    /// What has been spent so far, by phase.
+    #[must_use]
+    pub fn phases(&self) -> Phases {
+        self.phases
+    }
+
+    /// What the driver calls itself, for the result row.
+    #[must_use]
+    pub fn name(&self) -> &'static str {
+        self.driver.name()
+    }
+
+    /// What version of the system this is, for the result row.
+    #[must_use]
+    pub fn version(&self) -> String {
+        self.driver.version()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+    use crate::{Format, Rows, Value};
+
+    /// A driver that records what it was asked to do and takes no time doing it.
+    #[derive(Default)]
+    struct Recording {
+        calls: Vec<Phase>,
+        fails: Option<Phase>,
+    }
+
+    impl Driver for Recording {
+        fn name(&self) -> &'static str {
+            "recording"
+        }
+
+        fn version(&self) -> String {
+            "0".to_owned()
+        }
+
+        fn prepare(&mut self, _setup: &Setup) -> Result<(), DriverError> {
+            self.calls.push(Phase::Prepare);
+            self.fail(Phase::Prepare)
+        }
+
+        fn load(&mut self, _load: &Load) -> Result<(), DriverError> {
+            self.calls.push(Phase::Load);
+            self.fail(Phase::Load)?;
+            Ok(())
+        }
+
+        fn run(&mut self, _query: &Query) -> Result<Answer, DriverError> {
+            self.calls.push(Phase::Run);
+            self.fail(Phase::Run)?;
+            let mut rows = Rows::new();
+            rows.push([Value::Int(1)])?;
+            Ok(rows.finish(false))
+        }
+    }
+
+    impl Recording {
+        fn fail(&self, phase: Phase) -> Result<(), DriverError> {
+            if self.fails == Some(phase) {
+                return Err(DriverError::unsupported(phase.to_string(), "asked to fail"));
+            }
+            Ok(())
+        }
+    }
+
+    fn setup() -> Setup {
+        Setup {
+            directory: PathBuf::from("scratch"),
+            threads: 1,
+            memory: 1 << 30,
+        }
+    }
+
+    fn load() -> Load {
+        Load {
+            table: "hits".to_owned(),
+            files: vec![PathBuf::from("hits.parquet")],
+            format: Format::Parquet,
+        }
+    }
+
+    fn query() -> Query {
+        Query {
+            id: "q0".to_owned(),
+            sql: "SELECT 1".to_owned(),
+            ordered: false,
+        }
+    }
+
+    #[test]
+    fn every_phase_is_timed_and_counted() {
+        let mut driver = Recording::default();
+        let mut session = Session::new(&mut driver);
+
+        session.prepare(&setup()).unwrap();
+        session.load(&load()).unwrap();
+        session.load(&load()).unwrap();
+        session.query(&query()).unwrap();
+        session.query(&query()).unwrap();
+
+        let phases = session.phases();
+        assert_eq!(phases.tables, 2);
+        assert_eq!(phases.queries, 2);
+        assert!(phases.prepare > 0.0);
+        assert!(phases.load > 0.0);
+        assert!(phases.run > 0.0);
+        assert!(phases.total() >= phases.prepare + phases.load + phases.run - 1.0);
+    }
+
+    #[test]
+    fn a_query_before_a_load_is_refused_rather_than_answered() {
+        // A system that can answer without having been loaded read the data during preparation,
+        // which is the exact thing the split exists to make visible.
+        let mut driver = Recording::default();
+        let error = {
+            let mut session = Session::new(&mut driver);
+            session.prepare(&setup()).unwrap();
+            session.query(&query()).unwrap_err()
+        };
+
+        assert!(matches!(
+            error,
+            DriverError::OutOfOrder {
+                phase: Phase::Run,
+                wanted: Phase::Load
+            }
+        ));
+        assert_eq!(driver.calls, [Phase::Prepare]);
+    }
+
+    #[test]
+    fn a_load_before_a_prepare_is_refused_rather_than_run() {
+        let mut driver = Recording::default();
+        let error = Session::new(&mut driver).load(&load()).unwrap_err();
+
+        assert!(matches!(
+            error,
+            DriverError::OutOfOrder {
+                phase: Phase::Load,
+                wanted: Phase::Prepare
+            }
+        ));
+        assert!(driver.calls.is_empty());
+    }
+
+    #[test]
+    fn preparing_twice_is_refused() {
+        let mut driver = Recording::default();
+        let mut session = Session::new(&mut driver);
+
+        session.prepare(&setup()).unwrap();
+        let error = session.prepare(&setup()).unwrap_err();
+        assert!(matches!(
+            error,
+            DriverError::Repeated {
+                phase: Phase::Prepare
+            }
+        ));
+    }
+
+    #[test]
+    fn a_phase_that_failed_is_not_counted_as_one_that_happened() {
+        let mut driver = Recording {
+            fails: Some(Phase::Load),
+            ..Recording::default()
+        };
+        let mut session = Session::new(&mut driver);
+
+        session.prepare(&setup()).unwrap();
+        session.load(&load()).unwrap_err();
+
+        assert_eq!(session.phases().tables, 0);
+        // And the run phase is still closed, because nothing was ever loaded.
+        assert!(session.query(&query()).is_err());
+    }
+
+    #[test]
+    fn the_phases_read_as_the_words_a_person_would_use() {
+        assert_eq!(Phase::Prepare.to_string(), "prepare");
+        assert_eq!(Phase::Load.to_string(), "load");
+        assert_eq!(Phase::Run.to_string(), "run");
+    }
+}

--- a/docs/METHODOLOGY.md
+++ b/docs/METHODOLOGY.md
@@ -34,6 +34,20 @@ All three are separate metrics. None of them is the default. The tier and the ca
 
 Cross platform comparison of cold numbers is prohibited, because the primitive for dropping a cache is not equivalent across operating systems and the resulting numbers are not measuring the same thing.
 
+## The three phases
+
+Every system under test is driven through the same three phases, and each one is timed separately. Prepare is starting the system and applying its configuration. Load is getting a table in. Run is answering a query. Conflating them is the most common way a benchmark accidentally measures the wrong thing: load time charged to query time makes a system look slow, and an index built during preparation makes it look fast.
+
+Preparation is not given any file paths. That is the mechanism rather than a convention, because a driver handed the corpus before the load phase could read it, index it, convert it, or cache it, and every one of those would land in the phase the load timing is supposed to account for. Preparation gets a scratch directory, a thread count and a memory budget, and nothing it could start early with.
+
+A query cannot be answered before something has been loaded. A system that could answer one read the data during preparation, and the split exists precisely so that this shows up rather than disappearing into a phase nobody looks at.
+
+The driver does not hold the clock. The harness borrows the driver, calls the three methods itself, and times each call from the outside, so a driver cannot report a preparation that took no time. Drivers are checked in CI for a clock of their own, and a crate under `drivers/` that does not implement the trait fails the build, which is what makes "every driver reports all three" a property rather than an intention.
+
+All three phases are always reported. A driver that reads its files in place has a small load and a large run, one that ingests into a native format has the opposite, and both of those are true things about the system that a single total would hide. Loading can happen many times, because TPC-H is eight tables and ClickBench is one.
+
+A query has to return a materialised result. A system with lazy evaluation that hands back a plan has been timed on building a plan, and comparing that against a system that actually computed the answer is not a comparison.
+
 ## What gets compared
 
 Decode loop time, format scan time, and end to end query time are three different measurements and they are stored as three different metrics. Most of the apparent contradictions in the published literature come from comparing one against another. Nobody involved was being dishonest, they were answering different questions that share a word.
@@ -47,6 +61,10 @@ Where many comparisons are made at once, the multiplicity is accounted for, beca
 Every query produces a digest of its canonicalised result, and the digests are compared across systems. A row whose result does not match is marked incorrect and its timings are excluded from every aggregate.
 
 This is not paranoia. The motivating example in the fair benchmarking literature is a prototype that was faster because it used hardcoded group counts, types too small to hold the aggregate, and unhandled overflow. It was, of course, faster. A digest catches that class of thing without anyone having to suspect it.
+
+Canonicalised is the load bearing word, because three systems asked the same question return the same answer in three different shapes and none of those shapes is wrong. So the rendering is defined once, in the trait crate, and no driver renders its own results. Nulls have one spelling, text is escaped so that a value which happens to look like a null is not one, and drivers do not hash their own output, since a driver that hashes its own output can agree with itself about a wrong answer.
+
+Two of the rules cost something and are worth stating. Floats are rendered to six significant digits, because two engines summing a hundred million values will not agree past that when one adds them in parallel partial sums and the other in order. Six digits survives that and still catches a hardcoded group count or an overflowed accumulator, neither of which is a seventh digit difference. What it gives up is a genuine small error, and that is the price of a digest, which cannot express a tolerance. Rows are sorted unless the query specified an order, because two systems that returned the same rows in a different order both answered the question that was asked, and a query that does specify an order gets that order checked.
 
 ## Pre-registration
 

--- a/drivers/driver-null/CONFIG.md
+++ b/drivers/driver-null/CONFIG.md
@@ -4,6 +4,8 @@
 
 Not applicable. This driver does no work, so there is nothing to configure and nothing to get wrong. It exists so that running the harness against a system that does nothing measures what the harness itself costs.
 
+It implements the trait in full and returns an empty result from every query. That means every digest it produces disagrees with every real system, which is the correct outcome for a driver that computed nothing, and it is why this driver never appears in a results table.
+
 ## Settings
 
 None.
@@ -18,4 +20,4 @@ Measuring instrumentation overhead by subtracting two real systems was considere
 
 ## Last reviewed
 
-2026-09-04
+2026-09-06

--- a/drivers/driver-null/README.md
+++ b/drivers/driver-null/README.md
@@ -2,10 +2,8 @@
 
 A driver that does nothing.
 
-Running the harness against a system that does no work measures what the
+Running the harness against a system that does no work measures what the harness itself costs. The instrumentation budget is one percent, and this is how it is checked.
 
-harness itself costs. The instrumentation budget is one percent, and this is
-
-how it is checked.
+It is not a system under test and it never appears in a results table. It implements the trait in full and returns an empty result from every query, so every digest it produces disagrees with every real system, which is the right answer for a driver that computed nothing.
 
 Part of [iris-bench](https://github.com/tamnd/iris-bench). Licensed under Apache-2.0.

--- a/drivers/driver-null/src/lib.rs
+++ b/drivers/driver-null/src/lib.rs
@@ -1,11 +1,141 @@
 //! A driver that does nothing.
 //!
-//! Running the harness against a system that does no work measures what the
-//! harness itself costs. The instrumentation budget is one percent, and this is
-//! how it is checked.
+//! Running the harness against a system that does no work measures what the harness itself costs.
+//! The instrumentation budget is one percent, and this is how it is checked.
 //!
-//! Nothing is implemented yet. See the milestone that owns this crate in
-//! `docs/ROADMAP.md`.
+//! It is not a system under test and it never appears in a results table. Its answers are empty, so
+//! every result digest it produces disagrees with every real system, which is the correct outcome
+//! for a driver that did not compute anything.
+//!
+//! What it does record is what it was asked to do, so that a test can assert the harness called the
+//! phases in the right order with the right arguments without needing a database installed.
+
+use std::path::PathBuf;
+
+use bench_driver::{Answer, Driver, DriverError, Load, Query, Rows, Setup};
 
 /// The version of this crate, as reported by build metadata.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// A system that does nothing, as fast as nothing can be done.
+#[derive(Clone, PartialEq, Eq, Debug, Default)]
+pub struct Null {
+    /// The scratch directory preparation was given, once it has been.
+    pub directory: Option<PathBuf>,
+    /// The tables it was asked to load, in order.
+    pub tables: Vec<String>,
+    /// The query ids it was asked to answer, in order.
+    pub queries: Vec<String>,
+}
+
+impl Null {
+    /// A driver that has not been asked to do anything yet.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Driver for Null {
+    fn name(&self) -> &'static str {
+        "null"
+    }
+
+    fn version(&self) -> String {
+        VERSION.to_owned()
+    }
+
+    fn prepare(&mut self, setup: &Setup) -> Result<(), DriverError> {
+        self.directory = Some(setup.directory.clone());
+        Ok(())
+    }
+
+    fn load(&mut self, load: &Load) -> Result<(), DriverError> {
+        self.tables.push(load.table.clone());
+        Ok(())
+    }
+
+    fn run(&mut self, query: &Query) -> Result<Answer, DriverError> {
+        self.queries.push(query.id.clone());
+        // No rows, because no work was done. A driver that returned a plausible looking answer here
+        // would let a harness bug pass the correctness check on the one driver that cannot
+        // possibly be correct.
+        Ok(Rows::new().finish(query.ordered))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bench_driver::{Format, Session};
+
+    use super::*;
+
+    fn setup() -> Setup {
+        Setup {
+            directory: PathBuf::from("scratch"),
+            threads: 1,
+            memory: 1 << 30,
+        }
+    }
+
+    #[test]
+    fn it_reports_all_three_phases() {
+        let mut driver = Null::new();
+        let mut session = Session::new(&mut driver);
+
+        session.prepare(&setup()).unwrap();
+        session
+            .load(&Load {
+                table: "hits".to_owned(),
+                files: vec![PathBuf::from("hits.parquet")],
+                format: Format::Parquet,
+            })
+            .unwrap();
+        let (answer, _) = session
+            .query(&Query {
+                id: "q0".to_owned(),
+                sql: "SELECT 1".to_owned(),
+                ordered: false,
+            })
+            .unwrap();
+
+        let phases = session.phases();
+        assert!(phases.prepare > 0.0);
+        assert!(phases.load > 0.0);
+        assert!(phases.run > 0.0);
+        assert_eq!(phases.tables, 1);
+        assert_eq!(phases.queries, 1);
+
+        // Nothing was computed, so there is nothing to report having computed.
+        assert_eq!(answer.rows, 0);
+        assert!(answer.body.is_empty());
+    }
+
+    #[test]
+    fn it_records_what_it_was_asked_to_do() {
+        let mut driver = Null::new();
+        {
+            let mut session = Session::new(&mut driver);
+            session.prepare(&setup()).unwrap();
+            session
+                .load(&Load {
+                    table: "lineitem".to_owned(),
+                    files: Vec::new(),
+                    format: Format::Separated { separator: '|' },
+                })
+                .unwrap();
+        }
+
+        assert_eq!(driver.directory, Some(PathBuf::from("scratch")));
+        assert_eq!(driver.tables, ["lineitem"]);
+        assert!(driver.queries.is_empty());
+    }
+
+    #[test]
+    fn it_names_itself_without_a_version_in_the_name() {
+        let driver = Null::new();
+        assert_eq!(driver.name(), "null");
+        assert!(!driver.name().contains(|c: char| c.is_ascii_digit()));
+        assert_eq!(driver.version(), VERSION);
+    }
+}


### PR DESCRIPTION
Closes #14.

Conflating preparation, loading and querying is the most common way a benchmark accidentally measures the wrong thing. Load time charged to query time makes a system look slow, and an index built during preparation makes it look fast. Neither is usually deliberate, and both are easy to do by accident when each driver decides for itself where one phase ends and the next begins.

So the driver does not decide, and it does not report its own timings either. A `Session` borrows the driver exclusively, calls the three methods itself, and times each call from the outside. While a session exists nothing else can reach the driver, so there is no second path by which work could happen untimed.

## The two things that are mechanism rather than convention

`Setup` carries no file paths. A driver handed the corpus at preparation time could read it, index it, convert it, or cache it, and every one of those would land in the phase the load timing is supposed to account for. Preparation gets a scratch directory, a thread count and a memory budget, and nothing it could start early with. There is a test that asserts this, because the day someone adds a files field is the day loading stops being measurable, and a failing test is a better place to have that conversation than a review.

A query is refused before anything has been loaded. A system that can answer one read the data during preparation, and the whole point of the split is that this shows up rather than being absorbed into a phase nobody looks at.

## Why the result rendering is in this PR

It could have waited for #20, which is where the digests get compared. It did not wait, because #15, #16 and #17 all land first, and three drivers written against no canonical format is three formats that then have to be reconciled.

Three systems asked the same question return the same answer in three different shapes: different float formatting, different null spellings, different row order for a query that never specified one. None of those is a wrong answer and all of them are a different digest. Two of the rules cost something and are worth stating plainly.

Floats are rendered to six significant digits. Two engines summing a hundred million values will not agree past that, because a parallel partial sum and a serial one add the same numbers in a different order. Six digits survives that and still catches the class of thing the check exists for, since a hardcoded group count or an overflowed accumulator is not a seventh digit difference. What it gives up is a genuine small error, and that is the price of a digest, which cannot express a tolerance.

Rows are sorted unless the query specified an order. A query with no `ORDER BY` has no defined row order, so comparing two engines on the order they happened to produce is comparing them on something neither was asked to do. When the query does specify an order, the rows are left alone and the order is part of what is checked.

## What CI now refuses

A crate under `drivers/` that does not implement the trait, which is what makes "every driver reports all three" a property rather than an intention. A crate under `drivers/` that reaches for a clock of its own outside its tests, because a driver holding a clock can report a preparation that took no time.

## Also here

`driver-null` implements the trait for real. It returns an empty result from every query, so every digest it produces disagrees with every real system, which is the correct outcome for a driver that computed nothing. `docs/METHODOLOGY.md` gains a section on the three phases and the canonicalisation rules. The two crate READMEs lose the blank lines that were sitting in the middle of their sentences.

## Checked locally

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace --all-targets --all-features`, `cargo test --workspace --doc`, `cargo check --locked --workspace`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`, `python3 ci/discipline.py`, `python3 ci/test_discipline.py`. All green.
