### PR TITLE
The DuckDB driver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,10 +97,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
+name = "arrow"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cfdd0833e32a9874d2b55089333ad310c0be208aafa277385ce2461dec90be3"
+dependencies = [
+ "arrow-arith",
+ "arrow-array 58.4.0",
+ "arrow-buffer 58.4.0",
+ "arrow-cast",
+ "arrow-data 58.4.0",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema 58.4.0",
+ "arrow-select 58.4.0",
+ "arrow-string",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a41203398f0eaa6f7ec8e62c0da742a21abf282c148fc157f6c35c90e29981a"
+dependencies = [
+ "arrow-array 58.4.0",
+ "arrow-buffer 58.4.0",
+ "arrow-data 58.4.0",
+ "arrow-schema 58.4.0",
+ "chrono",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-array"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae33dad492b7df00a217563a7b0ef2874df68a0deea1b1a3acf628152f7f7a69"
+dependencies = [
+ "ahash",
+ "arrow-buffer 58.4.0",
+ "arrow-data 58.4.0",
+ "arrow-schema 58.4.0",
+ "chrono",
+ "half",
+ "hashbrown 0.17.1",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "arrow-array"
@@ -109,14 +168,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e5f6adeffdf587d7a31db5d2266189624b526730cd3627f9ff9fedae97ad584"
 dependencies = [
  "ahash",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-buffer 59.3.0",
+ "arrow-data 59.3.0",
+ "arrow-schema 59.3.0",
  "chrono",
  "half",
- "hashbrown",
+ "hashbrown 0.17.1",
  "num-complex",
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9552f96391c005e6ab449fa941420935e7e062489b12b8b1b08879b2163f5b5"
+dependencies = [
+ "bytes",
+ "half",
+ "num-bigint 0.4.8",
  "num-traits",
 ]
 
@@ -128,7 +199,42 @@ checksum = "097d193003ce7995d5d087089069ec2a6e0187faf5a6f8c9f38af2645d987182"
 dependencies = [
  "bytes",
  "half",
- "num-bigint",
+ "num-bigint 0.5.1",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8a327c9649f30d8406995f27642b68df354713cca3baaaf100f076f18d5f34"
+dependencies = [
+ "arrow-array 58.4.0",
+ "arrow-buffer 58.4.0",
+ "arrow-data 58.4.0",
+ "arrow-ord",
+ "arrow-schema 58.4.0",
+ "arrow-select 58.4.0",
+ "atoi",
+ "base64 0.22.1",
+ "chrono",
+ "comfy-table 7.1.4",
+ "half",
+ "lexical-core",
+ "num-traits",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-data"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b24852db04738907e06c04ea61e42fe7fda962a34513022dc0d0e754fb7976b"
+dependencies = [
+ "arrow-buffer 58.4.0",
+ "arrow-schema 58.4.0",
+ "half",
+ "num-integer",
  "num-traits",
 ]
 
@@ -138,8 +244,8 @@ version = "59.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ba2f832eaeca24b8f26143dba750e42ee4ab51cf7d65e701ca9607cfda9f358"
 dependencies = [
- "arrow-buffer",
- "arrow-schema",
+ "arrow-buffer 59.3.0",
+ "arrow-schema 59.3.0",
  "half",
  "num-integer",
  "num-traits",
@@ -151,12 +257,47 @@ version = "59.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcc41681ea80f521df14c36725b74d4c60702c47f0793af2be469c04527e2599"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 59.3.0",
+ "arrow-buffer 59.3.0",
+ "arrow-data 59.3.0",
+ "arrow-schema 59.3.0",
+ "arrow-select 59.3.0",
  "flatbuffers",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63a083ec750f5c043f02946b4baf05fcdbb55f4560a3277055caca5cc99f3eb0"
+dependencies = [
+ "arrow-array 58.4.0",
+ "arrow-buffer 58.4.0",
+ "arrow-data 58.4.0",
+ "arrow-schema 58.4.0",
+ "arrow-select 58.4.0",
+]
+
+[[package]]
+name = "arrow-row"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "514ba0ef0d4c5896202dae736251ce415abb43a950bed570fb7981b8716c0e4c"
+dependencies = [
+ "arrow-array 58.4.0",
+ "arrow-buffer 58.4.0",
+ "arrow-data 58.4.0",
+ "arrow-schema 58.4.0",
+ "half",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21ca356ad6425cecb6eb7b28e4f659f1ee7880fbb1a16127de7dd62901efee9e"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -167,15 +308,55 @@ checksum = "10fab8d4563491417ba801fab29d205104d20d4bdf37bda6cd1cf425cff598cd"
 
 [[package]]
 name = "arrow-select"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c58da39eb3d8350ad4a549e5c2bc49284dac554016c69829310350f1731b0aad"
+dependencies = [
+ "ahash",
+ "arrow-array 58.4.0",
+ "arrow-buffer 58.4.0",
+ "arrow-data 58.4.0",
+ "arrow-schema 58.4.0",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-select"
 version = "59.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc58569193c2525915f3cc6310edba3792f1200f65d6e9ed330aa33e691493b8"
 dependencies = [
  "ahash",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 59.3.0",
+ "arrow-buffer 59.3.0",
+ "arrow-data 59.3.0",
+ "arrow-schema 59.3.0",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-string"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6789b388467525e3271326b6b4915666ecfdf5142aef09779445c954b67543c"
+dependencies = [
+ "arrow-array 58.4.0",
+ "arrow-buffer 58.4.0",
+ "arrow-data 58.4.0",
+ "arrow-schema 58.4.0",
+ "arrow-select 58.4.0",
+ "memchr",
+ "num-traits",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
  "num-traits",
 ]
 
@@ -184,6 +365,12 @@ name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64"
@@ -245,7 +432,7 @@ version = "0.2.0"
 dependencies = [
  "bench-core",
  "bench-store",
- "comfy-table",
+ "comfy-table 8.0.0",
  "serde",
  "thiserror",
 ]
@@ -270,8 +457,8 @@ dependencies = [
 name = "bench-store"
 version = "0.2.0"
 dependencies = [
- "arrow-array",
- "arrow-schema",
+ "arrow-array 59.3.0",
+ "arrow-schema 59.3.0",
  "bench-core",
  "parquet",
  "serde",
@@ -315,6 +502,12 @@ name = "camino"
 version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb1307f12aa967b5a58416e87b3653360e0fd614a016b6e970db08fecbb1b80d"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
@@ -405,11 +598,22 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "comfy-table"
+version = "7.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a"
+dependencies = [
+ "crossterm 0.28.1",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "comfy-table"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "136c8c4c3823846e8ba6d4bda011b4e5d5827b8bb0ac26c31f9ab31abe9f54f2"
 dependencies = [
- "crossterm",
+ "crossterm 0.29.0",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -466,6 +670,19 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "parking_lot",
+ "rustix 0.38.44",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
@@ -474,7 +691,7 @@ dependencies = [
  "crossterm_winapi",
  "document-features",
  "parking_lot",
- "rustix",
+ "rustix 1.1.4",
  "winapi",
 ]
 
@@ -492,6 +709,17 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "dispatch2"
@@ -513,10 +741,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "driver-duckdb"
+version = "0.2.0"
+dependencies = [
+ "bench-driver",
+ "duckdb",
+ "tempfile",
+]
+
+[[package]]
 name = "driver-null"
 version = "0.2.0"
 dependencies = [
  "bench-driver",
+]
+
+[[package]]
+name = "duckdb"
+version = "1.10505.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "970e05eedd3f55c435194d9104f90a9b4a79a80d6e73251bc9ff43e178130c4e"
+dependencies = [
+ "arrow",
+ "cast",
+ "comfy-table 7.1.4",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libduckdb-sys",
+ "num-integer",
+ "strum",
 ]
 
 [[package]]
@@ -534,6 +788,18 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
@@ -577,6 +843,12 @@ dependencies = [
  "miniz_oxide",
  "zlib-rs",
 ]
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "futures-core"
@@ -651,9 +923,27 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "heck"
@@ -714,7 +1004,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc4e190f5d26ca7051642629da2c52fc03bde85a03197c99408dcd291734c855"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -787,16 +1077,96 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lexical-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
+name = "libduckdb-sys"
+version = "1.10505.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb514dab5e271e849235c1cb98bd65a2ae107fbd619a6740219319c54a71d95"
+dependencies = [
+ "cc",
+ "flate2",
+ "pkg-config",
+ "serde",
+ "serde_json",
+ "tar",
+ "ureq",
+ "vcpkg",
+ "zip",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -866,6 +1236,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -1005,18 +1385,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff322f54b1a0f9288e614ed1f2d329b380af5476420db19f46ffb865e1163d73"
 dependencies = [
  "ahash",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
+ "arrow-array 59.3.0",
+ "arrow-buffer 59.3.0",
+ "arrow-data 59.3.0",
  "arrow-ipc",
- "arrow-schema",
- "arrow-select",
- "base64",
+ "arrow-schema 59.3.0",
+ "arrow-select 59.3.0",
+ "base64 0.23.1",
  "bytes",
  "chrono",
  "half",
- "hashbrown",
- "num-bigint",
+ "hashbrown 0.17.1",
+ "num-bigint 0.5.1",
  "num-integer",
  "num-traits",
  "seq-macro",
@@ -1118,6 +1498,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1159,6 +1551,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -1166,7 +1571,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -1210,6 +1615,12 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -1330,6 +1741,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1392,7 +1824,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.3",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -1402,7 +1834,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -1580,7 +2012,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
 dependencies = [
- "base64",
+ "base64 0.23.1",
  "flate2",
  "log",
  "percent-encoding",
@@ -1597,7 +2029,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613"
 dependencies = [
- "base64",
+ "base64 0.23.1",
  "http",
  "httparse",
  "log",
@@ -1620,6 +2052,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -1948,7 +2386,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -1978,6 +2416,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
+name = "zip"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "zopfli",
+]
+
+[[package]]
 name = "zlib-rs"
 version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1988,6 +2440,18 @@ name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,10 @@ bytes = "1.12.1"
 camino = "1.2.5"
 clap = { version = "4.6.6", features = ["derive", "wrap_help"] }
 comfy-table = "8.0.0"
+# Bundled on purpose. The version of a system under test belongs in the lockfile rather than in
+# whatever each machine happened to have installed, because a version that varies by machine is a
+# version nobody pinned and every result row carries it.
+duckdb = { version = "1.10505.0", features = ["bundled"] }
 flate2 = "1.1.10"
 hdrhistogram = "7.6.0"
 hex = "0.4.3"
@@ -91,3 +95,15 @@ undocumented_unsafe_blocks = "deny"
 codegen-units = 1
 lto = "thin"
 debug = "line-tables-only"
+
+# DuckDB is bundled, which means its amalgamation gets compiled here, and at the dev profile's
+# defaults that is about 2.7 GB of debug info per build fingerprint and a system under test compiled
+# with no optimisation at all. Neither is any use. Nobody steps through DuckDB's internals in a
+# debugger, they measure them, and an unoptimised DuckDB is not the DuckDB anyone runs.
+[profile.dev.package.libduckdb-sys]
+debug = false
+opt-level = 2
+
+[profile.test.package.libduckdb-sys]
+debug = false
+opt-level = 2

--- a/crates/bench-driver/src/driver.rs
+++ b/crates/bench-driver/src/driver.rs
@@ -98,8 +98,12 @@ pub struct Load {
 /// Small on purpose. Every corpus in scope is either Parquet or a text file with one row per line
 /// and a single separator character, and a format enum with more in it than that would be
 /// describing formats nothing here reads.
+///
+/// Not `non_exhaustive`, deliberately. Every driver lives in this workspace, and adding a format
+/// should break each of their builds until someone has decided what that format means for that
+/// system. The alternative is a wildcard arm in every driver, which is a decision nobody made
+/// turning into a run that silently read the wrong thing.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-#[non_exhaustive]
 pub enum Format {
     /// Apache Parquet.
     Parquet,

--- a/drivers/driver-duckdb/CONFIG.md
+++ b/drivers/driver-duckdb/CONFIG.md
@@ -1,0 +1,39 @@
+# driver-duckdb configuration
+
+## Source
+
+DuckDB's own performance guide, at `duckdb.org/docs/stable/guides/performance`, read for this driver rather than reconstructed from what other benchmark harnesses do. The pages that matter are the environment page for threads and memory, the "how to tune workloads" page for insertion order, and the import page for how data is meant to get in.
+
+DuckDB is linked in bundled, so the version under test is fixed by this workspace's lockfile rather than by whatever each machine had installed. A version that varies by machine is a version nobody pinned, and it appears in every result row. The driver still asks the running system what version it is rather than reporting a constant, so a build that somehow linked something else says so.
+
+## Settings
+
+`threads` is set from the machine class, not left at DuckDB's default. The default reads the host's core count, and a default that reads the host makes every result a result about that host rather than about DuckDB.
+
+`memory_limit` is set from the machine class for the same reason. DuckDB's default is 80% of the machine's RAM, which is a sensible default and a terrible experimental control.
+
+`temp_directory` is set to a subdirectory of the run's scratch directory, so that spilling happens somewhere known, gets measured as part of the run, and is removed with everything else afterwards. Leaving it at the default puts spill files next to the database, which is also inside the scratch directory, but only by accident rather than by decision.
+
+`preserve_insertion_order` is set to false. This is in DuckDB's own performance guide as the first thing to change for large imports, and it lowers memory use on load. It means a query without an `ORDER BY` may come back in a different order, which costs nothing here because the canonical result form sorts rows that the query did not order.
+
+Data is loaded with `CREATE OR REPLACE TABLE ... AS SELECT * FROM read_parquet(...)` or `read_csv(...)`, into a persistent database file rather than an in-memory one. That matches DuckDB's published ClickBench entry and the import guidance, and it is also a configuration somebody actually deploys.
+
+## Deviations
+
+Reading the files in place, as a view over `read_parquet`, would be a legitimate thing to measure and is not what happens here. It moves the work from the load phase into the run phase, and DuckDB's own published entry loads into a table, so a view would be measuring a configuration DuckDB does not put forward. The load timing is where this choice is visible, which is the reason that phase is timed separately.
+
+`DECIMAL` results are rendered as doubles. DuckDB computes TPC-H money aggregates in exact decimal arithmetic and the other systems in the matrix return the same aggregate as a double, so an exact rendering would be a comparison only one of the three could pass. The canonical form rounds floats to six significant digits anyway, which is well inside the spread of a decimal and a double summing the same column. This is a deviation from what DuckDB actually computed and it is recorded as one.
+
+CSV and pipe separated files are loaded with DuckDB's schema auto-detection rather than an explicit column list. That means the column types come from DuckDB's sniffer and not from the workload, and two systems could disagree about a result because they inferred a column differently rather than because they computed differently. This is a real gap and it closes when the workloads land with their own schemas.
+
+## Rejected alternatives
+
+Linking against a system libduckdb was rejected. It would make the build much faster, and it would also mean the version under test is whatever each fleet machine happened to have, with a mismatch showing up as a silently different number rather than as an error.
+
+Setting `threads` to the physical core count, which is what the performance guide suggests, was rejected in favour of taking it from the machine class. The guide is written for someone tuning a deployment, where the host is the point. Here the host is the thing being controlled for, and every system in the matrix has to be given the same thread count or the comparison is between thread counts.
+
+Tuning anything not named in DuckDB's own documentation was rejected outright. A setting somebody here invented is a setting DuckDB's maintainers never endorsed, and the whole point of the `CONFIG.md` rule is that a baseline is configured by its own documentation.
+
+## Last reviewed
+
+2026-09-06

--- a/drivers/driver-duckdb/Cargo.toml
+++ b/drivers/driver-duckdb/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "driver-duckdb"
+description = "The DuckDB driver, configured from DuckDB's own performance guide."
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+readme.workspace = true
+publish.workspace = true
+
+[dependencies]
+bench-driver.workspace = true
+duckdb.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/drivers/driver-duckdb/README.md
+++ b/drivers/driver-duckdb/README.md
@@ -1,0 +1,9 @@
+# driver-duckdb
+
+The DuckDB driver.
+
+Configured from DuckDB's own performance guide rather than from whatever the defaults happen to be on the machine. Threads, memory limit and temp directory come from the machine class, because a default that reads the host makes every result a result about that host. `CONFIG.md` names every setting, where it came from, the two places this driver departs from what DuckDB actually computed, and why.
+
+DuckDB is linked in bundled, so the version under test is fixed by this workspace's lockfile rather than by what each machine had installed.
+
+Part of [iris-bench](https://github.com/tamnd/iris-bench). Licensed under Apache-2.0.

--- a/drivers/driver-duckdb/src/lib.rs
+++ b/drivers/driver-duckdb/src/lib.rs
@@ -1,0 +1,468 @@
+//! The `DuckDB` driver.
+//!
+//! Configured from `DuckDB`'s own performance guide rather than from whatever the defaults happen to
+//! be on the machine, and `CONFIG.md` names every setting, where it came from, and the one place we
+//! departed from the guide and why.
+//!
+//! `DuckDB` is linked in bundled, so the version under test is fixed by this workspace's lockfile
+//! rather than by what each machine had installed. A version that varies by machine is a version
+//! nobody pinned, and it goes into every result row.
+
+use std::path::Path;
+
+use bench_driver::{Answer, Driver, DriverError, Format, Load, Query, Rows, Setup, Value};
+use duckdb::Connection;
+use duckdb::types::ValueRef;
+
+/// The version of this crate, as reported by build metadata.
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// What [`Driver::version`] says before anything has been prepared.
+///
+/// A driver that has not been started cannot ask the system what version it is, and inventing an
+/// answer from a constant in this file would defeat the point of asking.
+const UNPREPARED: &str = "unprepared";
+
+/// `DuckDB`, in process.
+#[derive(Debug, Default)]
+pub struct DuckDb {
+    /// Open once preparation has happened.
+    connection: Option<Connection>,
+    /// What the system said its version was, read at preparation time.
+    version: Option<String>,
+}
+
+impl DuckDb {
+    /// A driver that has not been started yet.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The open connection, or a complaint that the phase order was not followed.
+    fn connection(&self) -> Result<&Connection, DriverError> {
+        self.connection.as_ref().ok_or_else(|| {
+            DriverError::system(
+                "the connection is not open",
+                "prepare has not run, so there is nothing to talk to",
+            )
+        })
+    }
+}
+
+impl Driver for DuckDb {
+    fn name(&self) -> &'static str {
+        "duckdb"
+    }
+
+    fn version(&self) -> String {
+        self.version
+            .clone()
+            .unwrap_or_else(|| UNPREPARED.to_owned())
+    }
+
+    fn prepare(&mut self, setup: &Setup) -> Result<(), DriverError> {
+        // A file rather than in memory. DuckDB's performance guide is written around a persistent
+        // database, and an in memory one measures a configuration nobody deploys.
+        let database = setup.directory.join("duckdb.db");
+        let connection = Connection::open(&database).map_err(|error| {
+            DriverError::system(format!("opening {}", database.display()), error)
+        })?;
+
+        let temp = setup.directory.join("temp");
+        std::fs::create_dir_all(&temp)
+            .map_err(|error| DriverError::system(format!("making {}", temp.display()), error))?;
+
+        // Every one of these is in CONFIG.md with the page it came from. Nothing here is left at a
+        // default that would read the host's core count or its free memory, because a default that
+        // reads the host makes every result a result about that host.
+        set(&connection, "threads", &setup.threads.to_string())?;
+        set(&connection, "memory_limit", &format!("'{}B'", setup.memory))?;
+        set(&connection, "temp_directory", &quoted(&temp))?;
+        set(&connection, "preserve_insertion_order", "false")?;
+
+        let version: String = connection
+            .query_row("SELECT version()", [], |row| row.get(0))
+            .map_err(|error| DriverError::system("asking DuckDB its version", error))?;
+
+        self.connection = Some(connection);
+        self.version = Some(version);
+        Ok(())
+    }
+
+    fn load(&mut self, load: &Load) -> Result<(), DriverError> {
+        let connection = self.connection()?;
+        let files = list(&load.files);
+        let reader = match load.format {
+            Format::Parquet => format!("read_parquet({files})"),
+            Format::Separated { separator } => format!(
+                "read_csv({files}, delim = '{}', header = false, auto_detect = true)",
+                escaped(separator)
+            ),
+        };
+        // CREATE TABLE AS rather than a view over the files. Reading in place would be a legitimate
+        // thing for a driver to do, but it would move the work into the run phase, and DuckDB's own
+        // published ClickBench entry loads into a table. The load timing is where that choice shows
+        // up, which is the whole reason the phase exists.
+        let statement = format!(
+            "CREATE OR REPLACE TABLE {} AS SELECT * FROM {reader}",
+            load.table
+        );
+        connection
+            .execute_batch(&statement)
+            .map_err(|error| DriverError::system(format!("loading {}", load.table), error))?;
+        Ok(())
+    }
+
+    fn run(&mut self, query: &Query) -> Result<Answer, DriverError> {
+        let connection = self.connection()?;
+        let mut statement = connection
+            .prepare(&query.sql)
+            .map_err(|error| DriverError::system(format!("preparing {}", query.id), error))?;
+        let mut answer = Rows::new();
+        let mut rows = statement
+            .query([])
+            .map_err(|error| DriverError::system(format!("running {}", query.id), error))?;
+
+        // Every row is pulled and rendered here, which is what makes this a measurement of the
+        // query rather than of building a plan.
+        while let Some(row) = rows
+            .next()
+            .map_err(|error| DriverError::system(format!("reading {}", query.id), error))?
+        {
+            let mut values = Vec::new();
+            for column in 0.. {
+                let Ok(raw) = row.get_ref(column) else { break };
+                values.push(value(raw, &query.id, column)?);
+            }
+            answer.push(values)?;
+        }
+        Ok(answer.finish(query.ordered))
+    }
+}
+
+/// Applies one setting, and says which one if it will not take.
+fn set(connection: &Connection, name: &str, value: &str) -> Result<(), DriverError> {
+    connection
+        .execute_batch(&format!("SET {name} = {value}"))
+        .map_err(|error| DriverError::system(format!("setting {name} to {value}"), error))
+}
+
+/// A path as a single quoted SQL string.
+fn quoted(path: &Path) -> String {
+    format!("'{}'", path.display().to_string().replace('\'', "''"))
+}
+
+/// A list of paths as a SQL list, which is what `read_parquet` and `read_csv` both take.
+fn list(files: &[std::path::PathBuf]) -> String {
+    let inside: Vec<String> = files.iter().map(|file| quoted(file)).collect();
+    format!("[{}]", inside.join(", "))
+}
+
+/// A separator inside a single quoted SQL string.
+fn escaped(separator: char) -> String {
+    if separator == '\'' {
+        "''".to_owned()
+    } else {
+        separator.to_string()
+    }
+}
+
+/// One `DuckDB` value in the canonical form.
+///
+/// A type this does not know about is an error rather than a guess. Stringifying an unknown type
+/// would produce something that digests differently in every system while looking like an answer,
+/// which is worse than saying the driver cannot render it.
+fn value(raw: ValueRef<'_>, query: &str, column: usize) -> Result<Value, DriverError> {
+    Ok(match raw {
+        ValueRef::Null => Value::Null,
+        ValueRef::Boolean(inner) => Value::Bool(inner),
+        ValueRef::TinyInt(inner) => Value::Int(i64::from(inner)),
+        ValueRef::SmallInt(inner) => Value::Int(i64::from(inner)),
+        ValueRef::Int(inner) => Value::Int(i64::from(inner)),
+        ValueRef::BigInt(inner) => Value::Int(inner),
+        ValueRef::UTinyInt(inner) => Value::Int(i64::from(inner)),
+        ValueRef::USmallInt(inner) => Value::Int(i64::from(inner)),
+        ValueRef::UInt(inner) => Value::Int(i64::from(inner)),
+        ValueRef::UBigInt(inner) => Value::Int(narrow(inner, query, column)?),
+        ValueRef::HugeInt(inner) => Value::Int(narrow(inner, query, column)?),
+        ValueRef::UHugeInt(inner) => Value::Int(narrow(inner, query, column)?),
+        ValueRef::Float(inner) => Value::Float(f64::from(inner)),
+        ValueRef::Double(inner) => Value::Float(inner),
+        // Rendered as a float rather than as exact digits, because the other systems in the matrix
+        // return the same aggregate as a double and a comparison that only two of the three can
+        // pass is not a comparison. CONFIG.md records this as the deviation it is.
+        ValueRef::Decimal(inner) => Value::Float(decimal(inner)),
+        ValueRef::Text(inner) => Value::Text(String::from_utf8_lossy(inner).into_owned()),
+        ValueRef::Date32(inner) => Value::Date(inner),
+        ValueRef::Time64(unit, inner) => Value::Time(microseconds(unit, inner, query, column)?),
+        ValueRef::Timestamp(unit, inner) => {
+            Value::Timestamp(microseconds(unit, inner, query, column)?)
+        }
+        other => {
+            return Err(DriverError::unsupported(
+                format!("{query} column {column}"),
+                format!("DuckDB returned {other:?}, which this driver has no canonical form for"),
+            ));
+        }
+    })
+}
+
+/// A wider integer as an `i64`, or a complaint.
+///
+/// No result in any workload here is larger than an `i64`, so one that is means the query is not
+/// the one we think it is. Wrapping it silently would be the exact overflow this repository exists
+/// to catch elsewhere, and `DuckDB` widening an aggregate to `HUGEINT` is precisely the case where a
+/// system quietly gets it right and another one quietly does not.
+fn narrow<T>(inner: T, query: &str, column: usize) -> Result<i64, DriverError>
+where
+    T: Copy + std::fmt::Display + TryInto<i64>,
+{
+    inner.try_into().map_err(|_| {
+        DriverError::unsupported(
+            format!("{query} column {column}"),
+            format!("{inner} does not fit in a signed 64 bit integer"),
+        )
+    })
+}
+
+/// A decimal as a double.
+///
+/// The scaled payload divided by ten to the scale, which is what the decimal means. Both halves are
+/// exact in a double for every width these workloads use, and the canonical form rounds to six
+/// significant digits anyway.
+fn decimal(inner: duckdb::types::Decimal) -> f64 {
+    #[allow(
+        clippy::cast_precision_loss,
+        reason = "an i128 payload wider than a double's mantissa is already past what six \
+                  significant digits would keep"
+    )]
+    let scaled = inner.value() as f64;
+    scaled / 10_f64.powi(i32::from(inner.scale()))
+}
+
+/// A time or timestamp in microseconds, whatever unit `DuckDB` counted it in.
+///
+/// Nanoseconds are refused rather than divided down. Rounding a nanosecond timestamp to a
+/// microsecond would make two instants that differ render the same, and a canonical form that
+/// merges values is worse than one that says it cannot render them.
+fn microseconds(
+    unit: duckdb::types::TimeUnit,
+    inner: i64,
+    query: &str,
+    column: usize,
+) -> Result<i64, DriverError> {
+    use duckdb::types::TimeUnit;
+    let factor = match unit {
+        TimeUnit::Second => 1_000_000,
+        TimeUnit::Millisecond => 1_000,
+        TimeUnit::Microsecond => 1,
+        TimeUnit::Nanosecond => {
+            return Err(DriverError::unsupported(
+                format!("{query} column {column}"),
+                "nanosecond precision has no canonical form here",
+            ));
+        }
+    };
+    inner.checked_mul(factor).ok_or_else(|| {
+        DriverError::unsupported(
+            format!("{query} column {column}"),
+            format!("{inner} {unit:?} does not fit in microseconds"),
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use bench_driver::Session;
+
+    use super::*;
+
+    fn setup(directory: &Path) -> Setup {
+        Setup {
+            directory: directory.to_path_buf(),
+            threads: 2,
+            memory: 1 << 30,
+        }
+    }
+
+    #[test]
+    fn it_reports_all_three_phases_against_a_real_database() {
+        let scratch = tempfile::tempdir().unwrap();
+        let table = scratch.path().join("numbers.csv");
+        std::fs::write(&table, "1|one\n2|two\n3|three\n").unwrap();
+
+        let mut driver = DuckDb::new();
+        let mut session = Session::new(&mut driver);
+
+        session.prepare(&setup(scratch.path())).unwrap();
+        session
+            .load(&Load {
+                table: "numbers".to_owned(),
+                files: vec![table],
+                format: Format::Separated { separator: '|' },
+            })
+            .unwrap();
+        let (answer, _) = session
+            .query(&Query {
+                id: "q0".to_owned(),
+                sql: "SELECT count(*), sum(column0) FROM numbers".to_owned(),
+                ordered: false,
+            })
+            .unwrap();
+
+        assert_eq!(answer.body, "3\t6\n");
+        let phases = session.phases();
+        assert!(phases.prepare > 0.0 && phases.load > 0.0 && phases.run > 0.0);
+        assert_eq!(phases.tables, 1);
+        assert_eq!(phases.queries, 1);
+    }
+
+    #[test]
+    fn it_asks_the_system_what_version_it_is() {
+        let scratch = tempfile::tempdir().unwrap();
+        let mut driver = DuckDb::new();
+
+        // Before preparation there is nothing to ask, and answering from a constant in this file
+        // would defeat the point of asking.
+        assert_eq!(driver.version(), UNPREPARED);
+
+        driver.prepare(&setup(scratch.path())).unwrap();
+        let version = driver.version();
+        assert!(
+            version.starts_with('v'),
+            "{version} does not look like a DuckDB version"
+        );
+        assert_ne!(version, UNPREPARED);
+    }
+
+    #[test]
+    fn the_settings_it_was_given_are_the_ones_in_force() {
+        let scratch = tempfile::tempdir().unwrap();
+        let mut driver = DuckDb::new();
+        driver.prepare(&setup(scratch.path())).unwrap();
+        let connection = driver.connection().unwrap();
+
+        let threads: i64 = connection
+            .query_row("SELECT current_setting('threads')::BIGINT", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(threads, 2);
+
+        let order: bool = connection
+            .query_row(
+                "SELECT current_setting('preserve_insertion_order')::BOOLEAN",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(!order);
+
+        let temp: String = connection
+            .query_row("SELECT current_setting('temp_directory')", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert!(temp.starts_with(scratch.path().to_str().unwrap()));
+    }
+
+    #[test]
+    fn every_type_it_can_return_has_a_canonical_form() {
+        let scratch = tempfile::tempdir().unwrap();
+        let mut driver = DuckDb::new();
+        driver.prepare(&setup(scratch.path())).unwrap();
+
+        let answer = driver
+            .run(&Query {
+                id: "types".to_owned(),
+                sql: "SELECT true, 1::TINYINT, 2::BIGINT, 3::UBIGINT, 4.5::DOUBLE, \
+                      6.25::DECIMAL(9, 2), 'text', NULL"
+                    .to_owned(),
+                ordered: true,
+            })
+            .unwrap();
+
+        assert_eq!(answer.columns, 8);
+        assert_eq!(answer.body, "true\t1\t2\t3\t4.5\t6.25\ttext\t\\N\n");
+    }
+
+    #[test]
+    fn dates_and_timestamps_come_back_in_the_canonical_form_rather_than_duckdbs() {
+        let scratch = tempfile::tempdir().unwrap();
+        let mut driver = DuckDb::new();
+        driver.prepare(&setup(scratch.path())).unwrap();
+
+        let answer = driver
+            .run(&Query {
+                id: "when".to_owned(),
+                sql: "SELECT DATE '2024-02-29', TIME '01:02:03.5', \
+                      TIMESTAMP '1998-12-01 13:45:00', HUGEINT '170141183460469'"
+                    .to_owned(),
+                ordered: true,
+            })
+            .unwrap();
+
+        assert_eq!(
+            answer.body,
+            "2024-02-29\t01:02:03.5\t1998-12-01 13:45:00\t170141183460469\n"
+        );
+    }
+
+    #[test]
+    fn an_integer_too_wide_for_the_canonical_form_is_refused_rather_than_wrapped() {
+        // DuckDB widens an aggregate to HUGEINT where another system would overflow, and silently
+        // wrapping it here would be the exact failure the digest comparison exists to catch.
+        let scratch = tempfile::tempdir().unwrap();
+        let mut driver = DuckDb::new();
+        driver.prepare(&setup(scratch.path())).unwrap();
+
+        let error = driver
+            .run(&Query {
+                id: "wide".to_owned(),
+                sql: "SELECT HUGEINT '170141183460469231731687303715884105727'".to_owned(),
+                ordered: true,
+            })
+            .unwrap_err();
+        assert!(error.to_string().contains("64 bit"), "{error}");
+    }
+
+    #[test]
+    fn a_type_with_no_canonical_form_is_refused_rather_than_stringified() {
+        // A struct rendered as whatever DuckDB prints would look like an answer and digest
+        // differently in every system, which is worse than saying so.
+        let scratch = tempfile::tempdir().unwrap();
+        let mut driver = DuckDb::new();
+        driver.prepare(&setup(scratch.path())).unwrap();
+
+        let error = driver
+            .run(&Query {
+                id: "struct".to_owned(),
+                sql: "SELECT {'a': 1}".to_owned(),
+                ordered: true,
+            })
+            .unwrap_err();
+        assert!(matches!(error, DriverError::Unsupported { .. }), "{error}");
+    }
+
+    #[test]
+    fn a_query_it_cannot_parse_says_which_query() {
+        let scratch = tempfile::tempdir().unwrap();
+        let mut driver = DuckDb::new();
+        driver.prepare(&setup(scratch.path())).unwrap();
+
+        let error = driver
+            .run(&Query {
+                id: "q41".to_owned(),
+                sql: "SELECT FROM WHERE".to_owned(),
+                ordered: false,
+            })
+            .unwrap_err();
+        assert!(error.to_string().contains("q41"), "{error}");
+    }
+
+    #[test]
+    fn it_names_itself_without_a_version_in_the_name() {
+        assert_eq!(DuckDb::new().name(), "duckdb");
+    }
+}


### PR DESCRIPTION
Closes #15.

The first real system in the matrix. It implements the trait from #14, runs against a real database in its tests, and carries a `CONFIG.md` with all five sections.

## Where the configuration came from

DuckDB's own performance guide, read for this driver rather than reconstructed from what other harnesses do. `threads`, `memory_limit` and `temp_directory` are set from the machine class rather than left at their defaults, because every one of those defaults reads the host, and a default that reads the host makes every result a result about that host rather than about DuckDB. `preserve_insertion_order` is set to false, which is the first thing the guide names for large imports, and it costs nothing here because the canonical result form already sorts rows that the query did not order.

Data goes into a persistent database file with `CREATE TABLE AS`, which is what DuckDB's published ClickBench entry does. Reading the files in place as a view would be a legitimate thing to measure and it is not what DuckDB puts forward, so it is not what is measured here. The load timing is where that choice is visible, which is the reason that phase is timed separately.

Two deviations are written down as deviations. `DECIMAL` results are rendered as doubles, because DuckDB computes TPC-H money aggregates in exact decimal arithmetic and the other two systems return the same aggregate as a double, so an exact rendering would be a comparison only one of the three could pass. And CSV loading uses DuckDB's schema sniffer rather than a schema from the workload, which is a real gap that closes when the workloads land in #18.

## Bundled, and what that cost

DuckDB is linked in bundled. The version under test then lives in this workspace's lockfile rather than in whatever each fleet machine happened to have installed, and a mismatch becomes impossible rather than becoming a silently different number. The driver still asks the running system what version it is instead of reporting a constant.

At the dev profile's defaults that costs about 2.7 GB of debug info per build fingerprint, which filled this machine's disk twice while writing it, and it compiles the system under test with no optimisation at all. Both are fixed with a per package profile: no debug info and `opt-level = 2` for `libduckdb-sys`. Nobody steps through DuckDB's internals in a debugger, they measure them, and an unoptimised DuckDB is not the DuckDB anyone runs. The whole `target` directory went from 13 GB to 1.1 GB.

## A change to #14

`Format` loses its `#[non_exhaustive]`. Every driver lives in this workspace, so adding a format should break each of their builds until somebody has decided what it means for that system. The alternative is a wildcard arm in every driver, which is a decision nobody made turning into a run that silently read the wrong thing. Writing the first driver is what surfaced it, because the first thing the compiler asked for was a `todo!()`.

## What the tests actually do

They start a real DuckDB, so they are a check on the driver rather than on a mock. They assert the settings that were asked for are the ones in force, that the version comes from the system, that every type the workloads produce has a canonical form, and that two things are refused rather than fudged: an integer too wide for the canonical form, since DuckDB widens an aggregate to `HUGEINT` where another system would overflow and wrapping it silently would be the exact failure the digest comparison exists to catch, and a type with no canonical form, since stringifying a struct would look like an answer and digest differently everywhere.

## Checked locally

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace --all-targets --all-features`, `cargo test --workspace --doc`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`, `cargo check --locked --workspace`, `python3 ci/discipline.py`, `python3 ci/test_discipline.py`. All green.
