### PR TITLE
Cut v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,7 +380,7 @@ checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "bench-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "bench-corpus"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "blake3",
  "camino",
@@ -407,7 +407,7 @@ dependencies = [
 
 [[package]]
 name = "bench-driver"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bench-core",
  "serde",
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "bench-env"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bench-core",
  "blake3",
@@ -428,7 +428,7 @@ dependencies = [
 
 [[package]]
 name = "bench-report"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bench-core",
  "bench-store",
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "bench-run"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bench-core",
  "bench-corpus",
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "bench-store"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "arrow-array 59.3.0",
  "arrow-schema 59.3.0",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "driver-duckdb"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bench-driver",
  "duckdb",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "driver-null"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bench-driver",
 ]
@@ -1009,7 +1009,7 @@ dependencies = [
 
 [[package]]
 name = "iris-bench-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "bench-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*", "drivers/*"]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 rust-version = "1.98"
 license = "Apache-2.0"
@@ -16,13 +16,13 @@ readme = "README.md"
 publish = false
 
 [workspace.dependencies]
-bench-core = { path = "crates/bench-core", version = "0.2.0" }
-bench-corpus = { path = "crates/bench-corpus", version = "0.2.0" }
-bench-driver = { path = "crates/bench-driver", version = "0.2.0" }
-bench-env = { path = "crates/bench-env", version = "0.2.0" }
-bench-report = { path = "crates/bench-report", version = "0.2.0" }
-bench-run = { path = "crates/bench-run", version = "0.2.0" }
-bench-store = { path = "crates/bench-store", version = "0.2.0" }
+bench-core = { path = "crates/bench-core", version = "0.2.1" }
+bench-corpus = { path = "crates/bench-corpus", version = "0.2.1" }
+bench-driver = { path = "crates/bench-driver", version = "0.2.1" }
+bench-env = { path = "crates/bench-env", version = "0.2.1" }
+bench-report = { path = "crates/bench-report", version = "0.2.1" }
+bench-run = { path = "crates/bench-run", version = "0.2.1" }
+bench-store = { path = "crates/bench-store", version = "0.2.1" }
 
 anyhow = "1.0.104"
 arrow-array = "59.3.0"


### PR DESCRIPTION
A patch release over v0.2.0, part way into B2, the drivers milestone.

Three things landed since the last tag. The `Driver` trait, with prepare, load and run timed separately and the clock kept out of the driver. The canonical result form extended to dates, times and timestamps, so that a date in a TPC-H answer and a timestamp in a ClickBench one are rendered the same way whichever system produced them. And the DuckDB driver, which is the first real system in the matrix and whose tests start a real database.

Version and lockfile only.

Nothing publishes. No crate in this repository goes to crates.io, so a release here is a tag and its notes.