### PR TITLE
The DataFusion driver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -97,6 +118,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "ar_archive_writer"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73cd58deff2140a0a8eae87e417bd01db68a33e148aa93d1e8cd837e55e312b6"
+dependencies = [
+ "object",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,16 +147,37 @@ version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6cfdd0833e32a9874d2b55089333ad310c0be208aafa277385ce2461dec90be3"
 dependencies = [
- "arrow-arith",
+ "arrow-arith 58.4.0",
  "arrow-array 58.4.0",
  "arrow-buffer 58.4.0",
- "arrow-cast",
+ "arrow-cast 58.4.0",
  "arrow-data 58.4.0",
- "arrow-ord",
- "arrow-row",
+ "arrow-ord 58.4.0",
+ "arrow-row 58.4.0",
  "arrow-schema 58.4.0",
  "arrow-select 58.4.0",
- "arrow-string",
+ "arrow-string 58.4.0",
+]
+
+[[package]]
+name = "arrow"
+version = "59.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c14b3d39f306bc28fd639d59f06e17a0f377d0021e1b7e9054e4d6fedc98774"
+dependencies = [
+ "arrow-arith 59.3.0",
+ "arrow-array 59.3.0",
+ "arrow-buffer 59.3.0",
+ "arrow-cast 59.3.0",
+ "arrow-csv",
+ "arrow-data 59.3.0",
+ "arrow-ipc",
+ "arrow-json",
+ "arrow-ord 59.3.0",
+ "arrow-row 59.3.0",
+ "arrow-schema 59.3.0",
+ "arrow-select 59.3.0",
+ "arrow-string 59.3.0",
 ]
 
 [[package]]
@@ -139,6 +190,20 @@ dependencies = [
  "arrow-buffer 58.4.0",
  "arrow-data 58.4.0",
  "arrow-schema 58.4.0",
+ "chrono",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "59.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2961626677665b2195eb59242af4c7befe7b8737ca2050295389362380104e"
+dependencies = [
+ "arrow-array 59.3.0",
+ "arrow-buffer 59.3.0",
+ "arrow-data 59.3.0",
+ "arrow-schema 59.3.0",
  "chrono",
  "num-traits",
 ]
@@ -172,6 +237,7 @@ dependencies = [
  "arrow-data 59.3.0",
  "arrow-schema 59.3.0",
  "chrono",
+ "chrono-tz",
  "half",
  "hashbrown 0.17.1",
  "num-complex",
@@ -212,7 +278,7 @@ dependencies = [
  "arrow-array 58.4.0",
  "arrow-buffer 58.4.0",
  "arrow-data 58.4.0",
- "arrow-ord",
+ "arrow-ord 58.4.0",
  "arrow-schema 58.4.0",
  "arrow-select 58.4.0",
  "atoi",
@@ -223,6 +289,43 @@ dependencies = [
  "lexical-core",
  "num-traits",
  "ryu",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "59.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "635c9c635668ad26adf76cce8fb276c4be7cf06e63bd516de7da514f9680ee53"
+dependencies = [
+ "arrow-array 59.3.0",
+ "arrow-buffer 59.3.0",
+ "arrow-data 59.3.0",
+ "arrow-ord 59.3.0",
+ "arrow-schema 59.3.0",
+ "arrow-select 59.3.0",
+ "atoi",
+ "base64 0.23.1",
+ "chrono",
+ "comfy-table 7.1.4",
+ "half",
+ "lexical-core",
+ "num-traits",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-csv"
+version = "59.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c2ebf8d631e79b02c16cf5ae860561272c26024ec88fce389a56aaddd558e86"
+dependencies = [
+ "arrow-array 59.3.0",
+ "arrow-cast 59.3.0",
+ "arrow-schema 59.3.0",
+ "chrono",
+ "csv",
+ "csv-core",
+ "regex",
 ]
 
 [[package]]
@@ -263,6 +366,33 @@ dependencies = [
  "arrow-schema 59.3.0",
  "arrow-select 59.3.0",
  "flatbuffers",
+ "lz4_flex",
+ "zstd",
+]
+
+[[package]]
+name = "arrow-json"
+version = "59.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2f57d7a81969f24ccf80809587b76c09897e6f829d2d65a5976bfb3218851f1"
+dependencies = [
+ "arrow-array 59.3.0",
+ "arrow-buffer 59.3.0",
+ "arrow-cast 59.3.0",
+ "arrow-ord 59.3.0",
+ "arrow-schema 59.3.0",
+ "arrow-select 59.3.0",
+ "chrono",
+ "half",
+ "indexmap",
+ "itoa",
+ "lexical-core",
+ "memchr",
+ "num-traits",
+ "ryu",
+ "serde_core",
+ "serde_json",
+ "simdutf8",
 ]
 
 [[package]]
@@ -279,6 +409,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow-ord"
+version = "59.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c900759f3bd8354fd4196bc4403eee846894dc2adf66b4225472006a0bf18c5"
+dependencies = [
+ "arrow-array 59.3.0",
+ "arrow-buffer 59.3.0",
+ "arrow-data 59.3.0",
+ "arrow-schema 59.3.0",
+ "arrow-select 59.3.0",
+]
+
+[[package]]
 name = "arrow-row"
 version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,6 +431,19 @@ dependencies = [
  "arrow-buffer 58.4.0",
  "arrow-data 58.4.0",
  "arrow-schema 58.4.0",
+ "half",
+]
+
+[[package]]
+name = "arrow-row"
+version = "59.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c6425032e28266e3fc4ff680805e57e670d6ea92473043f3e65b7ed6ac79f2"
+dependencies = [
+ "arrow-array 59.3.0",
+ "arrow-buffer 59.3.0",
+ "arrow-data 59.3.0",
+ "arrow-schema 59.3.0",
  "half",
 ]
 
@@ -305,6 +461,10 @@ name = "arrow-schema"
 version = "59.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10fab8d4563491417ba801fab29d205104d20d4bdf37bda6cd1cf425cff598cd"
+dependencies = [
+ "serde_core",
+ "serde_json",
+]
 
 [[package]]
 name = "arrow-select"
@@ -349,6 +509,46 @@ dependencies = [
  "num-traits",
  "regex",
  "regex-syntax",
+]
+
+[[package]]
+name = "arrow-string"
+version = "59.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e0813f3c35c1cfea65e14c20a953440f7783c088b7ad2d0db162ccdeefcec14"
+dependencies = [
+ "arrow-array 59.3.0",
+ "arrow-buffer 59.3.0",
+ "arrow-data 59.3.0",
+ "arrow-schema 59.3.0",
+ "arrow-select 59.3.0",
+ "memchr",
+ "num-traits",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "515a1f282e33d55983c499d7e9e87082e81cbc32974825bf9032f928392d5844"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -445,8 +645,8 @@ dependencies = [
  "bench-corpus",
  "bench-driver",
  "bench-env",
- "rand",
- "rand_chacha",
+ "rand 0.10.2",
+ "rand_chacha 0.10.0",
  "serde",
  "thiserror",
  "toml",
@@ -467,10 +667,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "bigdecimal"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695"
+dependencies = [
+ "autocfg",
+ "libm",
+ "num-bigint 0.4.8",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "blake3"
@@ -486,6 +708,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "brotli"
+version = "8.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,6 +757,15 @@ name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "bzip2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
+dependencies = [
+ "libbz2-rs-sys",
+]
 
 [[package]]
 name = "camino"
@@ -535,7 +805,7 @@ checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "rand_core",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -547,6 +817,16 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "windows-link",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
 ]
 
 [[package]]
@@ -619,6 +899,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "compression-codecs"
+version = "0.4.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fe67f2944eef52fc7b106b8c9450d243a88701a0c065f7f57235e76abaed7df"
+dependencies = [
+ "bzip2",
+ "compression-core",
+ "flate2",
+ "liblzma",
+ "memchr",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e8ccc4ea9f6acc32d102c0f6d471d11d913ad15f20c04de743374861fa1d414"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -669,6 +976,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31eee39dddec8330830986fcd7625edb5a24ec90ea038215273bbc3adb08ac6"
+
+[[package]]
 name = "crossterm"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,6 +1024,729 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "datafusion"
+version = "55.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96f76f0167ed0842b29a3d1e41be3c034c0a46409a3a703cc4cc84ee8c24abf4"
+dependencies = [
+ "arrow 59.3.0",
+ "arrow-schema 59.3.0",
+ "async-trait",
+ "bzip2",
+ "chrono",
+ "datafusion-catalog",
+ "datafusion-catalog-listing",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-datasource-arrow",
+ "datafusion-datasource-csv",
+ "datafusion-datasource-json",
+ "datafusion-datasource-parquet",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-functions",
+ "datafusion-functions-aggregate",
+ "datafusion-functions-nested",
+ "datafusion-functions-table",
+ "datafusion-functions-window",
+ "datafusion-optimizer",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-adapter",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-optimizer",
+ "datafusion-physical-plan",
+ "datafusion-session",
+ "datafusion-sql",
+ "flate2",
+ "futures",
+ "indexmap",
+ "itertools 0.15.0",
+ "liblzma",
+ "log",
+ "object_store",
+ "parking_lot",
+ "parquet",
+ "sqlparser",
+ "tempfile",
+ "tokio",
+ "url",
+ "uuid",
+ "zstd",
+]
+
+[[package]]
+name = "datafusion-catalog"
+version = "55.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d79ec3460f6ed5c58f9b3f2d873fbc77748b82653bff1b4cdaf06de33bb4e05f"
+dependencies = [
+ "arrow 59.3.0",
+ "async-trait",
+ "dashmap",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr",
+ "datafusion-physical-plan",
+ "datafusion-session",
+ "futures",
+ "itertools 0.15.0",
+ "log",
+ "object_store",
+ "parking_lot",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-catalog-listing"
+version = "55.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b48cef241e2efcfd496fe05ae4d0d5de20793451862faefe406c397a467e12d4"
+dependencies = [
+ "arrow 59.3.0",
+ "async-trait",
+ "datafusion-catalog",
+ "datafusion-common",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-adapter",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "futures",
+ "itertools 0.15.0",
+ "log",
+ "object_store",
+ "percent-encoding",
+]
+
+[[package]]
+name = "datafusion-common"
+version = "55.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f72810485975c258f1b4d00baab31728470676c60c5546f366ebd0d99f05ab6"
+dependencies = [
+ "arrow 59.3.0",
+ "arrow-ipc",
+ "arrow-schema 59.3.0",
+ "chrono",
+ "foldhash 0.2.0",
+ "half",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "itertools 0.15.0",
+ "libc",
+ "log",
+ "num-traits",
+ "object_store",
+ "parquet",
+ "recursive",
+ "sqlparser",
+ "tokio",
+ "uuid",
+ "web-time",
+]
+
+[[package]]
+name = "datafusion-common-runtime"
+version = "55.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533c28e75dba52f41bde187d23a1cb24ab91c7c097966824fa471e67b60320ea"
+dependencies = [
+ "futures",
+ "log",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-datasource"
+version = "55.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b00a1fa0da26f6087136a82fea7f13c76a672cbab452d4086952a7cf770a19b"
+dependencies = [
+ "arrow 59.3.0",
+ "async-compression",
+ "async-trait",
+ "bytes",
+ "bzip2",
+ "chrono",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-adapter",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-session",
+ "flate2",
+ "futures",
+ "glob",
+ "itertools 0.15.0",
+ "liblzma",
+ "log",
+ "object_store",
+ "parking_lot",
+ "rand 0.9.5",
+ "tokio",
+ "tokio-util",
+ "url",
+ "zstd",
+]
+
+[[package]]
+name = "datafusion-datasource-arrow"
+version = "55.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ad17ec881bff2ed7768b4bfe971d3efbf3473f2fd1f9d365447bccbdf908678"
+dependencies = [
+ "arrow 59.3.0",
+ "arrow-ipc",
+ "async-trait",
+ "bytes",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-session",
+ "futures",
+ "itertools 0.15.0",
+ "object_store",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-datasource-csv"
+version = "55.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5345285b0c3eaab412e7539b706973c083bd7e5bce575de5e0a3da488d08d1d"
+dependencies = [
+ "arrow 59.3.0",
+ "async-trait",
+ "bytes",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-session",
+ "futures",
+ "object_store",
+ "regex",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-datasource-json"
+version = "55.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da02fb9324f56bd8c53f1ee2e949547425cb66f76adc6832b10d44f80a1221d2"
+dependencies = [
+ "arrow 59.3.0",
+ "async-trait",
+ "bytes",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-session",
+ "futures",
+ "object_store",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "datafusion-datasource-parquet"
+version = "55.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c0b0dc1453952952fd5c69ad1c7f6042176e69ed233011d47e07cf74ed0949e"
+dependencies = [
+ "arrow 59.3.0",
+ "arrow-schema 59.3.0",
+ "async-trait",
+ "bytes",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-functions",
+ "datafusion-functions-aggregate-common",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-adapter",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-pruning",
+ "datafusion-session",
+ "futures",
+ "itertools 0.15.0",
+ "log",
+ "object_store",
+ "parking_lot",
+ "parquet",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-doc"
+version = "55.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a88fd985bc0550c36f557db69543cc9d6393b1509783520b30e902f23c555da6"
+
+[[package]]
+name = "datafusion-execution"
+version = "55.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a98f1052f91b4991f0bf2ce1e4e36dfbdcda454a956b8c8d562c7c845e8fce1d"
+dependencies = [
+ "arrow 59.3.0",
+ "arrow-buffer 59.3.0",
+ "async-trait",
+ "bytes",
+ "dashmap",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-physical-expr-common",
+ "futures",
+ "log",
+ "object_store",
+ "parking_lot",
+ "pin-project-lite",
+ "rand 0.9.5",
+ "tempfile",
+ "tokio",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
+name = "datafusion-expr"
+version = "55.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "464625a1f0e4b9df552d894fafcc8aac953ebbc8b0fa0acdaf20975fd615040e"
+dependencies = [
+ "arrow 59.3.0",
+ "arrow-schema 59.3.0",
+ "async-trait",
+ "chrono",
+ "datafusion-common",
+ "datafusion-doc",
+ "datafusion-expr-common",
+ "datafusion-functions-aggregate-common",
+ "datafusion-functions-window-common",
+ "datafusion-physical-expr-common",
+ "indexmap",
+ "itertools 0.15.0",
+ "recursive",
+ "serde_json",
+ "sqlparser",
+]
+
+[[package]]
+name = "datafusion-expr-common"
+version = "55.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604994999d5aeca1d1df645ffc98bc787447aaff05dde27aad0342b48fc1fe0"
+dependencies = [
+ "arrow 59.3.0",
+ "datafusion-common",
+ "indexmap",
+ "itertools 0.15.0",
+]
+
+[[package]]
+name = "datafusion-functions"
+version = "55.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051e97533e6af53e4aa0a0667cadc886abcaf36c4a5925019c55c0aa4c218fde"
+dependencies = [
+ "arrow 59.3.0",
+ "arrow-buffer 59.3.0",
+ "base64 0.23.1",
+ "blake2",
+ "blake3",
+ "chrono",
+ "chrono-tz",
+ "datafusion-common",
+ "datafusion-doc",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-macros",
+ "datafusion-physical-expr-common",
+ "hex",
+ "itertools 0.15.0",
+ "log",
+ "md-5",
+ "memchr",
+ "num-traits",
+ "rand 0.9.5",
+ "regex",
+ "sha2",
+ "uuid",
+]
+
+[[package]]
+name = "datafusion-functions-aggregate"
+version = "55.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d0f1bb166d3572b6ed40e1afb2faaacade962abc08c2fcf04babee74681c56b"
+dependencies = [
+ "arrow 59.3.0",
+ "datafusion-common",
+ "datafusion-doc",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-functions-aggregate-common",
+ "datafusion-macros",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "half",
+ "hashbrown 0.17.1",
+ "log",
+ "num-traits",
+]
+
+[[package]]
+name = "datafusion-functions-aggregate-common"
+version = "55.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ed756770f5f98369e181d692fd5ee6b1127ffd7322caba92f3730f9f5c92333"
+dependencies = [
+ "arrow 59.3.0",
+ "datafusion-common",
+ "datafusion-expr-common",
+ "datafusion-physical-expr-common",
+]
+
+[[package]]
+name = "datafusion-functions-nested"
+version = "55.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91173fdb5c0ff2a41169a8ffa1b385b8844f18728747bb0a37e35ad7d5772a4f"
+dependencies = [
+ "arrow 59.3.0",
+ "arrow-ord 59.3.0",
+ "datafusion-common",
+ "datafusion-doc",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-functions",
+ "datafusion-functions-aggregate",
+ "datafusion-functions-aggregate-common",
+ "datafusion-macros",
+ "datafusion-physical-expr-common",
+ "hashbrown 0.17.1",
+ "itertools 0.15.0",
+ "itoa",
+ "log",
+ "memchr",
+]
+
+[[package]]
+name = "datafusion-functions-table"
+version = "55.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1bcdfb286a745461b126719c32700777e83df4f17cc44db5d71ebce5731e840"
+dependencies = [
+ "arrow 59.3.0",
+ "async-trait",
+ "datafusion-catalog",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-physical-expr",
+ "datafusion-physical-plan",
+ "parking_lot",
+]
+
+[[package]]
+name = "datafusion-functions-window"
+version = "55.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ec4b508f1f93f00038ba3e737e894ec6c775528b4369413386655ae6125f0fc"
+dependencies = [
+ "arrow 59.3.0",
+ "datafusion-common",
+ "datafusion-doc",
+ "datafusion-expr",
+ "datafusion-functions-window-common",
+ "datafusion-macros",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "log",
+]
+
+[[package]]
+name = "datafusion-functions-window-common"
+version = "55.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b352020834140073fbf5b46ee0ceb926e5074a9d0bcae1dbd91d0586d999cde"
+dependencies = [
+ "datafusion-common",
+ "datafusion-physical-expr-common",
+]
+
+[[package]]
+name = "datafusion-macros"
+version = "55.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15192effab05d38cce10e92a6fb48c967b5f166b27b7195a165a72b232569c58"
+dependencies = [
+ "datafusion-doc",
+ "quote",
+ "syn 3.0.5",
+]
+
+[[package]]
+name = "datafusion-optimizer"
+version = "55.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854445d9f7847e1e46089cf61b8d341a64382f14484e912c83a0f23b31216896"
+dependencies = [
+ "arrow 59.3.0",
+ "chrono",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-physical-expr",
+ "indexmap",
+ "itertools 0.15.0",
+ "log",
+ "recursive",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
+name = "datafusion-physical-expr"
+version = "55.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "671558dad1d2aa253c39c0a4c52515958b99eb91abf649f4b88d5e69cc55282f"
+dependencies = [
+ "arrow 59.3.0",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-functions-aggregate-common",
+ "datafusion-physical-expr-common",
+ "half",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "itertools 0.15.0",
+ "parking_lot",
+ "petgraph",
+ "recursive",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-physical-expr-adapter"
+version = "55.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffae3d78c2da80ecc829cb58536cc5aca2e99cf1365eda694fc75bfe288861e0"
+dependencies = [
+ "arrow 59.3.0",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-functions",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "itertools 0.15.0",
+]
+
+[[package]]
+name = "datafusion-physical-expr-common"
+version = "55.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d9092ed15e7203fbd0903215172f7c9d18f10d94cba35137f3b3836f7c46f16"
+dependencies = [
+ "arrow 59.3.0",
+ "chrono",
+ "datafusion-common",
+ "datafusion-expr-common",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "itertools 0.15.0",
+ "parking_lot",
+ "pin-project",
+]
+
+[[package]]
+name = "datafusion-physical-optimizer"
+version = "55.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9005b6cf50b57b72d476c6ed4662b04be7ca6be5320ba9127c6d0b7e4218095b"
+dependencies = [
+ "arrow 59.3.0",
+ "datafusion-common",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-pruning",
+ "datafusion-session",
+ "itertools 0.15.0",
+ "recursive",
+]
+
+[[package]]
+name = "datafusion-physical-plan"
+version = "55.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5787e4fcff4adc4fce8948441103a99705018b49c8dff0720b650bd7a15da112"
+dependencies = [
+ "arrow 59.3.0",
+ "arrow-data 59.3.0",
+ "arrow-ipc",
+ "arrow-ord 59.3.0",
+ "arrow-schema 59.3.0",
+ "async-trait",
+ "bytes",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-functions",
+ "datafusion-functions-aggregate-common",
+ "datafusion-functions-window-common",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "futures",
+ "half",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "itertools 0.15.0",
+ "log",
+ "num-traits",
+ "parking_lot",
+ "pin-project-lite",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-pruning"
+version = "55.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e651c8df0b90daed6a7be5921ec0ee379e6909705f063eeff70fd4e35010e4c"
+dependencies = [
+ "arrow 59.3.0",
+ "datafusion-common",
+ "datafusion-datasource",
+ "datafusion-expr-common",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "log",
+]
+
+[[package]]
+name = "datafusion-session"
+version = "55.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb56667ee38217efab19b895d9a936052cfb47ed438a19663351bdc42a6214a1"
+dependencies = [
+ "arrow-schema 59.3.0",
+ "async-trait",
+ "datafusion-common",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-plan",
+ "parking_lot",
+]
+
+[[package]]
+name = "datafusion-sql"
+version = "55.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c29067cb9d32f8e603c45e15d61ea18f1069f96ceafeceb4e18466b8e5b31d9"
+dependencies = [
+ "arrow 59.3.0",
+ "bigdecimal",
+ "chrono",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-functions-nested",
+ "indexmap",
+ "log",
+ "recursive",
+ "regex",
+ "sqlparser",
+ "stacker",
+]
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -719,6 +1755,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+ "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -732,12 +1790,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
+]
+
+[[package]]
+name = "driver-datafusion"
+version = "0.2.1"
+dependencies = [
+ "bench-driver",
+ "datafusion",
+ "tempfile",
+ "tokio",
 ]
 
 [[package]]
@@ -762,7 +1841,7 @@ version = "1.10505.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "970e05eedd3f55c435194d9104f90a9b4a79a80d6e73251bc9ff43e178130c4e"
 dependencies = [
- "arrow",
+ "arrow 58.4.0",
  "cast",
  "comfy-table 7.1.4",
  "fallible-iterator",
@@ -772,6 +1851,12 @@ dependencies = [
  "num-integer",
  "strum",
 ]
+
+[[package]]
+name = "either"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "equivalent"
@@ -824,6 +1909,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flatbuffers"
 version = "25.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -851,10 +1942,84 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
@@ -868,10 +2033,25 @@ version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -906,8 +2086,14 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core",
+ "rand_core 0.10.1",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "half"
@@ -923,11 +2109,17 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -935,6 +2127,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -974,6 +2171,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "humantime"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -995,6 +2207,110 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
+
+[[package]]
+name = "icu_properties"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
+
+[[package]]
+name = "icu_provider"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -1042,6 +2358,24 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1134,6 +2468,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libbz2-rs-sys"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
+
+[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1157,6 +2497,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "liblzma"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fe0a34ca854fd4f20c07f696fc8675aec78f87d88d29f5e10257a7490a1b2e1"
+dependencies = [
+ "liblzma-sys",
+]
+
+[[package]]
+name = "liblzma-sys"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0dad045e4b1b7b170be4b60b54b780cafb4490165461bac7d1cf7b703f61d5f"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1173,6 +2533,12 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "litrs"
@@ -1196,12 +2562,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
+name = "lz4_flex"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecbdfe44b1bd960b68170b417450a628c43f7cf56bb3c5317e61cb230ee7f226"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1344,6 +2729,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "object_store"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "chrono",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "humantime",
+ "itertools 0.14.0",
+ "parking_lot",
+ "percent-encoding",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1392,14 +2812,22 @@ dependencies = [
  "arrow-schema 59.3.0",
  "arrow-select 59.3.0",
  "base64 0.23.1",
+ "brotli",
  "bytes",
  "chrono",
+ "flate2",
+ "futures",
  "half",
  "hashbrown 0.17.1",
+ "lz4_flex",
  "num-bigint 0.5.1",
  "num-integer",
  "num-traits",
+ "object_store",
  "seq-macro",
+ "simdutf8",
+ "snap",
+ "tokio",
  "twox-hash",
  "zstd",
 ]
@@ -1409,6 +2837,56 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "serde",
+]
+
+[[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1421,6 +2899,15 @@ name = "pkg-config"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -1438,6 +2925,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd034599e63b970727f70d79e02d62390a4a84f7c6b827c27c46d5ac3fa622"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
 ]
 
 [[package]]
@@ -1463,13 +2960,33 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.3",
- "rand_core",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1479,7 +2996,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1487,6 +3013,26 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "recursive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0786a43debb760f491b1bc0269fe5e84155353c67482b9e60d0cfb596054b43e"
+dependencies = [
+ "recursive-proc-macro-impl",
+ "stacker",
+]
+
+[[package]]
+name = "recursive-proc-macro-impl"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76009fbe0614077fc1a2ce255e3a1881a2e3a3527097d5dc6d8212c585e7e38b"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1685,6 +3231,7 @@ version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -1699,6 +3246,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1723,6 +3281,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1733,6 +3303,53 @@ name = "smallvec"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
+
+[[package]]
+name = "snap"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "199905e6153d6405f9728fe44daace35f8f837bbf830bb6e85fbd5828709a886"
+
+[[package]]
+name = "sqlparser"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c6d1b651dc4edf07eead2a0c6c78016ce971bc2c10da5266861b13f25e7cec"
+dependencies = [
+ "log",
+ "recursive",
+ "sqlparser_derive",
+]
+
+[[package]]
+name = "sqlparser_derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6dd45d8fc1c79299bfbb7190e42ccbbdf6a5f52e4a6ad98d92357ea965bd289"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stacker"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707f49d46706bacf8a2b00d51dace3f9de527c13eec3778f570c411f89e69967"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "strsim"
@@ -1787,6 +3404,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1874,6 +3502,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tokio"
+version = "1.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -1983,6 +3668,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5283634e518fe9e82c7b20520bb4bc209009fd16c82077c802f8111ecbb0117a"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2036,16 +3727,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
 name = "utf8-zero"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
+dependencies = [
+ "getrandom 0.4.3",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"
@@ -2104,6 +3824,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ef4c5d3d2cdf5c54f4231181768f5510842e350db025faf1f7163b1030ed928"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2133,6 +3863,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81941cd78d0c92026c33e5e01312845a4cb1e9af3407f9134b100dd03144103e"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2380,6 +4120,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
+name = "writeable"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2387,6 +4133,29 @@ checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix 1.1.4",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
 ]
 
 [[package]]
@@ -2410,10 +4179,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
+]
 
 [[package]]
 name = "zip"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,10 @@ bytes = "1.12.1"
 camino = "1.2.5"
 clap = { version = "4.6.6", features = ["derive", "wrap_help"] }
 comfy-table = "8.0.0"
+# Default features, which is what DataFusion's own benchmark entries build with. Arrow comes in
+# through this rather than through the workspace's own arrow, so that a driver renders the arrays
+# the engine actually produced instead of arrays from a second copy of Arrow.
+datafusion = "55.0.0"
 # Bundled on purpose. The version of a system under test belongs in the lockfile rather than in
 # whatever each machine happened to have installed, because a version that varies by machine is a
 # version nobody pinned and every result row carries it.
@@ -107,3 +111,14 @@ opt-level = 2
 [profile.test.package.libduckdb-sys]
 debug = false
 opt-level = 2
+
+# No debug info for anything outside this workspace. The systems under test are large, DataFusion
+# alone is a few hundred crates, and their debug info came to about 8 GB of a 13 GB target directory
+# on a machine that then had no room to build anything else. Nobody sets a breakpoint inside a
+# dependency here, they measure it, and our own crates keep their debug info so a panic in this
+# repository still says which line it came from.
+[profile.dev.package."*"]
+debug = false
+
+[profile.test.package."*"]
+debug = false

--- a/drivers/driver-datafusion/CONFIG.md
+++ b/drivers/driver-datafusion/CONFIG.md
@@ -1,0 +1,39 @@
+# driver-datafusion configuration
+
+## Source
+
+DataFusion's own benchmark harness in `apache/datafusion`, under `benchmarks/`, which is what its maintainers publish numbers from, together with the library documentation for `SessionConfig` and `RuntimeEnv`. The ClickBench entry there registers the Parquet files where they lie and queries them in place, and the TPC-H entry does the same over converted Parquet.
+
+The version under test is fixed by this workspace's lockfile, since DataFusion is a Rust library compiled into this binary rather than a server somebody installed. The driver still asks the running system what version it is, through DataFusion's own `version()` function, rather than reporting a constant from build metadata, so a build that somehow linked something else says so.
+
+## Settings
+
+`target_partitions` is set from the machine class, not left at DataFusion's default. The default reads the host's core count, and a default that reads the host makes every result a result about that host rather than about DataFusion.
+
+The tokio runtime is built with the same thread count for the same reason. DataFusion runs its plan on whatever runtime it is called from, so a default multi threaded runtime would size itself from the host as well and the partition count would be the only half of the parallelism anybody controlled.
+
+`RuntimeEnv` is given a memory limit from the machine class. DataFusion's default is an unbounded pool, which is a reasonable default for a library and a terrible experimental control, and it also means a query that would spill on a fleet machine instead grows until the host says no. The whole budget goes to the pool rather than a fraction of it, because the budget in `Setup` is already the allowance for the system under test and reserving a further slice here would quietly give DataFusion less than the other drivers got.
+
+The disk manager is pointed at a subdirectory of the run's scratch directory, so spilling happens somewhere known, gets measured as part of the run, and is removed with everything else afterwards.
+
+Tables are registered as listing tables over the exact files the corpus manifest names, one url per file, rather than over a directory. A directory would be read as whatever happens to be on the disk at the time, and the manifest is the thing that says what a corpus is.
+
+## Deviations
+
+Data is not ingested. DataFusion is a query engine over files rather than a database with its own storage, so the load phase registers the files and infers a schema, and every scan is paid for in the run phase. This is DataFusion's published configuration and it is the honest one, but it means the load number here is not comparable with the load number from a driver that ingested, and the run numbers carry work that the other driver did once. The phases are reported separately for exactly this reason, and a reader comparing only the run column across the two is comparing different things.
+
+There is no in memory alternative worth having. ClickBench `hits` is 14 GB and TPC-H at scale factor 20 is 22.5 GB, neither of which fits in the memory budget of any machine in this fleet, so a driver that materialised into memory would simply fail on the corpora this repository was built to measure.
+
+Text corpora are read with DataFusion's schema inference and no header row, so the column names and types come from DataFusion rather than from the workload. That is the same gap the DuckDB driver has, two systems could disagree about a result because they inferred a column differently rather than because they computed differently, and it closes when the workloads land with their own schemas.
+
+## Rejected alternatives
+
+Writing the corpus to Parquet first and registering that, which is what DataFusion's TPC-H harness does with the `dbgen` output, was rejected. The conversion is not part of any phase this harness times, so it would be work done off the clock, and the corpus is pinned by digest as the bytes that were published rather than as something this repository rewrote.
+
+Setting `batch_size` away from its default was rejected. It is a real tuning knob and DataFusion's own entries leave it alone, so changing it would be this repository tuning a baseline by its own guesswork, which is the thing the `CONFIG.md` rule exists to stop.
+
+Enabling `repartition_file_scans` or the other repartition switches by hand was rejected for the same reason. They are on by default already, and a driver that turned defaults on and off by hand would be publishing a configuration DataFusion's maintainers never put forward.
+
+## Last reviewed
+
+2026-09-06

--- a/drivers/driver-datafusion/Cargo.toml
+++ b/drivers/driver-datafusion/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "driver-datafusion"
+description = "The DataFusion driver, configured from DataFusion's own published benchmark entries."
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+readme.workspace = true
+publish.workspace = true
+
+[dependencies]
+bench-driver.workspace = true
+datafusion.workspace = true
+tokio.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/drivers/driver-datafusion/README.md
+++ b/drivers/driver-datafusion/README.md
@@ -1,0 +1,9 @@
+# driver-datafusion
+
+The DataFusion driver.
+
+DataFusion is a query engine over files rather than a database with its own storage, so this driver registers the corpus where it lies instead of ingesting it, which is what DataFusion's own published benchmark entries do. Loading costs almost nothing and every scan is paid for in the run phase, which is a different trade from the one DuckDB makes and exactly the difference the three phases exist to show. `CONFIG.md` names every setting, where it came from, and what that choice costs a reader comparing the two.
+
+Partition count, thread count and memory budget come from the machine class rather than from DataFusion's defaults, because those defaults read the host.
+
+Part of [iris-bench](https://github.com/tamnd/iris-bench). Licensed under Apache-2.0.

--- a/drivers/driver-datafusion/src/lib.rs
+++ b/drivers/driver-datafusion/src/lib.rs
@@ -1,0 +1,696 @@
+//! The `DataFusion` driver.
+//!
+//! `DataFusion` is a query engine over files rather than a database with its own storage, so this
+//! driver registers the corpus where it lies instead of ingesting it. That is what `DataFusion`'s
+//! own published benchmark entries do, and it is a different trade from the one `DuckDB` makes.
+//! Loading costs almost nothing here and the scan is paid for in the run phase, which is exactly
+//! the difference the three phases exist to show. `CONFIG.md` says so in full.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use bench_driver::{Answer, Driver, DriverError, Format, Load, Query, Rows, Setup, Value};
+use datafusion::arrow::array::{Array, ArrayRef, AsArray};
+use datafusion::arrow::datatypes::{
+    DataType, Date32Type, Date64Type, Decimal128Type, Float32Type, Float64Type, Int8Type,
+    Int16Type, Int32Type, Int64Type, Time32MillisecondType, Time32SecondType,
+    Time64MicrosecondType, Time64NanosecondType, TimeUnit, TimestampMicrosecondType,
+    TimestampMillisecondType, TimestampNanosecondType, TimestampSecondType, UInt8Type, UInt16Type,
+    UInt32Type, UInt64Type,
+};
+use datafusion::datasource::file_format::csv::CsvFormat;
+use datafusion::datasource::file_format::parquet::ParquetFormat;
+use datafusion::datasource::listing::{
+    ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl,
+};
+use datafusion::error::Result as DataFusionResult;
+use datafusion::execution::disk_manager::{DiskManagerBuilder, DiskManagerMode};
+use datafusion::execution::runtime_env::RuntimeEnvBuilder;
+use datafusion::prelude::{SessionConfig, SessionContext};
+use tokio::runtime::Runtime;
+
+/// The version of this crate, as reported by build metadata.
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// What [`Driver::version`] says before anything has been prepared.
+///
+/// A driver that has not been started cannot ask the system what version it is, and answering from
+/// a constant in this file would defeat the point of asking.
+const UNPREPARED: &str = "unprepared";
+
+/// How much of the memory budget `DataFusion` is allowed to hand out.
+///
+/// All of it. The budget in [`Setup`] is already the whole allowance for the system under test, so
+/// reserving a further slice here would quietly give `DataFusion` less than every other driver got.
+const POOL_FRACTION: f64 = 1.0;
+
+/// How many milliseconds a day is, for the one Arrow date type that counts in them.
+const MILLISECONDS_PER_DAY: i64 = 24 * 60 * 60 * 1_000;
+
+/// `DataFusion`, in process.
+pub struct DataFusion {
+    /// Built at preparation time, with the thread count the machine class asked for.
+    runtime: Option<Runtime>,
+    /// The session everything runs against, open once preparation has happened.
+    context: Option<SessionContext>,
+    /// What the system said its version was, read at preparation time.
+    version: Option<String>,
+}
+
+impl std::fmt::Debug for DataFusion {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Hand written because neither a tokio runtime nor a session context is Debug, and the two
+        // things worth seeing here are whether it started and what it said it was.
+        formatter
+            .debug_struct("DataFusion")
+            .field("runtime", &self.runtime.is_some())
+            .field("context", &self.context.is_some())
+            .field("version", &self.version)
+            .finish()
+    }
+}
+
+impl Default for DataFusion {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DataFusion {
+    /// A driver that has not been started yet.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            runtime: None,
+            context: None,
+            version: None,
+        }
+    }
+
+    /// The runtime and the session, or a complaint that the phase order was not followed.
+    fn started(&self) -> Result<(&Runtime, &SessionContext), DriverError> {
+        match (self.runtime.as_ref(), self.context.as_ref()) {
+            (Some(runtime), Some(context)) => Ok((runtime, context)),
+            _ => Err(DriverError::system(
+                "the session is not open",
+                "prepare has not run, so there is nothing to talk to",
+            )),
+        }
+    }
+}
+
+impl Driver for DataFusion {
+    fn name(&self) -> &'static str {
+        "datafusion"
+    }
+
+    fn version(&self) -> String {
+        self.version
+            .clone()
+            .unwrap_or_else(|| UNPREPARED.to_owned())
+    }
+
+    fn prepare(&mut self, setup: &Setup) -> Result<(), DriverError> {
+        // Both of these are set from the machine class rather than left to DataFusion, which sizes
+        // its partitions from the host's core count and hands out memory without a ceiling. A
+        // default that reads the host makes every result a result about that host.
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(setup.threads)
+            .enable_all()
+            .build()
+            .map_err(|error| DriverError::system("starting the runtime", error))?;
+
+        let temp = setup.directory.join("temp");
+        std::fs::create_dir_all(&temp)
+            .map_err(|error| DriverError::system(format!("making {}", temp.display()), error))?;
+
+        let environment = RuntimeEnvBuilder::new()
+            .with_memory_limit(
+                usize::try_from(setup.memory).unwrap_or(usize::MAX),
+                POOL_FRACTION,
+            )
+            .with_disk_manager_builder(
+                DiskManagerBuilder::default().with_mode(DiskManagerMode::Directories(vec![temp])),
+            )
+            .build_arc()
+            .map_err(|error| DriverError::system("building the runtime environment", error))?;
+
+        let config = SessionConfig::new().with_target_partitions(setup.threads);
+        let context = SessionContext::new_with_config_rt(config, environment);
+
+        let asked: DataFusionResult<Option<String>> = runtime.block_on(async {
+            let frame = context.sql("SELECT version()").await?;
+            let batches = frame.collect().await?;
+            Ok(batches
+                .first()
+                .and_then(|batch| batch.column(0).as_string_opt::<i32>())
+                .and_then(|column| column.iter().next().flatten())
+                .map(str::to_owned))
+        });
+        let version = asked
+            .map_err(|error| DriverError::system("asking DataFusion its version", error))?
+            .ok_or_else(|| {
+                DriverError::system(
+                    "asking DataFusion its version",
+                    "version() returned no rows",
+                )
+            })?;
+
+        self.runtime = Some(runtime);
+        self.context = Some(context);
+        self.version = Some(version);
+        Ok(())
+    }
+
+    fn load(&mut self, load: &Load) -> Result<(), DriverError> {
+        let (runtime, context) = self.started()?;
+        let options = options(load)?;
+        let urls = urls(&load.files)?;
+
+        // Registered where the files lie rather than copied into anything. See CONFIG.md: this is
+        // DataFusion's published configuration, and it means the load phase records the schema
+        // inference and nothing else while the run phase carries every scan.
+        let registered: DataFusionResult<()> = runtime.block_on(async {
+            let config = ListingTableConfig::new_with_multi_paths(urls)
+                .with_listing_options(options)
+                .infer_schema(&context.state())
+                .await?;
+            let table = ListingTable::try_new(config)?;
+            context.register_table(load.table.as_str(), Arc::new(table))?;
+            Ok(())
+        });
+        registered
+            .map_err(|error| DriverError::system(format!("loading {}", load.table), error))?;
+        Ok(())
+    }
+
+    fn run(&mut self, query: &Query) -> Result<Answer, DriverError> {
+        let (runtime, context) = self.started()?;
+        // collect rather than a stream that is dropped part way through. A lazy engine that
+        // returned a plan here would have been timed on planning, and the comparison against a
+        // system that actually computed the result would be worthless.
+        let batches = runtime
+            .block_on(async {
+                let frame = context.sql(&query.sql).await?;
+                frame.collect().await
+            })
+            .map_err(|error| DriverError::system(format!("running {}", query.id), error))?;
+
+        let mut answer = Rows::new();
+        for batch in &batches {
+            for row in 0..batch.num_rows() {
+                let mut values = Vec::with_capacity(batch.num_columns());
+                for column in batch.columns() {
+                    values.push(value(column, row, &query.id)?);
+                }
+                answer.push(values)?;
+            }
+        }
+        Ok(answer.finish(query.ordered))
+    }
+}
+
+/// How to read the files of one table.
+fn options(load: &Load) -> Result<ListingOptions, DriverError> {
+    Ok(match load.format {
+        Format::Parquet => ListingOptions::new(Arc::new(ParquetFormat::default())),
+        Format::Separated { separator } => {
+            let delimiter = u8::try_from(separator).map_err(|_| {
+                DriverError::unsupported(
+                    load.table.clone(),
+                    format!("{separator:?} is not a single byte, and DataFusion takes one byte"),
+                )
+            })?;
+            // No header row, because the corpora in scope do not have one, and the column names
+            // therefore come from DataFusion rather than from the workload. CONFIG.md records that
+            // as the gap it is.
+            let format = CsvFormat::default()
+                .with_delimiter(delimiter)
+                .with_has_header(false);
+            ListingOptions::new(Arc::new(format))
+        }
+    })
+}
+
+/// The files of one table, as the urls a listing table takes.
+///
+/// Each file is named on its own rather than a directory being globbed, because the manifest says
+/// which files a corpus is and a directory listing would say whatever happens to be on the disk.
+fn urls(files: &[PathBuf]) -> Result<Vec<ListingTableUrl>, DriverError> {
+    files
+        .iter()
+        .map(|file| {
+            ListingTableUrl::parse(file.to_string_lossy())
+                .map_err(|error| DriverError::system(format!("reading {}", file.display()), error))
+        })
+        .collect()
+}
+
+/// One value out of an Arrow array, in the canonical form.
+///
+/// A type this does not know about is an error rather than a guess. Rendering an unknown type the
+/// way Arrow prints it would produce something that digests differently in every system while
+/// looking like an answer, which is worse than saying the driver cannot render it.
+#[allow(
+    clippy::too_many_lines,
+    reason = "one arm per Arrow type, and splitting it would only move the arms somewhere else"
+)]
+fn value(column: &ArrayRef, row: usize, query: &str) -> Result<Value, DriverError> {
+    if column.is_null(row) {
+        return Ok(Value::Null);
+    }
+    let unsupported = |what: &DataType| {
+        DriverError::unsupported(
+            format!("{query} column of type {what}"),
+            "DataFusion returned a type this driver has no canonical form for".to_owned(),
+        )
+    };
+    Ok(match column.data_type() {
+        // A column whose whole type is null carries no validity buffer, so the check above does not
+        // catch it and it has to be named.
+        DataType::Null => Value::Null,
+        DataType::Boolean => Value::Bool(column.as_boolean().value(row)),
+        DataType::Int8 => Value::Int(i64::from(column.as_primitive::<Int8Type>().value(row))),
+        DataType::Int16 => Value::Int(i64::from(column.as_primitive::<Int16Type>().value(row))),
+        DataType::Int32 => Value::Int(i64::from(column.as_primitive::<Int32Type>().value(row))),
+        DataType::Int64 => Value::Int(column.as_primitive::<Int64Type>().value(row)),
+        DataType::UInt8 => Value::Int(i64::from(column.as_primitive::<UInt8Type>().value(row))),
+        DataType::UInt16 => Value::Int(i64::from(column.as_primitive::<UInt16Type>().value(row))),
+        DataType::UInt32 => Value::Int(i64::from(column.as_primitive::<UInt32Type>().value(row))),
+        DataType::UInt64 => Value::Int(narrow(
+            column.as_primitive::<UInt64Type>().value(row),
+            query,
+        )?),
+        DataType::Float32 => {
+            Value::Float(f64::from(column.as_primitive::<Float32Type>().value(row)))
+        }
+        DataType::Float64 => Value::Float(column.as_primitive::<Float64Type>().value(row)),
+        DataType::Utf8 => Value::Text(column.as_string::<i32>().value(row).to_owned()),
+        DataType::LargeUtf8 => Value::Text(column.as_string::<i64>().value(row).to_owned()),
+        DataType::Utf8View => Value::Text(column.as_string_view().value(row).to_owned()),
+        DataType::Date32 => Value::Date(column.as_primitive::<Date32Type>().value(row)),
+        // Milliseconds since the epoch, which Arrow guarantees are a whole number of days, so this
+        // divides rather than rounds.
+        DataType::Date64 => {
+            Value::Date(days(column.as_primitive::<Date64Type>().value(row), query)?)
+        }
+        DataType::Time32(TimeUnit::Second) => Value::Time(scale(
+            i64::from(column.as_primitive::<Time32SecondType>().value(row)),
+            1_000_000,
+            query,
+        )?),
+        DataType::Time32(TimeUnit::Millisecond) => Value::Time(scale(
+            i64::from(column.as_primitive::<Time32MillisecondType>().value(row)),
+            1_000,
+            query,
+        )?),
+        DataType::Time64(TimeUnit::Microsecond) => {
+            Value::Time(column.as_primitive::<Time64MicrosecondType>().value(row))
+        }
+        DataType::Time64(TimeUnit::Nanosecond) => Value::Time(microseconds(
+            column.as_primitive::<Time64NanosecondType>().value(row),
+            query,
+        )?),
+        DataType::Timestamp(_, Some(_)) => {
+            return Err(DriverError::unsupported(
+                query.to_owned(),
+                "a timestamp with a timezone has no canonical form here, because the canonical \
+                 form has no timezone to render it in",
+            ));
+        }
+        DataType::Timestamp(TimeUnit::Second, None) => Value::Timestamp(scale(
+            column.as_primitive::<TimestampSecondType>().value(row),
+            1_000_000,
+            query,
+        )?),
+        DataType::Timestamp(TimeUnit::Millisecond, None) => Value::Timestamp(scale(
+            column.as_primitive::<TimestampMillisecondType>().value(row),
+            1_000,
+            query,
+        )?),
+        DataType::Timestamp(TimeUnit::Microsecond, None) => {
+            Value::Timestamp(column.as_primitive::<TimestampMicrosecondType>().value(row))
+        }
+        DataType::Timestamp(TimeUnit::Nanosecond, None) => Value::Timestamp(microseconds(
+            column.as_primitive::<TimestampNanosecondType>().value(row),
+            query,
+        )?),
+        // Rendered as a float rather than as exact digits, for the reason the DuckDB driver
+        // renders its decimals as floats: the other systems in the matrix return the same
+        // aggregate as a double, and a comparison only one of the three can pass is not a
+        // comparison. CONFIG.md records it there as the deviation it is.
+        DataType::Decimal128(_, digits) => Value::Float(decimal(
+            column.as_primitive::<Decimal128Type>().value(row),
+            *digits,
+        )),
+        other => return Err(unsupported(other)),
+    })
+}
+
+/// A whole number of days out of a count of milliseconds.
+fn days(milliseconds: i64, query: &str) -> Result<i32, DriverError> {
+    i32::try_from(milliseconds.div_euclid(MILLISECONDS_PER_DAY)).map_err(|_| {
+        DriverError::unsupported(
+            query.to_owned(),
+            format!("{milliseconds} milliseconds is further from the epoch than a date goes"),
+        )
+    })
+}
+
+/// A count in some coarser unit, in microseconds.
+fn scale(inner: i64, factor: i64, query: &str) -> Result<i64, DriverError> {
+    inner.checked_mul(factor).ok_or_else(|| {
+        DriverError::unsupported(
+            query.to_owned(),
+            format!("{inner} does not fit in microseconds"),
+        )
+    })
+}
+
+/// A count of nanoseconds in microseconds, when that loses nothing.
+///
+/// Nanosecond is `DataFusion`'s default timestamp unit, so refusing it outright would refuse most
+/// of what it returns, and dividing it down would make two instants that differ render the same. A
+/// value that divides exactly is the same instant written in a coarser unit and is converted, and
+/// one with a remainder is refused, which keeps the rule that the canonical form never merges two
+/// values that are not equal.
+fn microseconds(nanoseconds: i64, query: &str) -> Result<i64, DriverError> {
+    if nanoseconds % 1_000 == 0 {
+        Ok(nanoseconds / 1_000)
+    } else {
+        Err(DriverError::unsupported(
+            query.to_owned(),
+            format!("{nanoseconds} nanoseconds is finer than the canonical form goes"),
+        ))
+    }
+}
+
+/// A decimal as a double.
+///
+/// The scaled payload divided by ten to the scale, which is what the decimal means. Both halves
+/// are exact in a double for every width these workloads use, and the canonical form rounds to six
+/// significant digits anyway.
+fn decimal(scaled: i128, digits: i8) -> f64 {
+    #[allow(
+        clippy::cast_precision_loss,
+        reason = "an i128 payload wider than a double's mantissa is already past what six \
+                  significant digits would keep"
+    )]
+    let payload = scaled as f64;
+    payload / 10_f64.powi(i32::from(digits))
+}
+
+/// A wider integer as an `i64`, or a complaint.
+///
+/// No result in any workload here is larger than an `i64`, so one that is means the query is not
+/// the one we think it is, and wrapping it silently would be the exact overflow the digest
+/// comparison exists to catch.
+fn narrow<T>(inner: T, query: &str) -> Result<i64, DriverError>
+where
+    T: Copy + std::fmt::Display + TryInto<i64>,
+{
+    inner.try_into().map_err(|_| {
+        DriverError::unsupported(
+            query.to_owned(),
+            format!("{inner} does not fit in a signed 64 bit integer"),
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use bench_driver::Session;
+
+    use super::*;
+
+    fn setup(directory: &Path) -> Setup {
+        Setup {
+            directory: directory.to_path_buf(),
+            threads: 2,
+            memory: 1 << 30,
+        }
+    }
+
+    fn prepared(directory: &Path) -> DataFusion {
+        let mut driver = DataFusion::new();
+        driver.prepare(&setup(directory)).unwrap();
+        driver
+    }
+
+    fn numbers(directory: &Path, name: &str, rows: &str) -> PathBuf {
+        let file = directory.join(name);
+        std::fs::write(&file, rows).unwrap();
+        file
+    }
+
+    #[test]
+    fn it_reports_all_three_phases_against_a_real_engine() {
+        let scratch = tempfile::tempdir().unwrap();
+        let table = numbers(scratch.path(), "numbers.csv", "1|one\n2|two\n3|three\n");
+
+        let mut driver = DataFusion::new();
+        let mut session = Session::new(&mut driver);
+
+        session.prepare(&setup(scratch.path())).unwrap();
+        session
+            .load(&Load {
+                table: "numbers".to_owned(),
+                files: vec![table],
+                format: Format::Separated { separator: '|' },
+            })
+            .unwrap();
+        let (answer, _) = session
+            .query(&Query {
+                id: "q0".to_owned(),
+                sql: "SELECT count(*), sum(column_1) FROM numbers".to_owned(),
+                ordered: false,
+            })
+            .unwrap();
+
+        assert_eq!(answer.body, "3\t6\n");
+        let phases = session.phases();
+        assert!(phases.prepare > 0.0 && phases.load > 0.0 && phases.run > 0.0);
+        assert_eq!(phases.tables, 1);
+        assert_eq!(phases.queries, 1);
+    }
+
+    #[test]
+    fn it_reads_the_files_it_was_given_rather_than_the_directory_they_are_in() {
+        // The manifest says what a corpus is. A directory says what happens to be on the disk, and
+        // a stray file next to the corpus would otherwise become part of every answer.
+        let scratch = tempfile::tempdir().unwrap();
+        let first = numbers(scratch.path(), "part-0.csv", "1|one\n");
+        let second = numbers(scratch.path(), "part-1.csv", "2|two\n");
+        numbers(scratch.path(), "part-2.csv", "3|three\n");
+
+        let mut driver = prepared(scratch.path());
+        driver
+            .load(&Load {
+                table: "numbers".to_owned(),
+                files: vec![first, second],
+                format: Format::Separated { separator: '|' },
+            })
+            .unwrap();
+        let answer = driver
+            .run(&Query {
+                id: "q0".to_owned(),
+                sql: "SELECT sum(column_1) FROM numbers".to_owned(),
+                ordered: false,
+            })
+            .unwrap();
+
+        assert_eq!(answer.body, "3\n");
+    }
+
+    #[test]
+    fn parquet_is_registered_where_it_lies_and_answered_from_there() {
+        // Parquet is the form every corpus in scope is measured in, so the path that matters most
+        // is exercised against a real file rather than only the text one.
+        let scratch = tempfile::tempdir().unwrap();
+        let file = scratch.path().join("numbers.parquet");
+        let mut driver = prepared(scratch.path());
+        driver
+            .run(&Query {
+                id: "write".to_owned(),
+                sql: format!(
+                    "COPY (SELECT 1 AS n UNION ALL SELECT 2 UNION ALL SELECT 3) TO '{}' \
+                     STORED AS PARQUET",
+                    file.display()
+                ),
+                ordered: true,
+            })
+            .unwrap();
+
+        driver
+            .load(&Load {
+                table: "numbers".to_owned(),
+                files: vec![file.clone()],
+                format: Format::Parquet,
+            })
+            .unwrap();
+        let answer = driver
+            .run(&Query {
+                id: "q0".to_owned(),
+                sql: "SELECT count(*), sum(n) FROM numbers".to_owned(),
+                ordered: false,
+            })
+            .unwrap();
+
+        assert_eq!(answer.body, "3\t6\n");
+        // Registered rather than ingested, so the file the corpus named is still the only copy.
+        assert!(file.exists());
+    }
+
+    #[test]
+    fn it_asks_the_system_what_version_it_is() {
+        let scratch = tempfile::tempdir().unwrap();
+        let mut driver = DataFusion::new();
+
+        // Before preparation there is nothing to ask, and answering from a constant in this file
+        // would defeat the point of asking.
+        assert_eq!(driver.version(), UNPREPARED);
+
+        driver.prepare(&setup(scratch.path())).unwrap();
+        let version = driver.version();
+        assert!(
+            version.contains("DataFusion"),
+            "{version} does not look like a DataFusion version"
+        );
+        assert_ne!(version, UNPREPARED);
+    }
+
+    #[test]
+    fn the_settings_it_was_given_are_the_ones_in_force() {
+        let scratch = tempfile::tempdir().unwrap();
+        let driver = prepared(scratch.path());
+        let (_, context) = driver.started().unwrap();
+
+        // Read back off the session the engine is holding rather than off the builder this driver
+        // used, so that a setting DataFusion quietly declined to take would show up here.
+        let options = context.copied_config();
+        assert_eq!(options.options().execution.target_partitions, 2);
+
+        // Spilling goes somewhere known and inside the run's scratch directory, rather than
+        // wherever the default put it.
+        assert!(scratch.path().join("temp").is_dir());
+    }
+
+    #[test]
+    fn every_type_it_can_return_has_a_canonical_form() {
+        let scratch = tempfile::tempdir().unwrap();
+        let mut driver = prepared(scratch.path());
+
+        let answer = driver
+            .run(&Query {
+                id: "types".to_owned(),
+                sql: "SELECT true, arrow_cast(1, 'Int8'), arrow_cast(2, 'Int64'), \
+                      arrow_cast(3, 'UInt64'), arrow_cast(4.5, 'Float64'), \
+                      arrow_cast(6.25, 'Decimal128(9, 2)'), 'text', NULL"
+                    .to_owned(),
+                ordered: true,
+            })
+            .unwrap();
+
+        assert_eq!(answer.columns, 8);
+        assert_eq!(answer.body, "true\t1\t2\t3\t4.5\t6.25\ttext\t\\N\n");
+    }
+
+    #[test]
+    fn dates_and_timestamps_come_back_in_the_canonical_form_rather_than_arrows() {
+        let scratch = tempfile::tempdir().unwrap();
+        let mut driver = prepared(scratch.path());
+
+        let answer = driver
+            .run(&Query {
+                id: "when".to_owned(),
+                sql: "SELECT DATE '2024-02-29', \
+                      arrow_cast(3723500000, 'Time64(Microsecond)'), \
+                      TIMESTAMP '1998-12-01 13:45:00'"
+                    .to_owned(),
+                ordered: true,
+            })
+            .unwrap();
+
+        assert_eq!(answer.body, "2024-02-29\t01:02:03.5\t1998-12-01 13:45:00\n");
+    }
+
+    #[test]
+    fn a_nanosecond_timestamp_converts_when_it_can_and_says_so_when_it_cannot() {
+        // Nanosecond is DataFusion's default timestamp unit, so refusing it outright would refuse
+        // most of what it returns. Whole microseconds convert, a remainder does not.
+        let scratch = tempfile::tempdir().unwrap();
+        let mut driver = prepared(scratch.path());
+
+        let answer = driver
+            .run(&Query {
+                id: "whole".to_owned(),
+                sql: "SELECT arrow_cast(1000, 'Timestamp(Nanosecond, None)')".to_owned(),
+                ordered: true,
+            })
+            .unwrap();
+        assert_eq!(answer.body, "1970-01-01 00:00:00.000001\n");
+
+        let error = driver
+            .run(&Query {
+                id: "fine".to_owned(),
+                sql: "SELECT arrow_cast(1001, 'Timestamp(Nanosecond, None)')".to_owned(),
+                ordered: true,
+            })
+            .unwrap_err();
+        assert!(matches!(error, DriverError::Unsupported { .. }), "{error}");
+    }
+
+    #[test]
+    fn an_integer_too_wide_for_the_canonical_form_is_refused_rather_than_wrapped() {
+        let scratch = tempfile::tempdir().unwrap();
+        let mut driver = prepared(scratch.path());
+
+        let error = driver
+            .run(&Query {
+                id: "wide".to_owned(),
+                sql: "SELECT arrow_cast('18446744073709551615', 'UInt64')".to_owned(),
+                ordered: true,
+            })
+            .unwrap_err();
+        assert!(error.to_string().contains("64 bit"), "{error}");
+    }
+
+    #[test]
+    fn a_type_with_no_canonical_form_is_refused_rather_than_stringified() {
+        // A list rendered as whatever Arrow prints would look like an answer and digest
+        // differently in every system, which is worse than saying so.
+        let scratch = tempfile::tempdir().unwrap();
+        let mut driver = prepared(scratch.path());
+
+        let error = driver
+            .run(&Query {
+                id: "list".to_owned(),
+                sql: "SELECT make_array(1, 2)".to_owned(),
+                ordered: true,
+            })
+            .unwrap_err();
+        assert!(matches!(error, DriverError::Unsupported { .. }), "{error}");
+    }
+
+    #[test]
+    fn a_query_it_cannot_parse_says_which_query() {
+        let scratch = tempfile::tempdir().unwrap();
+        let mut driver = prepared(scratch.path());
+
+        let error = driver
+            .run(&Query {
+                id: "q41".to_owned(),
+                sql: "SELECT FROM WHERE".to_owned(),
+                ordered: false,
+            })
+            .unwrap_err();
+        assert!(error.to_string().contains("q41"), "{error}");
+    }
+
+    #[test]
+    fn it_names_itself_without_a_version_in_the_name() {
+        assert_eq!(DataFusion::new().name(), "datafusion");
+    }
+}

--- a/drivers/driver-duckdb/src/lib.rs
+++ b/drivers/driver-duckdb/src/lib.rs
@@ -243,9 +243,10 @@ fn decimal(inner: duckdb::types::Decimal) -> f64 {
 
 /// A time or timestamp in microseconds, whatever unit `DuckDB` counted it in.
 ///
-/// Nanoseconds are refused rather than divided down. Rounding a nanosecond timestamp to a
-/// microsecond would make two instants that differ render the same, and a canonical form that
-/// merges values is worse than one that says it cannot render them.
+/// A nanosecond value that divides exactly is the same instant written in a coarser unit, so it is
+/// converted. One with a remainder is refused rather than rounded, because rounding would make two
+/// instants that differ render the same, and a canonical form that merges values is worse than one
+/// that says it cannot render them.
 fn microseconds(
     unit: duckdb::types::TimeUnit,
     inner: i64,
@@ -258,10 +259,14 @@ fn microseconds(
         TimeUnit::Millisecond => 1_000,
         TimeUnit::Microsecond => 1,
         TimeUnit::Nanosecond => {
-            return Err(DriverError::unsupported(
-                format!("{query} column {column}"),
-                "nanosecond precision has no canonical form here",
-            ));
+            return if inner % 1_000 == 0 {
+                Ok(inner / 1_000)
+            } else {
+                Err(DriverError::unsupported(
+                    format!("{query} column {column}"),
+                    format!("{inner} nanoseconds is finer than the canonical form goes"),
+                ))
+            };
         }
     };
     inner.checked_mul(factor).ok_or_else(|| {


### PR DESCRIPTION
Closes #16.

## Where the configuration came from

DataFusion's own benchmark harness in `apache/datafusion`, under `benchmarks/`, which is what its maintainers publish numbers from, together with the library documentation for `SessionConfig` and `RuntimeEnv`. `target_partitions`, the tokio runtime's thread count and the memory pool limit all come from the machine class rather than from the defaults, because DataFusion sizes its partitions from the host's core count and hands out memory without a ceiling. Those are reasonable defaults for a library and terrible experimental controls. The disk manager is pointed at a subdirectory of the run's scratch directory so spilling happens somewhere known and is removed with everything else.

The whole memory budget goes to the pool rather than a fraction of it, since the budget in `Setup` is already the allowance for the system under test and reserving a further slice here would quietly have given DataFusion less than the other drivers got.

## It registers rather than ingests

DataFusion is a query engine over files rather than a database with its own storage, so the load phase registers the files and infers a schema and every scan is paid for in the run phase. That is its published configuration and the trait already blesses it: registering a file where it lies and ingesting into a native format are both correct answers, and the load timing is where the difference becomes visible.

`CONFIG.md` says plainly what that costs a reader. The load number here is not comparable with a driver that ingested, and the run numbers carry work that the other driver did once. There is also no in memory alternative worth having, since ClickBench `hits` is 14 GB and TPC-H at scale factor 20 is 22.5 GB, and a driver that materialised would simply fail on the corpora this repository was built to measure.

Tables are registered over the exact files the manifest names, one url per file, rather than over a directory. A directory is whatever happens to be on the disk, and there is a test that puts a third file next to the two a table was given and checks it does not turn up in the answer.

## One change to what already landed

Nanosecond timestamps and times now convert when they divide exactly into microseconds rather than being refused outright, in this driver and in the DuckDB one, so the two render by the same rule. Nanosecond is DataFusion's default timestamp unit, so refusing it would have refused most of what it returns. A value that divides exactly is the same instant written in a coarser unit. One with a remainder is still refused, so the canonical form still never merges two values that are not equal, and there is a test that shows both halves of that.

## Disk

DataFusion is a few hundred crates and at the dev profile's defaults their debug info alone came to about 8 GB of a 13 GB target directory, on a machine that then had no room to build anything else. Debug info is now off for everything outside this workspace, which is the same argument the `libduckdb-sys` profile already makes: nobody sets a breakpoint inside a dependency here, they measure it. Our own crates keep theirs, so a panic in this repository still says which line. The target directory is 2.3 GB with both systems in it.

## What the tests do

Twelve tests, all against a real engine rather than a mock. All three phases against a CSV table, a Parquet table written by DataFusion itself and then registered and queried where it lies, the files it was given rather than the directory they sit in, the version read out of `version()`, the settings read back off the session the engine is holding rather than off the builder this driver used, every type it can return in canonical form, dates and timestamps, the nanosecond rule in both directions, an integer too wide for an `i64` refused rather than wrapped, a list type refused rather than stringified, and a query it cannot parse saying which query.

## Local gate

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `python3 ci/discipline.py`, `cd ci && python3 test_discipline.py`, `cargo test --workspace --all-targets --all-features`, `cargo test --workspace --doc`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`, `cargo check --locked --workspace`. All green.