### PR TITLE
v0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,7 +580,7 @@ checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "bench-core"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -589,7 +589,7 @@ dependencies = [
 
 [[package]]
 name = "bench-corpus"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "blake3",
  "camino",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "bench-driver"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bench-core",
  "serde",
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "bench-env"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bench-core",
  "blake3",
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "bench-report"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bench-core",
  "bench-store",
@@ -639,7 +639,7 @@ dependencies = [
 
 [[package]]
 name = "bench-run"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "arrow-array 59.3.0",
  "arrow-schema 59.3.0",
@@ -664,7 +664,7 @@ dependencies = [
 
 [[package]]
 name = "bench-store"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "arrow-array 59.3.0",
  "arrow-schema 59.3.0",
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "bench-workload"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bench-driver",
  "blake3",
@@ -1831,7 +1831,7 @@ dependencies = [
 
 [[package]]
 name = "driver-arrow-parquet"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "arrow-array 59.3.0",
  "arrow-schema 59.3.0",
@@ -1842,7 +1842,7 @@ dependencies = [
 
 [[package]]
 name = "driver-datafusion"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bench-driver",
  "datafusion",
@@ -1852,7 +1852,7 @@ dependencies = [
 
 [[package]]
 name = "driver-duckdb"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bench-driver",
  "duckdb",
@@ -1861,7 +1861,7 @@ dependencies = [
 
 [[package]]
 name = "driver-null"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bench-driver",
 ]
@@ -2356,7 +2356,7 @@ dependencies = [
 
 [[package]]
 name = "iris-bench-cli"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "bench-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*", "drivers/*"]
 
 [workspace.package]
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 rust-version = "1.98"
 license = "Apache-2.0"
@@ -16,14 +16,14 @@ readme = "README.md"
 publish = false
 
 [workspace.dependencies]
-bench-core = { path = "crates/bench-core", version = "0.2.1" }
-bench-corpus = { path = "crates/bench-corpus", version = "0.2.1" }
-bench-driver = { path = "crates/bench-driver", version = "0.2.1" }
-bench-env = { path = "crates/bench-env", version = "0.2.1" }
-bench-report = { path = "crates/bench-report", version = "0.2.1" }
-bench-run = { path = "crates/bench-run", version = "0.2.1" }
-bench-store = { path = "crates/bench-store", version = "0.2.1" }
-bench-workload = { path = "crates/bench-workload", version = "0.2.1" }
+bench-core = { path = "crates/bench-core", version = "0.2.2" }
+bench-corpus = { path = "crates/bench-corpus", version = "0.2.2" }
+bench-driver = { path = "crates/bench-driver", version = "0.2.2" }
+bench-env = { path = "crates/bench-env", version = "0.2.2" }
+bench-report = { path = "crates/bench-report", version = "0.2.2" }
+bench-run = { path = "crates/bench-run", version = "0.2.2" }
+bench-store = { path = "crates/bench-store", version = "0.2.2" }
+bench-workload = { path = "crates/bench-workload", version = "0.2.2" }
 
 anyhow = "1.0.104"
 arrow-array = "59.3.0"


### PR DESCRIPTION
A patch release between B1 and B2. Version bump and lockfile, nothing else.

What has landed since v0.2.1 is the three system drivers and the ClickBench workload: the DuckDB driver, the DataFusion driver, the arrow-rs Parquet reader, and the 43 published queries run under the upstream protocol with results digested and compared across all three.

Nothing here publishes to crates.io, so this is a tag and a set of notes.
