### PR TITLE
Add clickbench answer, for seeing what a disagreement is about

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,14 @@ cargo run --release -p iris-bench-cli -- clickbench check duckdb.json datafusion
 
 Agreement is per query, across every system that answered it. A query only one system answered is reported separately rather than counted as confirmed, and a system that gave two different answers across its own three runs is named even when the systems agreed with each other.
 
+A digest tells you two systems differ and tells you nothing about what they differ on, so there is a fourth command for the moment after a comparison fails. It takes the table in the same way a run does, runs only the queries you name, and prints the rows both digests were taken over.
+
+```
+cargo run --release -p iris-bench-cli -- clickbench answer --driver duckdb --file /var/tmp/iris-corpus/hits.parquet --query q23
+```
+
+It takes no timings, so it needs no gate and it is fine on a busy machine, and nothing it prints can end up in a table of numbers.
+
 The other check on the same records is against the public leaderboard, which is what says the harness itself is not wrong.
 
 ```

--- a/crates/bench-cli/README.md
+++ b/crates/bench-cli/README.md
@@ -2,7 +2,7 @@
 
 `iris-bench`, the command line tool.
 
-Everything this repository can do from a terminal is here and nowhere else, so the tool is the only way anybody runs anything and there is no second path with different defaults on it. `check` says what the machine is and which eligibility gates it passes. `noise`, `overhead` and `resident` are the measurements about the harness itself. `corpus` fetches or generates a pinned corpus into the store. `clickbench` runs the workload against one system, compares the records afterwards, and calibrates them against the public leaderboard.
+Everything this repository can do from a terminal is here and nowhere else, so the tool is the only way anybody runs anything and there is no second path with different defaults on it. `check` says what the machine is and which eligibility gates it passes. `noise`, `overhead` and `resident` are the measurements about the harness itself. `corpus` fetches or generates a pinned corpus into the store. `clickbench` runs the workload against one system, compares the records afterwards, calibrates them against the public leaderboard, and prints the rows behind a query when the comparison says two systems disagreed about it.
 
 `run`, `reproduce` and `report` are named and do nothing yet. They are the milestones after this one, and they are in the command list rather than absent from it so that the shape of the finished tool is visible from the help text.
 

--- a/crates/bench-cli/src/clickbench.rs
+++ b/crates/bench-cli/src/clickbench.rs
@@ -188,6 +188,85 @@ pub(crate) fn run(
     Ok(())
 }
 
+/// Runs named queries once each and prints what came back.
+///
+/// This is the command for after `check` failed. A digest says two systems differ and says nothing
+/// at all about what they differ on, and a benchmark that hashes an answer and throws it away
+/// leaves the reader guessing at exactly the moment guessing is most expensive. So this takes the
+/// same table in the same way a run does, runs the queries the comparison complained about, and
+/// prints the canonical rendering both digests were taken over.
+///
+/// It takes no timings, so it asks for no permit and it is fine on a busy machine. Nothing it
+/// prints can end up in a table of numbers.
+pub(crate) fn answer(
+    driver: &str,
+    file: &Path,
+    wanted: &[String],
+    rows: usize,
+    threads: usize,
+    memory: u64,
+    scratch: Option<PathBuf>,
+) -> anyhow::Result<()> {
+    let dialect = clickbench::dialect(driver)
+        .with_context(|| format!("no published ClickBench query set is chosen for {driver}"))?;
+    let workload = clickbench::workload(dialect);
+    for id in wanted {
+        anyhow::ensure!(
+            workload.queries.iter().any(|query| &query.id == id),
+            "{driver} has no query called {id}"
+        );
+    }
+
+    let directory = scratch.unwrap_or_else(|| PathBuf::from("run-scratch").join(driver));
+    std::fs::create_dir_all(&directory)
+        .with_context(|| format!("making {}", directory.display()))?;
+
+    let projection = clickbench::projection(driver);
+    let mut system = system(driver)?;
+    let mut session = Session::new(system.as_mut());
+    session.prepare(&Setup {
+        directory,
+        threads,
+        memory,
+    })?;
+    session.load(&Load {
+        table: clickbench::TABLE.to_owned(),
+        files: vec![file.to_owned()],
+        format: Format::Parquet,
+        projection: projection.map(str::to_owned),
+    })?;
+
+    // In the order they were asked for rather than in workload order, because the caller is holding
+    // two of these side by side and wants the same query in the same place in both.
+    for id in wanted {
+        let query = workload
+            .queries
+            .iter()
+            .find(|query| &query.id == id)
+            .expect("the ids were checked above");
+        println!("\n{id} {}", query.sql);
+        match session.query(query) {
+            Ok((answer, _)) => {
+                println!(
+                    "{} rows, {} columns, digest {}",
+                    answer.rows,
+                    answer.columns,
+                    bench_workload::Digest::of(&answer)
+                );
+                let lines: Vec<&str> = answer.body.lines().collect();
+                for line in lines.iter().take(rows) {
+                    println!("  {line}");
+                }
+                if let Some(hidden) = lines.len().checked_sub(rows).filter(|left| *left > 0) {
+                    println!("  and {hidden} more rows, raise --rows to see them");
+                }
+            }
+            Err(error) => println!("did not answer: {error}"),
+        }
+    }
+    Ok(())
+}
+
 /// Reads several records back and says whether the systems agreed.
 ///
 /// Separate from the run because the systems are run one at a time, often on different days, and a
@@ -444,5 +523,24 @@ mod tests {
     fn a_name_with_no_driver_is_refused_rather_than_defaulted() {
         assert!(system("duckdb").is_ok());
         assert!(system("clickhouse").is_err());
+    }
+
+    #[test]
+    fn answer_checks_the_query_ids_before_it_touches_the_corpus() {
+        // Fourteen gigabytes take a while to open and the mistake here is a typed query id, so the
+        // ids are checked against the workload first. The file below does not exist, and the error
+        // that comes back is about the id rather than about the file, which is what says the order
+        // is the one intended rather than the one that happened.
+        let error = answer(
+            "duckdb",
+            Path::new("/nonexistent/hits.parquet"),
+            &["q43".to_owned()],
+            10,
+            1,
+            1 << 30,
+            None,
+        )
+        .expect_err("q43 is one past the end of the workload");
+        assert!(error.to_string().contains("no query called q43"), "{error}");
     }
 }

--- a/crates/bench-cli/src/main.rs
+++ b/crates/bench-cli/src/main.rs
@@ -182,12 +182,14 @@ enum Command {
     Report,
 }
 
-/// The three parts of `clickbench`.
+/// The four parts of `clickbench`.
 ///
 /// Running and comparing are separate because the systems are measured one at a time, often on
 /// different days, and a comparison that could only happen inside a run would be a comparison that
 /// never happened. Calibrating is separate from both because it reads every record of a run
 /// together, and a single record cannot tell a misconfiguration apart from a slower machine.
+/// Answering is separate from all three because it is what somebody reaches for after a comparison
+/// failed, and it takes no timings at all.
 #[derive(Debug, Subcommand)]
 enum ClickbenchCommand {
     /// Measure one system.
@@ -229,6 +231,30 @@ enum ClickbenchCommand {
         /// put next to a leaderboard.
         #[arg(long)]
         anyway: bool,
+    },
+    /// Print what one system actually returns for named queries, rather than what it hashes to.
+    Answer {
+        /// Which system: `duckdb`, `datafusion` or `arrow-parquet`.
+        #[arg(long)]
+        driver: String,
+        /// The Parquet file holding the hits table, already fetched and already verified.
+        #[arg(long, value_name = "PATH")]
+        file: PathBuf,
+        /// Which queries, by the id the record calls them, such as `q23`. Repeat for more.
+        #[arg(long, required = true, value_name = "ID")]
+        query: Vec<String>,
+        /// How many rows of each answer to print before saying how many were left.
+        #[arg(long, default_value_t = 40)]
+        rows: usize,
+        /// How many threads the system is allowed. Defaults to the whole machine.
+        #[arg(long)]
+        threads: Option<usize>,
+        /// How many gibibytes the system is allowed.
+        #[arg(long, default_value_t = 16)]
+        memory: u64,
+        /// Where the system may write, when that is not `run-scratch/`.
+        #[arg(long, value_name = "PATH")]
+        scratch: Option<PathBuf>,
     },
     /// Read records back and say whether the systems agreed about the answers.
     Check {
@@ -317,6 +343,65 @@ fn check(require: Requirement, out: Option<PathBuf>) -> anyhow::Result<()> {
     Ok(capture.require(require.into())?)
 }
 
+/// Hands one of the four `clickbench` subcommands its arguments.
+///
+/// Its own function rather than an arm of the match in `main`, because the run alone has eleven
+/// arguments and burying four commands' worth of that inside another match makes the one place a
+/// reader goes to find out what a flag does the hardest place in the crate to read.
+fn clickbench(what: ClickbenchCommand) -> anyhow::Result<()> {
+    // Absent means the whole machine, which is what the leaderboard entries are taken with, and it
+    // is resolved here rather than in the module so that the record has a number in it either way.
+    let whole = || std::thread::available_parallelism().map_or(1, Into::into);
+    match what {
+        ClickbenchCommand::Run {
+            driver,
+            file,
+            out,
+            seed,
+            pass,
+            in_order,
+            threads,
+            memory,
+            scratch,
+            cold,
+            anyway,
+        } => clickbench::run(
+            &driver,
+            &file,
+            out,
+            seed,
+            pass,
+            in_order,
+            threads.unwrap_or_else(whole),
+            memory * (1 << 30),
+            scratch,
+            cold,
+            anyway,
+        ),
+        ClickbenchCommand::Answer {
+            driver,
+            file,
+            query,
+            rows,
+            threads,
+            memory,
+            scratch,
+        } => clickbench::answer(
+            &driver,
+            &file,
+            &query,
+            rows,
+            threads.unwrap_or_else(whole),
+            memory * (1 << 30),
+            scratch,
+        ),
+        ClickbenchCommand::Check { records } => clickbench::check(&records),
+        ClickbenchCommand::Calibrate { records, column } => {
+            clickbench::calibrate(&records, column.into())
+        }
+    }
+}
+
 fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
@@ -376,38 +461,7 @@ fn main() -> anyhow::Result<()> {
             f64::from(floor) * 1_000.0,
             anyway,
         ),
-        Command::Clickbench { what } => match what {
-            ClickbenchCommand::Run {
-                driver,
-                file,
-                out,
-                seed,
-                pass,
-                in_order,
-                threads,
-                memory,
-                scratch,
-                cold,
-                anyway,
-            } => clickbench::run(
-                &driver,
-                &file,
-                out,
-                seed,
-                pass,
-                in_order,
-                threads
-                    .unwrap_or_else(|| std::thread::available_parallelism().map_or(1, Into::into)),
-                memory * (1 << 30),
-                scratch,
-                cold,
-                anyway,
-            ),
-            ClickbenchCommand::Check { records } => clickbench::check(&records),
-            ClickbenchCommand::Calibrate { records, column } => {
-                clickbench::calibrate(&records, column.into())
-            }
-        },
+        Command::Clickbench { what } => clickbench(what),
         Command::Corpus {
             name,
             root,


### PR DESCRIPTION
The first complete three driver run against the real corpus came back with ten of the forty three queries disagreeing between DuckDB and DataFusion. The findings are in #20. The problem this PR fixes is that there was no way to look at any of them.

A run digests each answer and discards it. That is the right thing for a stored record, since keeping ten rows of a hundred and five columns for every query of every run is a lot of result file for something nobody reads on the happy path. But it means the moment a comparison fails is the moment the tool has the least to say, and the only thing left is to read the SQL and reason about what its shape implies. That is how the eight unstable queries in #20 got classified, and it is not good enough to close a gate whose exit condition says resolved rather than tolerated.

So `clickbench answer` takes the table in exactly the way a run does, with the same setup script and the same projection, runs only the queries named on the command line, and prints the canonical rendering both digests were taken over.

```
iris-bench clickbench answer --driver duckdb --file hits.parquet --query q23 --query q21
```

It prints the query id, the SQL, the row and column counts, the digest, and the rows, capped by `--rows` with a line saying how many were held back. Printing the digest is what lets a printout be lined up against a record rather than trusted to be the same run.

It records no timings, so it asks for no permit at all and works on a machine that would refuse to produce a number. Nothing it prints can end up in a table, which is why it is allowed to be that relaxed.

The query ids are checked against the workload before the corpus is opened. The mistake to expect here is a typed id and the corpus takes a while to open, so a typo should not cost that. There is a test asserting the error comes back about the id rather than about the file.

The `clickbench` arm of `main` moved into its own function. The run alone has eleven arguments, and four commands of that inside another match made the one place a reader goes to find out what a flag does the hardest thing in the crate to read.

Local gate green: fmt, clippy, discipline, discipline tests, workspace tests, doc tests, rustdoc, and a locked check.