### PR TITLE
The reproduce command and the verdict vocabulary

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -114,7 +114,11 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: ossf/scorecard-action@v2
+      # The one action here that is not on a major tag, because OpenSSF does not publish one. Their
+      # tags are exact versions only, so `v2` resolves to nothing and the job fails at the point it
+      # tries to download the action. Bumping this by hand is the cost of that, and it is a smaller
+      # cost than dropping the check.
+      - uses: ossf/scorecard-action@v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,7 +453,7 @@ version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21ca356ad6425cecb6eb7b28e4f659f1ee7880fbb1a16127de7dd62901efee9e"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -673,6 +673,7 @@ dependencies = [
  "bench-core",
  "parquet",
  "serde",
+ "serde_json",
  "thiserror",
  "toml",
 ]
@@ -701,6 +702,12 @@ dependencies = [
  "num-integer",
  "num-traits",
 ]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -1010,7 +1017,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "crossterm_winapi",
  "parking_lot",
  "rustix 0.38.44",
@@ -1023,7 +1030,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "crossterm_winapi",
  "document-features",
  "parking_lot",
@@ -1770,6 +1777,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1808,7 +1846,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "objc2",
 ]
 
@@ -1954,7 +1992,7 @@ version = "25.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "rustc_version",
 ]
 
@@ -2375,6 +2413,7 @@ dependencies = [
  "driver-datafusion",
  "driver-duckdb",
  "iris-source",
+ "jiff",
  "serde",
  "serde_json",
  "tempfile",
@@ -2423,6 +2462,59 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
 
 [[package]]
 name = "jobserver"
@@ -2727,7 +2819,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "dispatch2",
  "objc2",
 ]
@@ -2744,7 +2836,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "objc2",
 ]
 
@@ -2942,6 +3034,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
+name = "portable-atomic"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10ab3eb7f3becc3a1cbc4f2c6f20267996cfc1a6467a873763411b136a122715"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3081,7 +3188,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -3142,7 +3249,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -3155,7 +3262,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,12 @@ datafusion = "55.0.0"
 # Bundled on purpose. The version of a system under test belongs in the lockfile rather than in
 # whatever each machine happened to have installed, because a version that varies by machine is a
 # version nobody pinned and every result row carries it.
-duckdb = { version = "1.10505.0", features = ["bundled"] }
+# Parquet is linked in rather than left to autoloading. Without it DuckDB fetches the extension the
+# first time a query touches a Parquet file, which puts a download inside the machine under test, and
+# the version it lands on is whatever the server had rather than the one the lockfile names. It also
+# fails outright where the extension directory is not writable, which is how the Windows job found
+# this.
+duckdb = { version = "1.10505.0", features = ["bundled", "parquet"] }
 flate2 = "1.1.10"
 hdrhistogram = "7.6.0"
 hex = "0.4.3"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Public BI has been both the design input and the evaluation set for six years of
 
 Pre-alpha. B0 is done as of `v0.1.0` and B1 as of `v0.2.0`, so the measuring apparatus and the data exist and the benchmarks do not. Milestones B0 through B8 are [public](https://github.com/tamnd/iris-bench/milestones) with one issue per exit gate.
 
-What B0 established is in `docs/ROADMAP.md` under that milestone, and the short version is that this fleet can measure, on one machine, for ratios always and for durations under a gate. The noise floor is 1.05% on the one eligible role and over two percent everywhere else, and the harness adds 41.1 ns to a sample, which is under one percent of anything longer than 4.1 microseconds. `iris-bench check`, `noise`, `overhead`, `resident`, `corpus` and `clickbench` run today. Nothing else does.
+What B0 established is in `docs/ROADMAP.md` under that milestone, and the short version is that this fleet can measure, on one machine, for ratios always and for durations under a gate. The noise floor is 1.05% on the one eligible role and over two percent everywhere else, and the harness adds 41.1 ns to a sample, which is under one percent of anything longer than 4.1 microseconds. `iris-bench check`, `noise`, `overhead`, `resident`, `corpus`, `clickbench` and `reproduce` run today. Nothing else does.
 
 B1 is done and is the corpora. ClickBench, TPC-H at scale factor 1 and 20, Public BI in both the full 206 table set and the 36 table subset, and Silesia and enwik8 are pinned and reproduce, some by download, the TPC-H pair from `dbgen`, and the last two from a mirror because their original hosting has moved more than once. Every one of them was fetched or generated end to end through the real command rather than checked on paper, which is 43 GB of Public BI and 22 GB of TPC-H among other things.
 
@@ -117,6 +117,20 @@ cargo run --release -p iris-bench-cli -- clickbench calibrate duckdb.json datafu
 ClickBench publishes the numbers behind every row of its leaderboard, and this carries the DuckDB and DataFusion files for c6a.4xlarge with their address and their digest. The machine here is not that machine, so the comparison is not against any particular ratio. A faster machine moves every query on every system by about one factor, so each driver gets its own ratio against the published numbers, the machine factor is the geometric mean of those ratios, and a driver more than 25 percent away from the shared factor is reported as misconfigured along with the queries that put it there. What that cannot catch is a mistake that slows everything here equally, which looks exactly like a slower machine, and the crate says so rather than leaving it to be discovered.
 
 All of that rests on the run being a fair measurement of the machine it was taken on, so the record now carries whether the machine passed its gates, what overrode them when it did not, and how many threads and how much memory each system was given. Calibration refuses to grade a run that did not pass, because a busy machine is not one factor the arithmetic divides out: another tenant competing for memory bandwidth slows the queries that stream and leaves the rest alone, which is the same shape a misconfigured driver makes. It also refuses records that were given different budgets, since a shared machine factor across two drivers means something only if both ran on the same machine. Passing `--anyway` prints the table with all of that said on it, which is for looking rather than for publishing.
+
+## Claims
+
+A claim this project intends to make is registered before it is run, with the threshold that decides it, and `docs/CLAIMS.md` is that ledger. The registrations are committed files under `crates/bench-store/claims/`, one per claim, and running one is one command.
+
+```
+cargo run --release -p iris-bench-cli -- reproduce C0002
+```
+
+It emits one of five words and there is no sixth: REPRODUCED, REPRODUCED-WITH-CAVEAT, NOT-REPRODUCED, NOT-ATTEMPTABLE, PENDING. The three that follow from a measurement are arithmetic over the reading, the threshold and what the instrument can resolve, rather than a word somebody picks after seeing the number. A reading outside the bar is NOT-REPRODUCED whatever else was true about the run, and the only thing a caveat does is turn a pass into a pass with the condition next to it.
+
+NOT-ATTEMPTABLE covers two situations and both are facts about our circumstances rather than criticism of anybody's work. One is an artifact that cannot be obtained or cannot be run here, which has to carry a citation saying where it was looked for. The other is a bar narrower than what our instrument can resolve, and it is why a claim settled by a comparison runs its own control in the same session. A harness that cannot put two copies of one buffer closer than nine percent has no business reporting that two different things are three percent apart, so a reading that close to its bar is recorded as undecided and the bar is not widened to a number the instrument happens to clear.
+
+Unlike the gates this exits zero on every verdict, because a failed reproduction is a result. What it refuses is a claim nobody registered, a reading taken before the day its own threshold was written down, and a claim whose instrument nobody has built yet, since work that was never attempted is a gap here rather than a verdict.
 
 ## Machines
 

--- a/crates/bench-cli/Cargo.toml
+++ b/crates/bench-cli/Cargo.toml
@@ -25,6 +25,7 @@ bench-store.workspace = true
 bench-workload.workspace = true
 clap.workspace = true
 iris-source.workspace = true
+jiff.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true

--- a/crates/bench-cli/src/clickbench.rs
+++ b/crates/bench-cli/src/clickbench.rs
@@ -720,12 +720,14 @@ mod tests {
         }
     }
 
-    fn fit(threads: usize, memory: u64) -> Option<Conditions> {
-        Some(Conditions {
+    /// A record taken on a machine that passed, wrapped by the caller so that the tests below read
+    /// `Some(fit(..))` against the `None` the version before this field wrote.
+    fn fit(threads: usize, memory: u64) -> Conditions {
+        Conditions {
             refused: None,
             threads,
             memory,
-        })
+        }
     }
 
     fn named(count: usize) -> Vec<PathBuf> {
@@ -744,7 +746,7 @@ mod tests {
             threads: 32,
             memory: 6 << 30,
         });
-        let records = [record(fit(32, 6 << 30)), record(unfit)];
+        let records = [record(Some(fit(32, 6 << 30))), record(unfit)];
         let error = conditions(&named(2), &records, false)
             .expect_err("one of them was taken on an unfit machine");
         assert!(error.to_string().contains("failed its gates"), "{error}");
@@ -768,7 +770,10 @@ mod tests {
     fn records_given_different_machines_are_not_one_run() {
         // Same environment hash, both fit, and still not comparable: a shared machine factor across
         // two drivers only means anything if both were given the same machine to run on.
-        let records = [record(fit(32, 12 << 30)), record(fit(32, 6 << 30))];
+        let records = [
+            record(Some(fit(32, 12 << 30))),
+            record(Some(fit(32, 6 << 30))),
+        ];
         let error = conditions(&named(2), &records, false)
             .expect_err("one got twice the memory budget of the other");
         assert!(
@@ -776,13 +781,19 @@ mod tests {
             "{error}"
         );
 
-        let threads = [record(fit(32, 12 << 30)), record(fit(16, 12 << 30))];
+        let threads = [
+            record(Some(fit(32, 12 << 30))),
+            record(Some(fit(16, 12 << 30))),
+        ];
         conditions(&named(2), &threads, false).expect_err("and one got half the threads");
     }
 
     #[test]
     fn a_fit_run_of_one_machine_grades_without_complaint() {
-        let records = [record(fit(32, 12 << 30)), record(fit(32, 12 << 30))];
+        let records = [
+            record(Some(fit(32, 12 << 30))),
+            record(Some(fit(32, 12 << 30))),
+        ];
         conditions(&named(2), &records, false).expect("both passed and both got the same machine");
     }
 }

--- a/crates/bench-cli/src/main.rs
+++ b/crates/bench-cli/src/main.rs
@@ -1,12 +1,13 @@
 //! `iris-bench`, the command line tool.
 //!
-//! Only `check`, `clickbench`, `corpus`, `noise`, `overhead` and `resident` are implemented. See
-//! `docs/ROADMAP.md` for the rest.
+//! Only `check`, `clickbench`, `corpus`, `noise`, `overhead`, `reproduce` and `resident` are
+//! implemented. See `docs/ROADMAP.md` for the rest.
 
 mod clickbench;
 mod corpus;
 mod noise;
 mod overhead;
+mod reproduce;
 mod resident;
 
 use std::path::PathBuf;
@@ -173,10 +174,21 @@ enum Command {
         /// Path to a run manifest.
         manifest: String,
     },
-    /// Re-run a published reproduction target and record a verdict.
+    /// Run a registered claim and record which of the five verdicts it came to.
+    ///
+    /// Unlike the gates, this exits zero whichever word it lands on, because a failed reproduction
+    /// is a result rather than a broken build. It exits non zero when it cannot produce a verdict
+    /// at all.
     Reproduce {
-        /// Target identifier, for example `f3` or `alp`.
+        /// Claim identifier, as `docs/CLAIMS.md` cites it, for example `C0002`.
         target: String,
+        /// Measure even though the machine failed its gates. The verdict then carries a caveat, and
+        /// a caveat never turns a failure into anything softer.
+        #[arg(long)]
+        anyway: bool,
+        /// Where to write the verdict and everything it was drawn from.
+        #[arg(long, value_name = "PATH")]
+        out: Option<PathBuf>,
     },
     /// Render the store.
     Report,
@@ -475,6 +487,11 @@ fn main() -> anyhow::Result<()> {
             generator,
             scratch,
         } => corpus::run(&name, root, store, generator.as_deref(), scratch),
+        Command::Reproduce {
+            target,
+            anyway,
+            out,
+        } => reproduce::run(&target, anyway, out),
         other => anyhow::bail!("not implemented yet: {other:?}"),
     }
 }

--- a/crates/bench-cli/src/reproduce.rs
+++ b/crates/bench-cli/src/reproduce.rs
@@ -1,0 +1,324 @@
+//! `iris-bench reproduce`: run a registered claim and say which of the five words it came to.
+//!
+//! The claim is read from the registry in `bench-store`, which is committed files rather than
+//! anything this command constructs. So the threshold in front of a reader is the one that was
+//! written down before the number existed, and the ordering is checkable rather than asserted.
+//! Nothing here can widen a bar, and [`bench_store::claim`] refuses to grade a reading taken before
+//! its own registration.
+//!
+//! # This is not a gate
+//!
+//! `resident` and `overhead` exit non zero when they miss their bar, because they are gates and a
+//! claim that stops holding should stop a build. This exits zero on every verdict including
+//! `NOT-REPRODUCED`, because a failed reproduction is a result and the third of the three rules in
+//! the README is that losses are published. What it exits non zero on is being unable to produce a
+//! verdict at all: an entry that cannot be graded, a claim nobody registered, or an instrument this
+//! repository has not written yet.
+//!
+//! That last one is deliberately an error rather than `NOT-ATTEMPTABLE`. Work nobody has started is
+//! a gap in this repository, and giving it a verdict would put a finished looking row on a page for
+//! something that was never attempted.
+//!
+//! # The control comes first
+//!
+//! An instrument that cannot put two copies of the same thing at parity cannot report that two
+//! different things are three percent apart. So a claim measured by a comparison runs its control
+//! in the same session, on the same machine, minutes apart, and what the control misses parity by
+//! is carried into the grading as the resolution. A reading that close to its bar is not decided in
+//! either direction, which is the honest answer and is the one this would rather give than widen
+//! the bar until the instrument clears it.
+
+use anyhow::Context as _;
+use bench_store::claim::{Attempt, Caveat, Claim, Instrument, Measured, Resident, Verdict};
+
+use crate::resident::{self, Measurement, Setup};
+
+/// Runs one registered claim and prints the verdict.
+///
+/// # Errors
+///
+/// If nothing is registered under `target`, if the instrument cannot be run, or if what came back
+/// cannot be graded. Not on the verdict, whichever of the five it is.
+pub(crate) fn run(
+    target: &str,
+    anyway: bool,
+    out: Option<std::path::PathBuf>,
+) -> anyhow::Result<()> {
+    let claim = bench_store::claim::registered(target).ok_or_else(|| {
+        let registered: Vec<String> = bench_store::claim::registry()
+            .into_iter()
+            .map(|claim| format!("{} {}", claim.id, claim.title))
+            .collect();
+        anyhow::anyhow!(
+            "nothing is registered as {target}. What is registered:\n  {}",
+            registered.join("\n  ")
+        )
+    })?;
+
+    println!("{}, {}", claim.id, claim.title);
+    println!(
+        "registered {} in {}",
+        claim.registered.day, claim.registered.source
+    );
+    println!(
+        "the bar is {}, within {:.2}% of {:.3}",
+        claim.bar.reading,
+        claim.bar.tolerance * 100.0,
+        claim.bar.target
+    );
+    if !claim.citable() {
+        println!("registered as exploratory, so whatever this comes to cannot be cited as a claim");
+    }
+    println!();
+
+    let attempt = attempt(&claim, anyway)?;
+    let verdict = claim.decide(Some(&attempt))?;
+
+    println!();
+    println!("{verdict}");
+    println!("{}", why(&claim, &attempt, verdict));
+    if let Attempt::Measured(measured) = &attempt {
+        for caveat in &measured.caveats {
+            println!("  caveat: {}", caveat.what());
+        }
+    }
+
+    if let Some(path) = out {
+        let record = Record {
+            claim: &claim,
+            attempt: &attempt,
+            verdict,
+        };
+        std::fs::write(&path, serde_json::to_string_pretty(&record)?)
+            .with_context(|| format!("writing the verdict to {}", path.display()))?;
+        println!("written to {}", path.display());
+    }
+
+    Ok(())
+}
+
+/// A verdict and everything it was drawn from, for the file `--out` writes.
+///
+/// The claim goes in alongside the reading rather than being referred to by identifier, so that the
+/// file says what the threshold was on the day rather than what the registry says it is now.
+#[derive(Debug, serde::Serialize)]
+struct Record<'a> {
+    claim: &'a Claim,
+    attempt: &'a Attempt,
+    verdict: Verdict,
+}
+
+/// Runs whatever instrument the claim registered.
+fn attempt(claim: &Claim, anyway: bool) -> anyhow::Result<Attempt> {
+    match claim.instrument {
+        Instrument::Resident(resident) => windowed(resident, anyway),
+    }
+}
+
+/// Runs the resident comparison, and its control, and turns the pair into one reading.
+fn windowed(registered: Resident, anyway: bool) -> anyhow::Result<Attempt> {
+    let setup = |control| -> anyhow::Result<Setup> {
+        Ok(Setup {
+            size: registered.size,
+            span: usize::try_from(registered.span)
+                .context("a window span that does not fit in memory")?,
+            chunk: usize::try_from(registered.chunk)
+                .context("a range that does not fit in memory")?,
+            pairs: registered.pairs,
+            control,
+        })
+    };
+
+    // The control first. Running it after the reading would mean grading the reading against a
+    // resolution measured on a machine that had since changed, and the whole reason the two are in
+    // one session is that they are meant to be the same machine.
+    let control = resident::measure(setup(true)?, registered.warmup, anyway)?;
+    println!("{}", control.capture.class);
+    println!("environment {}", control.capture.hash);
+    line("control", &control);
+
+    let reading = resident::measure(setup(false)?, registered.warmup, anyway)?;
+    line("reading", &reading);
+
+    let mut caveats = Vec::new();
+    if control.capture.failed().is_some() || reading.capture.failed().is_some() {
+        caveats.push(Caveat::GatesOverridden);
+    }
+
+    Ok(Attempt::Measured(Measured {
+        day: today(),
+        value: reading.ratio.ratio,
+        resolution: resolution(&control),
+        caveats,
+    }))
+}
+
+/// What the control says this instrument can resolve, as a fraction.
+///
+/// The far end of the control's interval rather than its midpoint, because the bias is itself
+/// measured with uncertainty and taking the near end would credit the instrument with a precision
+/// the run did not establish.
+fn resolution(control: &Measurement) -> f64 {
+    let ratio = &control.ratio;
+    (ratio.lo - 1.0).abs().max((ratio.hi - 1.0).abs())
+}
+
+/// One line of a run, as a percentage with its interval.
+fn line(what: &str, measurement: &Measurement) {
+    let ratio = &measurement.ratio;
+    println!(
+        "  {what:<8}  {:>8.2}%   interval {:.2}% to {:.2}%",
+        ratio.ratio * 100.0,
+        ratio.lo * 100.0,
+        ratio.hi * 100.0
+    );
+}
+
+/// Says in one sentence why the verdict is the word it is.
+///
+/// The arithmetic is printed rather than only the answer, because a reader who disagrees with the
+/// verdict should be able to see which of the three numbers they disagree with.
+fn why(claim: &Claim, attempt: &Attempt, verdict: Verdict) -> String {
+    let Attempt::Measured(measured) = attempt else {
+        return match attempt {
+            Attempt::Refused(refused) => format!("{}, see {}", refused.what, refused.citation),
+            Attempt::Measured(_) => unreachable!("matched above"),
+        };
+    };
+
+    let off = (measured.value - claim.bar.target).abs() / claim.bar.target.abs() * 100.0;
+    let bar = claim.bar.tolerance * 100.0;
+    let resolution = measured.resolution * 100.0;
+
+    match verdict {
+        Verdict::Reproduced | Verdict::ReproducedWithCaveat => format!(
+            "the reading is {off:.2}% off the target, the bar is {bar:.2}%, and the control puts \
+             {resolution:.2}% beyond this instrument, so it is inside with room the instrument can \
+             see"
+        ),
+        Verdict::NotReproduced => format!(
+            "the reading is {off:.2}% off the target, the bar is {bar:.2}%, and the control puts \
+             {resolution:.2}% beyond this instrument, so it is outside by more than the instrument \
+             could be wrong by"
+        ),
+        Verdict::NotAttemptable => format!(
+            "the reading is {off:.2}% off the target and the bar is {bar:.2}%, and the control puts \
+             {resolution:.2}% beyond this instrument, which is more than the gap between them. This \
+             harness cannot settle it either way, and widening the bar to a number it does clear \
+             would be answering a different question"
+        ),
+        // Nothing this command produces is pending, because it has just run the thing.
+        Verdict::Pending => "nothing was run".to_owned(),
+    }
+}
+
+/// Today, as `YYYY-MM-DD` in the machine's own time zone.
+fn today() -> String {
+    jiff::Zoned::now().date().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use bench_store::claim::{Bar, Purpose, Registration};
+
+    use super::*;
+
+    fn claim(target: f64, tolerance: f64) -> Claim {
+        Claim {
+            id: "C0002".to_owned(),
+            title: "a title".to_owned(),
+            purpose: Purpose::Confirmatory,
+            registered: Registration {
+                day: "2026-09-04".to_owned(),
+                source: "an issue".to_owned(),
+            },
+            bar: Bar {
+                reading: "one thing over another".to_owned(),
+                target,
+                tolerance,
+            },
+            instrument: Instrument::Resident(Resident {
+                size: 1024,
+                span: 1024,
+                chunk: 512,
+                pairs: 2,
+                warmup: 0,
+            }),
+        }
+    }
+
+    fn measured(value: f64, resolution: f64) -> Attempt {
+        Attempt::Measured(Measured {
+            day: "2026-09-06".to_owned(),
+            value,
+            resolution,
+            caveats: Vec::new(),
+        })
+    }
+
+    #[test]
+    fn the_sentence_under_a_verdict_carries_the_three_numbers_it_came_from() {
+        let claim = claim(1.0, 0.03);
+        let attempt = measured(1.4351, 0.0935);
+        let verdict = claim.decide(Some(&attempt)).unwrap();
+        let sentence = why(&claim, &attempt, verdict);
+
+        assert_eq!(verdict, Verdict::NotReproduced);
+        assert!(sentence.contains("43.51%"), "{sentence}");
+        assert!(sentence.contains("3.00%"), "{sentence}");
+        assert!(sentence.contains("9.35%"), "{sentence}");
+    }
+
+    #[test]
+    fn a_reading_inside_what_the_control_cannot_see_says_so_rather_than_picking_a_side() {
+        let claim = claim(1.0, 0.03);
+        let attempt = measured(0.9672, 0.0935);
+        let verdict = claim.decide(Some(&attempt)).unwrap();
+
+        assert_eq!(verdict, Verdict::NotAttemptable);
+        assert!(
+            why(&claim, &attempt, verdict).contains("widening the bar"),
+            "the reason a reading is not decided is worth saying out loud"
+        );
+    }
+
+    #[test]
+    fn the_resolution_is_the_far_end_of_the_control_interval() {
+        // A control reported as 91.12% with an interval of 90.65% to 91.84% is 9.35% from parity at
+        // its worst, not 8.88%. Grading against the midpoint would credit the instrument with a
+        // precision this run did not establish.
+        let ratio = bench_core::Ratio {
+            ratio: 0.9112,
+            lo: 0.9065,
+            hi: 0.9184,
+            confidence: 0.95,
+            n: 60,
+        };
+        assert!((far(&ratio) - 0.0935).abs() < 1e-9, "{}", far(&ratio));
+    }
+
+    /// The arithmetic of [`resolution`], without a whole [`Measurement`] to carry it.
+    fn far(ratio: &bench_core::Ratio) -> f64 {
+        (ratio.lo - 1.0).abs().max((ratio.hi - 1.0).abs())
+    }
+
+    #[test]
+    fn a_claim_nobody_registered_is_an_error_and_not_a_verdict() {
+        let error = run("C9999", false, None).unwrap_err();
+        let message = format!("{error}");
+        assert!(
+            message.contains("nothing is registered as C9999"),
+            "{message}"
+        );
+        // And it says what is, because the next thing anybody does after this is guess again.
+        assert!(message.contains("C0002"), "{message}");
+    }
+
+    #[test]
+    fn today_is_a_day_the_ledger_can_order() {
+        let today = today();
+        assert_eq!(today.len(), 10, "{today}");
+        assert_eq!(&today[4..5], "-");
+        assert_eq!(&today[7..8], "-");
+    }
+}

--- a/crates/bench-cli/src/resident.rs
+++ b/crates/bench-cli/src/resident.rs
@@ -536,7 +536,7 @@ mod tests {
 
     #[test]
     fn a_window_smaller_than_a_chunk_is_refused_before_anything_is_measured() {
-        let error = gate(1024 * 1024, 4096, 8192, 1, 0, 0.03, true, false).unwrap_err();
+        let error = measure(refusable(false), 0, true).unwrap_err();
         assert!(format!("{error}").contains("cannot be served by a window"));
     }
 
@@ -545,8 +545,24 @@ mod tests {
         // The span is what the window reserves and a control run does not open one, so refusing a
         // control because of a span it will never use would be refusing the one run that answers
         // whether the refusal was worth listening to.
-        let outcome = gate(1024 * 1024, 4096, 8192, 2, 0, 1.0, true, true);
+        //
+        // This asks `measure` rather than `gate` on purpose. What is under test is whether the run
+        // is refused before it starts, and going through `gate` would also put the result up
+        // against a bar, which on a shared machine is a question about that machine rather than
+        // about the refusal.
+        let outcome = measure(refusable(true), 0, true);
         assert!(outcome.is_ok(), "{outcome:?}");
+    }
+
+    /// A setup whose chunk is larger than its span, which is the shape the refusal is about.
+    fn refusable(control: bool) -> Setup {
+        Setup {
+            size: 1024 * 1024,
+            span: 4096,
+            chunk: 8192,
+            pairs: 2,
+            control,
+        }
     }
 
     #[test]

--- a/crates/bench-cli/src/resident.rs
+++ b/crates/bench-cli/src/resident.rs
@@ -167,23 +167,60 @@ fn scan<S: RangeSource>(source: &mut S, chunk: usize) -> anyhow::Result<u64> {
     Ok(sum)
 }
 
-/// Runs the gate.
+/// How one run of the comparison was set up.
+///
+/// A struct rather than a row of arguments because `reproduce` builds one of these from a
+/// registered claim and this command builds one from the command line, and the two should be
+/// handing the measurement the same thing.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct Setup {
+    /// How large a file to scan, in bytes.
+    pub(crate) size: u64,
+    /// How much address space the window reserves, in bytes.
+    pub(crate) span: usize,
+    /// How large each range a scan asks for is, in bytes.
+    pub(crate) chunk: usize,
+    /// How many pairs of measurements to take.
+    pub(crate) pairs: u32,
+    /// Compare the buffer against a second buffer, which measures this command's own bias.
+    pub(crate) control: bool,
+}
+
+/// What one run of the comparison was, and what it came to.
+#[derive(Debug)]
+pub(crate) struct Measurement {
+    /// The machine, read before anything was timed.
+    pub(crate) capture: Capture,
+    /// The windowed path over the whole buffer path, with its interval.
+    pub(crate) ratio: Ratio,
+    /// How it was set up.
+    setup: Setup,
+    /// The windowed side on its own.
+    windowed: Summary,
+    /// The buffered side on its own.
+    buffered: Summary,
+    /// How many times the window moved per scan.
+    slides: u64,
+}
+
+/// Runs the comparison and returns what it came to, without deciding anything about it.
+///
+/// Separate from [`gate`] because a gate and a registered claim want different things from the same
+/// numbers. The gate exits non zero when the bar is missed, and `reproduce` records a verdict
+/// either way, so the part that decides is above this rather than inside it.
 ///
 /// # Errors
 ///
 /// If the machine is not fit to produce a ratio and `anyway` was not asked for, if the file cannot
-/// be written or opened, or if the measured interval does not clear `bar`.
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn gate(
-    size: u64,
-    span: usize,
-    chunk: usize,
-    pairs: u32,
-    warmup: u32,
-    bar: f64,
-    anyway: bool,
-    control: bool,
-) -> anyhow::Result<()> {
+/// be written or opened, or if there are not enough pairs to compare.
+pub(crate) fn measure(setup: Setup, warmup: u32, anyway: bool) -> anyhow::Result<Measurement> {
+    let Setup {
+        size,
+        span,
+        chunk,
+        pairs,
+        control,
+    } = setup;
     if chunk > span && !control {
         bail!(
             "a chunk of {chunk} bytes cannot be served by a window with a span of {span}, so this \
@@ -259,19 +296,46 @@ pub(crate) fn gate(
     let window_summary = summarise(&windowed, Bootstrap::default()).expect("at least one pair");
     let buffer_summary = summarise(&buffered, Bootstrap::default()).expect("at least one pair");
 
-    report(
-        &capture,
-        size,
-        span,
-        chunk,
-        pairs,
-        &window_summary,
-        &buffer_summary,
-        &ratio,
-        bar,
-        (left.slides() - before_slides) / u64::from(pairs),
-        control,
-    );
+    Ok(Measurement {
+        capture,
+        ratio,
+        setup,
+        windowed: window_summary,
+        buffered: buffer_summary,
+        slides: (left.slides() - before_slides) / u64::from(pairs),
+    })
+}
+
+/// Runs the gate.
+///
+/// # Errors
+///
+/// If the measurement cannot be taken, or if the measured interval does not clear `bar`.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn gate(
+    size: u64,
+    span: usize,
+    chunk: usize,
+    pairs: u32,
+    warmup: u32,
+    bar: f64,
+    anyway: bool,
+    control: bool,
+) -> anyhow::Result<()> {
+    let measurement = measure(
+        Setup {
+            size,
+            span,
+            chunk,
+            pairs,
+            control,
+        },
+        warmup,
+        anyway,
+    )?;
+    let ratio = &measurement.ratio;
+
+    report(&measurement, bar);
 
     if anyway {
         println!();
@@ -318,20 +382,24 @@ pub(crate) fn gate(
 }
 
 /// Prints what was measured.
-#[allow(clippy::too_many_arguments)]
-fn report(
-    capture: &Capture,
-    size: u64,
-    span: usize,
-    chunk: usize,
-    pairs: u32,
-    windowed: &Summary,
-    buffered: &Summary,
-    ratio: &Ratio,
-    bar: f64,
-    slides: u64,
-    control: bool,
-) {
+fn report(measurement: &Measurement, bar: f64) {
+    let Measurement {
+        capture,
+        ratio,
+        setup:
+            Setup {
+                size,
+                span,
+                chunk,
+                pairs,
+                control,
+            },
+        windowed,
+        buffered,
+        slides,
+    } = measurement;
+    let (size, span, chunk, pairs, slides) = (*size, *span, *chunk, *pairs, *slides);
+    let control = *control;
     let mib = 1024 * 1024;
     println!("{}", capture.class);
     println!("environment {}", capture.hash);

--- a/crates/bench-run/src/cache.rs
+++ b/crates/bench-run/src/cache.rs
@@ -61,9 +61,20 @@ mod tests {
     use super::*;
 
     /// Whether this process could drop the cache even if the mechanism existed.
+    ///
+    /// `cfg!` below is a value and not a compilation switch, so the call still has to compile
+    /// everywhere the tests run even where the branch is never taken. Windows has no effective user
+    /// id to ask about, and the answer it needs is the same one every non root process gets.
+    #[cfg(unix)]
     fn privileged() -> bool {
         // SAFETY: geteuid takes no arguments and cannot fail.
         unsafe { libc::geteuid() == 0 }
+    }
+
+    /// Whether this process could drop the cache even if the mechanism existed.
+    #[cfg(not(unix))]
+    fn privileged() -> bool {
+        false
     }
 
     #[test]

--- a/crates/bench-store/Cargo.toml
+++ b/crates/bench-store/Cargo.toml
@@ -24,5 +24,8 @@ serde.workspace = true
 thiserror.workspace = true
 toml.workspace = true
 
+[dev-dependencies]
+serde_json.workspace = true
+
 [lints]
 workspace = true

--- a/crates/bench-store/claims/C0002.toml
+++ b/crates/bench-store/claims/C0002.toml
@@ -1,0 +1,26 @@
+# C0002, registered in tamnd/iris on the day below and measured two days later. The entry in
+# docs/CLAIMS.md is the prose version of this file. Two copies of one fact drift, which is why
+# generating that page from these files rather than maintaining both is its own issue.
+
+id = "C0002"
+title = "what the sliding window costs on a file that is already resident"
+purpose = "confirmatory"
+
+[registered]
+day = "2026-09-04"
+source = "tamnd/iris issue #26 and the M4 checklist of that repository"
+
+[bar]
+reading = "a scan of a resident local file through the windowed path, divided by a scan of the same bytes handed over as one buffer"
+target = 1.0
+tolerance = 0.03
+
+# The defaults of `iris-bench resident`, in bytes, so that re-running this claim does not depend on
+# what the defaults happen to be on the day. A registered claim that reads its numbers from whatever
+# the tool currently defaults to is a claim whose threshold can be moved without editing it.
+[instrument.resident]
+size = 268435456
+span = 4194304
+chunk = 262144
+pairs = 60
+warmup = 3

--- a/crates/bench-store/src/claim.rs
+++ b/crates/bench-store/src/claim.rs
@@ -1,0 +1,722 @@
+//! The claim ledger: what this project said it would test, and how it came out.
+//!
+//! A claim is registered before it is run, with the threshold that decides it and the instrument
+//! that would settle it. Registration is the whole point. A threshold written after the number
+//! exists is not a threshold, it is a description of the number, and the two are indistinguishable
+//! on the page a reader eventually sees. So a claim carries the day it was registered and where the
+//! threshold was written down, and [`Claim::decide`] refuses to grade a measurement taken before
+//! that day rather than trusting whoever assembled the entry.
+//!
+//! ```
+//! use bench_store::claim::{Attempt, Measured, Verdict, registry};
+//!
+//! let claim = registry().into_iter().find(|one| one.id == "C0002").expect("C0002 is registered");
+//!
+//! // What the windowed path actually came to, at the span iris ships, against a bar of three
+//! // percent and an instrument whose own bias is nine.
+//! let measured = Attempt::Measured(Measured {
+//!     day: "2026-09-06".to_owned(),
+//!     value: 1.4351,
+//!     resolution: 0.0888,
+//!     caveats: Vec::new(),
+//! });
+//!
+//! assert_eq!(claim.decide(Some(&measured)).unwrap(), Verdict::NotReproduced);
+//! assert_eq!(claim.decide(None).unwrap(), Verdict::Pending);
+//! ```
+//!
+//! # The five words
+//!
+//! `REPRODUCED`, `REPRODUCED-WITH-CAVEAT`, `NOT-REPRODUCED`, `NOT-ATTEMPTABLE` and `PENDING`. The
+//! set is closed and the spelling is fixed, which is the only reason it is worth having. A
+//! vocabulary somebody can extend is a vocabulary that grows a gentler word every time a result
+//! comes out badly, and the gentler word is always the one that gets quoted. [`Verdict`] parses
+//! exactly these five and serialises as exactly these five, so the word in a file, the word on a
+//! terminal and the word in the ledger are one string.
+//!
+//! None of the three that follow from a measurement is chosen by a person. [`Bar::decide`] is the
+//! only thing that produces them, from the number, the threshold and what the instrument can
+//! resolve.
+//!
+//! # A caveat cannot rescue a failure
+//!
+//! A measurement outside the bar is `NOT-REPRODUCED` whatever else was true about the run. Caveats
+//! only ever turn a `REPRODUCED` into a `REPRODUCED-WITH-CAVEAT`, never a `NOT-REPRODUCED` into
+//! anything. Softening a loss with a note about the conditions is exactly the move the fixed
+//! vocabulary exists to prevent, and allowing a caveat to travel in both directions would hand it
+//! back.
+//!
+//! # `NOT-ATTEMPTABLE` is about our circumstances
+//!
+//! Two different situations reach it and both are facts about us rather than criticism of anybody's
+//! work. One is an artifact that cannot be obtained or cannot be run here, which arrives as
+//! [`Attempt::Refused`] and has to carry a citation, because an unsupported assertion that
+//! something was unavailable is not better than no entry. The other is a bar narrower than what the
+//! instrument can resolve, where the honest answer is that this harness cannot settle the question
+//! either way. The entry says which, and the verdict is the same word for both because both mean
+//! the claim was not settled here.
+//!
+//! What is not `NOT-ATTEMPTABLE` is a claim whose instrument has not been written yet. That is a
+//! gap in this repository's work, and dressing it as a verdict would put a finished looking row on
+//! a page for something nobody has started. A caller asked to run one of those gets an error.
+//!
+//! # What the resolution is for
+//!
+//! An instrument that cannot tell two copies of the same thing apart to within nine percent cannot
+//! honestly report that two different things are three percent apart. So a measurement carries what
+//! its instrument resolves, measured in the same run rather than assumed, and a reading close
+//! enough to the bar that the difference is inside that figure is not decided in either direction.
+//!
+//! The alternative, widening the bar until the instrument clears it, produces a number that looks
+//! like a pass and means nothing, and it is the reason this rule is code here instead of a habit.
+
+use std::fmt;
+use std::str::FromStr;
+
+/// Every claim this repository has registered, as the files that carry them.
+///
+/// One file per claim, committed, and the file is the registration. Adding an entry to this list is
+/// a change to a public list of what the project intends to prove.
+const REGISTERED: &[&str] = &[include_str!("../claims/C0002.toml")];
+
+/// Every registered claim, parsed.
+///
+/// # Panics
+///
+/// If a carried claim does not parse, which is a bug in this crate rather than anything a caller
+/// can do about it. The test below parses all of them.
+#[must_use]
+pub fn registry() -> Vec<Claim> {
+    REGISTERED
+        .iter()
+        .map(|text| toml::from_str(text).expect("a carried claim has to parse"))
+        .collect()
+}
+
+/// Looks a registered claim up by identifier, ignoring case.
+///
+/// Ignoring case because the identifiers are cited in prose as `C0002` and typed on a command line
+/// as `c0002`, and refusing the second would be a papercut with nothing behind it.
+#[must_use]
+pub fn registered(id: &str) -> Option<Claim> {
+    registry()
+        .into_iter()
+        .find(|claim| claim.id.eq_ignore_ascii_case(id))
+}
+
+/// One registered claim.
+#[derive(Clone, PartialEq, Debug, serde::Serialize, serde::Deserialize)]
+pub struct Claim {
+    /// The identifier other documents cite, such as `C0002`.
+    pub id: String,
+    /// What the claim is about, in one phrase.
+    pub title: String,
+    /// Whether a verdict here may be cited as evidence.
+    pub purpose: Purpose,
+    /// When the threshold was committed, and where.
+    pub registered: Registration,
+    /// What the reading is judged against.
+    pub bar: Bar,
+    /// What would be run to settle it.
+    pub instrument: Instrument,
+}
+
+impl Claim {
+    /// Whether a verdict on this claim may be cited as a claim anywhere.
+    ///
+    /// False for an exploratory registration, and that is fixed when the claim is registered. It is
+    /// what stops a measurement taken to see what happens from being promoted to evidence once it
+    /// comes out well.
+    #[must_use]
+    pub fn citable(&self) -> bool {
+        self.purpose == Purpose::Confirmatory
+    }
+
+    /// Turns what was attempted into one of the five words.
+    ///
+    /// `None` is a claim nobody has run, which is `PENDING` and is meant to be visible as a gap in
+    /// a committed file rather than as a number that quietly never appeared.
+    ///
+    /// # Errors
+    ///
+    /// If the entry cannot be graded at all: a measurement older than its own threshold, a day that
+    /// is not a day, a registration that does not say where the threshold was written, a refusal
+    /// with no citation, or a bar expressed as a fraction of zero. None of those is a result, so
+    /// none of them is a verdict.
+    pub fn decide(&self, attempt: Option<&Attempt>) -> Result<Verdict, Ungradable> {
+        if self.registered.source.trim().is_empty() {
+            return Err(Ungradable::Unregistered {
+                claim: self.id.clone(),
+            });
+        }
+        if !is_day(&self.registered.day) {
+            return Err(Ungradable::NotADay {
+                claim: self.id.clone(),
+                which: "registered",
+                given: self.registered.day.clone(),
+            });
+        }
+
+        let Some(attempt) = attempt else {
+            return Ok(Verdict::Pending);
+        };
+
+        match attempt {
+            Attempt::Refused(refused) => {
+                if refused.citation.trim().is_empty() {
+                    return Err(Ungradable::NoCitation {
+                        claim: self.id.clone(),
+                    });
+                }
+                Ok(Verdict::NotAttemptable)
+            }
+            Attempt::Measured(measured) => {
+                if !is_day(&measured.day) {
+                    return Err(Ungradable::NotADay {
+                        claim: self.id.clone(),
+                        which: "measured",
+                        given: measured.day.clone(),
+                    });
+                }
+                // Both are `YYYY-MM-DD`, which orders the same way as text and as a date, and that
+                // is the reason the format is checked above rather than taken on trust.
+                if measured.day < self.registered.day {
+                    return Err(Ungradable::Backdated {
+                        claim: self.id.clone(),
+                        registered: self.registered.day.clone(),
+                        measured: measured.day.clone(),
+                    });
+                }
+                self.bar
+                    .decide(measured)
+                    .ok_or(Ungradable::RelativeToNothing {
+                        claim: self.id.clone(),
+                    })
+            }
+        }
+    }
+}
+
+/// Whether a verdict may be cited as evidence, fixed at registration.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Purpose {
+    /// Registered to settle something, and citable.
+    Confirmatory,
+    /// Registered to find out what happens, and not citable as a claim anywhere.
+    Exploratory,
+}
+
+/// When a threshold was committed, and where it can be read.
+#[derive(Clone, PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]
+pub struct Registration {
+    /// The day, as `YYYY-MM-DD`.
+    pub day: String,
+    /// Where the threshold was written down, in enough detail to go and look: an issue, a commit,
+    /// or a document and the commit that carried it.
+    pub source: String,
+}
+
+/// What a reading is judged against, written before the reading exists.
+#[derive(Clone, PartialEq, Debug, serde::Serialize, serde::Deserialize)]
+pub struct Bar {
+    /// What is divided by what, so that the number has a meaning without the code in front of you.
+    pub reading: String,
+    /// The value the reading is compared against.
+    pub target: f64,
+    /// How far from the target the reading may sit, as a fraction of the target.
+    pub tolerance: f64,
+}
+
+impl Bar {
+    /// Grades one measurement, or `None` when the target is zero and a fraction of it means
+    /// nothing.
+    ///
+    /// The three outcomes are the reading being inside the bar with room the instrument can see,
+    /// outside it with room the instrument can see, or too close to the bar for this instrument to
+    /// call. Caveats only separate the first into its two spellings.
+    #[must_use]
+    pub fn decide(&self, measured: &Measured) -> Option<Verdict> {
+        if self.target.abs() < f64::EPSILON {
+            return None;
+        }
+        let off = (measured.value - self.target).abs() / self.target.abs();
+        if off + measured.resolution <= self.tolerance {
+            Some(if measured.caveats.is_empty() {
+                Verdict::Reproduced
+            } else {
+                Verdict::ReproducedWithCaveat
+            })
+        } else if off - measured.resolution > self.tolerance {
+            Some(Verdict::NotReproduced)
+        } else {
+            Some(Verdict::NotAttemptable)
+        }
+    }
+}
+
+/// What would be run to settle a claim.
+///
+/// The variants are the instruments that exist. A claim naming one that does not fails to parse,
+/// so an entry cannot sit in the ledger looking registered while nothing could ever settle it.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Instrument {
+    /// `iris-bench resident`, with the arguments the registration fixed.
+    Resident(Resident),
+}
+
+/// The arguments `iris-bench resident` is run with to settle a claim, in bytes.
+///
+/// Bytes rather than the mebibytes and kibibytes the command line takes, because a registration is
+/// read by whoever is checking the ordering years later and a unit in the field name is one fewer
+/// thing for them to get wrong.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]
+pub struct Resident {
+    /// How large a file to scan.
+    pub size: u64,
+    /// How much address space the window reserves.
+    pub span: u64,
+    /// How large each range a scan asks for is.
+    pub chunk: u64,
+    /// How many pairs of measurements to take.
+    pub pairs: u32,
+    /// How many scans of each side to run before recording anything.
+    pub warmup: u32,
+}
+
+/// What a run of a claim produced.
+#[derive(Clone, PartialEq, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Attempt {
+    /// A number came back.
+    Measured(Measured),
+    /// Nothing could be run, for a reason about our circumstances.
+    Refused(Refused),
+}
+
+/// A number and everything needed to grade it.
+#[derive(Clone, PartialEq, Debug, serde::Serialize, serde::Deserialize)]
+pub struct Measured {
+    /// The day it was taken, as `YYYY-MM-DD`.
+    pub day: String,
+    /// The reading, in whatever [`Bar::reading`] says it is.
+    pub value: f64,
+    /// What the instrument can resolve, as a fraction of the target, measured in the same run.
+    ///
+    /// Zero for a deterministic reading such as a compression ratio, where re-running produces the
+    /// same number and there is nothing for a control to say.
+    pub resolution: f64,
+    /// What was true about the run that a reader would want next to a pass.
+    pub caveats: Vec<Caveat>,
+}
+
+/// Why nothing could be run.
+#[derive(Clone, PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]
+pub struct Refused {
+    /// The day the attempt was made, as `YYYY-MM-DD`.
+    pub day: String,
+    /// What was missing, worded as a fact about our circumstances.
+    pub what: String,
+    /// Where it was looked for, so that the refusal is checkable rather than asserted.
+    pub citation: String,
+}
+
+/// Something true about a run that a reader would want next to a pass.
+///
+/// Each of these is a fact the harness knows about the run rather than a judgement somebody made
+/// afterwards, which is what keeps `REPRODUCED-WITH-CAVEAT` from becoming the polite spelling of a
+/// result nobody liked.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Caveat {
+    /// The machine failed an eligibility gate and the run was taken anyway.
+    GatesOverridden,
+    /// The artifact was run on a platform its authors did not say they tested.
+    UntestedPlatform,
+    /// Part of the configuration is in nobody's documentation and was guessed.
+    ConfigurationGuessed,
+}
+
+impl Caveat {
+    /// What it means, in one line, for putting next to a verdict.
+    #[must_use]
+    pub fn what(self) -> &'static str {
+        match self {
+            Self::GatesOverridden => {
+                "the machine failed an eligibility gate and the run was taken anyway"
+            }
+            Self::UntestedPlatform => {
+                "the artifact was run on a platform its authors did not say they tested"
+            }
+            Self::ConfigurationGuessed => {
+                "part of the configuration is in nobody's documentation and was guessed"
+            }
+        }
+    }
+}
+
+/// One of five words, and there is no sixth.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, serde::Serialize, serde::Deserialize)]
+pub enum Verdict {
+    /// The reading met the threshold that was registered before it existed.
+    #[serde(rename = "REPRODUCED")]
+    Reproduced,
+    /// The reading met it, and something about the run belongs next to that.
+    #[serde(rename = "REPRODUCED-WITH-CAVEAT")]
+    ReproducedWithCaveat,
+    /// The reading did not meet it.
+    #[serde(rename = "NOT-REPRODUCED")]
+    NotReproduced,
+    /// It was not settled here, and the entry says which of the two reasons applies.
+    #[serde(rename = "NOT-ATTEMPTABLE")]
+    NotAttemptable,
+    /// Registered, and nobody has run it.
+    #[serde(rename = "PENDING")]
+    Pending,
+}
+
+impl Verdict {
+    /// The word, which is the same string everywhere this verdict appears.
+    #[must_use]
+    pub fn word(self) -> &'static str {
+        match self {
+            Self::Reproduced => "REPRODUCED",
+            Self::ReproducedWithCaveat => "REPRODUCED-WITH-CAVEAT",
+            Self::NotReproduced => "NOT-REPRODUCED",
+            Self::NotAttemptable => "NOT-ATTEMPTABLE",
+            Self::Pending => "PENDING",
+        }
+    }
+
+    /// All five, in the order they are written in `docs/CLAIMS.md`.
+    #[must_use]
+    pub fn all() -> [Self; 5] {
+        [
+            Self::Reproduced,
+            Self::ReproducedWithCaveat,
+            Self::NotReproduced,
+            Self::NotAttemptable,
+            Self::Pending,
+        ]
+    }
+}
+
+impl fmt::Display for Verdict {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.word())
+    }
+}
+
+impl FromStr for Verdict {
+    type Err = NotAVerdict;
+
+    fn from_str(text: &str) -> Result<Self, Self::Err> {
+        Self::all()
+            .into_iter()
+            .find(|verdict| verdict.word() == text)
+            .ok_or_else(|| NotAVerdict {
+                given: text.to_owned(),
+            })
+    }
+}
+
+/// A word that is not one of the five.
+#[derive(Clone, PartialEq, Eq, Debug, thiserror::Error)]
+#[error(
+    "{given} is not a verdict, and the five are REPRODUCED, REPRODUCED-WITH-CAVEAT, \
+     NOT-REPRODUCED, NOT-ATTEMPTABLE and PENDING"
+)]
+pub struct NotAVerdict {
+    /// What was given instead.
+    pub given: String,
+}
+
+/// An entry that cannot be turned into a verdict at all.
+///
+/// Every one of these is a fault in the entry rather than an outcome of the claim, which is why
+/// they are errors and not a sixth word.
+#[derive(Clone, PartialEq, Eq, Debug, thiserror::Error)]
+pub enum Ungradable {
+    /// The registration does not say where the threshold was written down.
+    #[error(
+        "{claim} does not say where its threshold was registered, so there is nothing to check the \
+         ordering against and it cannot be graded"
+    )]
+    Unregistered {
+        /// Which claim.
+        claim: String,
+    },
+    /// A day is not a day, so the ordering cannot be checked.
+    #[error("{claim} gives {given} as the day it was {which}, and a day here is YYYY-MM-DD")]
+    NotADay {
+        /// Which claim.
+        claim: String,
+        /// Which of the two days, `registered` or `measured`.
+        which: &'static str,
+        /// What was given.
+        given: String,
+    },
+    /// The measurement is older than the threshold that judges it.
+    #[error(
+        "{claim} was measured on {measured} and registered on {registered}, so the threshold was \
+         not committed before the number existed and this is not a pre-registered result"
+    )]
+    Backdated {
+        /// Which claim.
+        claim: String,
+        /// The day the threshold was committed.
+        registered: String,
+        /// The day the number was taken.
+        measured: String,
+    },
+    /// A refusal with nothing behind it.
+    #[error(
+        "{claim} was recorded as unattemptable with no citation, and where the artifact was looked \
+         for is the part of that a reader cannot supply"
+    )]
+    NoCitation {
+        /// Which claim.
+        claim: String,
+    },
+    /// A tolerance expressed as a fraction of zero.
+    #[error("{claim} has a target of zero, and a tolerance is a fraction of the target")]
+    RelativeToNothing {
+        /// Which claim.
+        claim: String,
+    },
+}
+
+/// Whether a string is a `YYYY-MM-DD` day.
+///
+/// Shape only. A day this accepts still orders correctly against another one it accepts, which is
+/// all [`Claim::decide`] asks of it, and a full calendar here would be a date library nobody needs.
+fn is_day(text: &str) -> bool {
+    let bytes = text.as_bytes();
+    bytes.len() == 10
+        && bytes[4] == b'-'
+        && bytes[7] == b'-'
+        && bytes
+            .iter()
+            .enumerate()
+            .all(|(at, byte)| at == 4 || at == 7 || byte.is_ascii_digit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The claim the rest of these grade against, with the bar C0002 registered.
+    fn claim() -> Claim {
+        registered("C0002").expect("C0002 is registered")
+    }
+
+    fn measured(value: f64, resolution: f64, caveats: Vec<Caveat>) -> Attempt {
+        Attempt::Measured(Measured {
+            day: "2026-09-06".to_owned(),
+            value,
+            resolution,
+            caveats,
+        })
+    }
+
+    #[test]
+    fn every_carried_claim_parses_and_has_an_identifier() {
+        let claims = registry();
+        assert!(!claims.is_empty());
+        for claim in &claims {
+            assert!(claim.id.starts_with('C'), "{}", claim.id);
+            assert!(!claim.title.is_empty(), "{}", claim.id);
+            assert!(!claim.bar.reading.is_empty(), "{}", claim.id);
+        }
+    }
+
+    #[test]
+    fn a_claim_is_found_however_its_identifier_is_typed() {
+        assert_eq!(registered("c0002").map(|claim| claim.id), Some(claim().id));
+        assert!(registered("C9999").is_none());
+    }
+
+    #[test]
+    fn the_registered_bar_is_the_one_the_ledger_prints() {
+        // If somebody widens the bar in the file, this is the test that has to be edited too, which
+        // is the point at which moving a threshold stops being a quiet change.
+        let claim = claim();
+        assert!((claim.bar.tolerance - 0.03).abs() < 1e-12);
+        assert!((claim.bar.target - 1.0).abs() < 1e-12);
+        assert_eq!(claim.purpose, Purpose::Confirmatory);
+        assert!(claim.citable());
+    }
+
+    #[test]
+    fn a_claim_nobody_has_run_is_pending() {
+        assert_eq!(claim().decide(None).unwrap(), Verdict::Pending);
+    }
+
+    #[test]
+    fn the_windowed_path_at_the_span_iris_ships_did_not_reproduce() {
+        // The numbers C0002 actually came back with. Forty three percent off a three percent bar is
+        // outside it by far more than the nine percent the instrument cannot see, so this is
+        // decided rather than left open.
+        let verdict = claim()
+            .decide(Some(&measured(1.4351, 0.0888, Vec::new())))
+            .unwrap();
+        assert_eq!(verdict, Verdict::NotReproduced);
+    }
+
+    #[test]
+    fn a_reading_the_instrument_cannot_tell_from_the_bar_is_not_decided_either_way() {
+        // The same claim at a span that holds the whole file: three percent off a three percent bar,
+        // with a control that puts two copies of one buffer nine percent apart. Calling that a pass
+        // or a failure would be reporting the harness.
+        let verdict = claim()
+            .decide(Some(&measured(0.9672, 0.0888, Vec::new())))
+            .unwrap();
+        assert_eq!(verdict, Verdict::NotAttemptable);
+    }
+
+    #[test]
+    fn a_caveat_cannot_turn_a_failure_into_anything_softer() {
+        let with = claim()
+            .decide(Some(&measured(1.4351, 0.0, vec![Caveat::GatesOverridden])))
+            .unwrap();
+        let without = claim()
+            .decide(Some(&measured(1.4351, 0.0, Vec::new())))
+            .unwrap();
+        assert_eq!(with, Verdict::NotReproduced);
+        assert_eq!(with, without);
+    }
+
+    #[test]
+    fn a_caveat_is_the_whole_difference_between_the_two_spellings_of_a_pass() {
+        let clean = claim()
+            .decide(Some(&measured(1.01, 0.0, Vec::new())))
+            .unwrap();
+        let noted = claim()
+            .decide(Some(&measured(1.01, 0.0, vec![Caveat::UntestedPlatform])))
+            .unwrap();
+        assert_eq!(clean, Verdict::Reproduced);
+        assert_eq!(noted, Verdict::ReproducedWithCaveat);
+    }
+
+    #[test]
+    fn a_measurement_older_than_its_own_threshold_is_not_graded() {
+        let early = Attempt::Measured(Measured {
+            day: "2026-09-03".to_owned(),
+            value: 1.0,
+            resolution: 0.0,
+            caveats: Vec::new(),
+        });
+        let error = claim().decide(Some(&early)).unwrap_err();
+        assert!(
+            matches!(error, Ungradable::Backdated { .. }),
+            "{error:?}, and a threshold written after the number is not a threshold"
+        );
+    }
+
+    #[test]
+    fn an_unattemptable_claim_has_to_say_where_the_artifact_was_looked_for() {
+        let refused = |citation: &str| {
+            Attempt::Refused(Refused {
+                day: "2026-09-06".to_owned(),
+                what: "the artifact is not published anywhere we could find".to_owned(),
+                citation: citation.to_owned(),
+            })
+        };
+
+        let error = claim().decide(Some(&refused("   "))).unwrap_err();
+        assert!(matches!(error, Ungradable::NoCitation { .. }), "{error:?}");
+
+        let cited = refused("the paper's artifact link, dead as of the day above");
+        assert_eq!(
+            claim().decide(Some(&cited)).unwrap(),
+            Verdict::NotAttemptable
+        );
+    }
+
+    #[test]
+    fn a_registration_that_does_not_say_where_cannot_be_graded() {
+        let mut claim = claim();
+        claim.registered.source = String::new();
+        let error = claim.decide(None).unwrap_err();
+        assert!(
+            matches!(error, Ungradable::Unregistered { .. }),
+            "{error:?}"
+        );
+    }
+
+    #[test]
+    fn a_day_that_is_not_a_day_is_refused_rather_than_compared() {
+        // Two strings that are not both YYYY-MM-DD do not order the way their dates do, so this is
+        // checked instead of letting the ordering check quietly answer with nonsense.
+        assert!(is_day("2026-09-04"));
+        assert!(!is_day("2026-9-4"));
+        assert!(!is_day("4 September 2026"));
+        assert!(!is_day(""));
+
+        let mut claim = claim();
+        claim.registered.day = "September 2026".to_owned();
+        let error = claim.decide(None).unwrap_err();
+        assert!(matches!(error, Ungradable::NotADay { .. }), "{error:?}");
+    }
+
+    #[test]
+    fn a_tolerance_that_is_a_fraction_of_zero_is_refused() {
+        let mut claim = claim();
+        claim.bar.target = 0.0;
+        let error = claim
+            .decide(Some(&measured(1.0, 0.0, Vec::new())))
+            .unwrap_err();
+        assert!(
+            matches!(error, Ungradable::RelativeToNothing { .. }),
+            "{error:?}"
+        );
+    }
+
+    #[test]
+    fn the_five_words_round_trip_and_nothing_else_parses() {
+        for verdict in Verdict::all() {
+            assert_eq!(verdict.word().parse::<Verdict>().unwrap(), verdict);
+            assert_eq!(verdict.to_string(), verdict.word());
+            // The stored spelling and the printed one are one string, so a file cannot disagree
+            // with a terminal about what happened.
+            let json = serde_json::to_string(&verdict).unwrap();
+            assert_eq!(json, format!("\"{}\"", verdict.word()));
+        }
+        for not in ["reproduced", "MOSTLY-REPRODUCED", "INCONCLUSIVE", ""] {
+            assert!(not.parse::<Verdict>().is_err(), "{not} parsed");
+        }
+    }
+
+    #[test]
+    fn the_instrument_a_claim_names_carries_what_it_would_be_run_with() {
+        let Instrument::Resident(resident) = claim().instrument;
+        assert_eq!(resident.size, 256 * 1024 * 1024);
+        assert_eq!(resident.span, 4 * 1024 * 1024);
+        assert_eq!(resident.chunk, 256 * 1024);
+        assert_eq!(resident.pairs, 60);
+    }
+
+    #[test]
+    fn an_instrument_this_repository_does_not_have_fails_to_parse() {
+        // A claim that named an instrument nobody wrote would sit in the ledger looking registered
+        // while nothing could ever settle it, so it is refused at the point the file is read.
+        let text = "\
+id = \"C0000\"
+title = \"something nobody can measure\"
+purpose = \"confirmatory\"
+
+[registered]
+day = \"2026-09-04\"
+source = \"nowhere\"
+
+[bar]
+reading = \"a thing over another thing\"
+target = 1.0
+tolerance = 0.03
+
+[instrument.telepathy]
+";
+        assert!(toml::from_str::<Claim>(text).is_err());
+    }
+}

--- a/crates/bench-store/src/lib.rs
+++ b/crates/bench-store/src/lib.rs
@@ -7,8 +7,15 @@
 //! Nothing is deleted. Corrections are new rows that reference the run they
 //! correct.
 //!
-//! Nothing is implemented yet. See the milestone that owns this crate in
-//! `docs/ROADMAP.md`.
+//! What is implemented so far is [`claim`], which is the half of this crate
+//! that decides what a result means rather than where it is kept. It carries
+//! the registered claims, the five verdicts and the arithmetic that turns a
+//! reading into one of them. The storage half is the milestone that owns this
+//! crate in `docs/ROADMAP.md`.
+
+pub mod claim;
+
+pub use claim::{Attempt, Bar, Caveat, Claim, Measured, Purpose, Refused, Ungradable, Verdict};
 
 /// The version of this crate, as reported by build metadata.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/deny.toml
+++ b/deny.toml
@@ -39,6 +39,19 @@ allow = [
 name = "webpki-roots"
 allow = ["CDLA-Permissive-2.0"]
 
+# libbz2-rs-sys arrives under DataFusion, through async-compression and the bzip2
+# crate, and carries the bzip2 licence rather than a common one. It is a permissive
+# BSD style licence with no copyleft in it and it is compatible with Apache-2.0, so
+# the only reason it is not in the general allow list is that nothing else here uses
+# it and a second crate showing up under it should be looked at by a person. Nothing
+# in this repository turns that codec on. It is in the graph because DataFusion is
+# taken with its default features, which is what DataFusion's own benchmark entries
+# build with, and reducing the features to dodge a licence check would change the
+# system under test.
+[[licenses.exceptions]]
+name = "libbz2-rs-sys"
+allow = ["bzip2-1.0.6"]
+
 # The harness itself must not link anything under a strong copyleft licence.
 # Systems under test are a different matter: they run in their own processes,
 # and a GPL licensed database is perfectly fine to benchmark.

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -12,6 +12,24 @@ A claim gets an identifier when it is registered, and the identifier is what oth
 
 **Verdict** is recorded whichever way it goes. A claim that fails its own threshold stays on this page with the failure written out.
 
+## The five verdicts
+
+REPRODUCED, REPRODUCED-WITH-CAVEAT, NOT-REPRODUCED, NOT-ATTEMPTABLE, PENDING. The set is closed and the spelling is fixed, and that is the only reason it is worth having. A vocabulary somebody can extend grows a gentler word every time a result comes out badly, and the gentler word is the one that gets quoted.
+
+The three that follow from a measurement are not chosen by a person. `bench_store::claim` takes the reading, the threshold and what the instrument can resolve, and returns the word, so the wording of a result is arithmetic rather than a decision made after seeing the number. A reading outside the bar is NOT-REPRODUCED whatever else was true about the run: a caveat can turn a REPRODUCED into a REPRODUCED-WITH-CAVEAT and it can never turn a loss into anything softer.
+
+NOT-ATTEMPTABLE is a fact about our circumstances and is worded that way. It is not a criticism of anyone's work. Two things reach it. One is an artifact that cannot be obtained or cannot be run here, which has to carry a citation saying where it was looked for, because an unsupported assertion that something was unavailable is not better than no entry at all. The other is a bar narrower than what our instrument can resolve, where the honest answer is that this harness cannot settle the question either way. C0002 below is the second kind at one of its spans.
+
+What is not a verdict is a claim whose instrument nobody has written yet. That is a gap in this repository's work, and giving it a word would put a finished looking row on a page for something that was never attempted, so `iris-bench reproduce` errors on it instead.
+
+## Running one
+
+`iris-bench reproduce C0002` reads the registration, runs what it names, and prints the word with the arithmetic that produced it. Unlike the gates it exits zero on every verdict, because a failed reproduction is a result rather than a broken build.
+
+The registrations it reads are committed files under `crates/bench-store/claims/`, one per claim, and they are the registration rather than a copy of it. The threshold in front of a reader is the one in version control, and the tool refuses to grade a reading taken before the day its own threshold was registered.
+
+C0001 is not among them. It registered three bands rather than one bar, and the registry models a single threshold and a single reading, so retrofitting a word onto it would mean inventing a reading it never had. It stays prose until the registry can hold the shape it was actually registered in.
+
 ## This file is maintained by hand, for now
 
 It should be generated from the results store, and it is not, because the store is a stub. A ledger somebody edits drifts within weeks and it drifts in the flattering direction without anybody deciding to do that, which is why replacing this file with a generated one is issue #27 rather than a nice to have. Until then the entries are written out longhand and each one names the artifact its numbers came from, so the drift is at least checkable against something.
@@ -47,7 +65,7 @@ The four rows agree on the band and on which shape decides it, which is the thin
 
 ### C0002, what the sliding window costs on a file that is already resident
 
-**Status** measured, and the threshold is not decidable with the instrument that exists. **Purpose** confirmatory. **Registered** 2026-09-04, in `tamnd/iris` issue #26 and in the M4 checklist of that repository. **Measured** 2026-09-06.
+**Status** measured. **Purpose** confirmatory. **Registered** 2026-09-04, in `tamnd/iris` issue #26 and in the M4 checklist of that repository, and carried as `crates/bench-store/claims/C0002.toml` so that `iris-bench reproduce C0002` runs it. **Measured** 2026-09-06.
 
 **Threshold**, committed in advance: a scan of a resident local file through the windowed path stays within three percent of a scan of the same bytes handed over as one buffer. There is no band structure here. Either the abstraction is free on the easy case or hosts will keep a second code path for resident files, which is the outcome the whole source design exists to avoid.
 
@@ -55,7 +73,7 @@ The four rows agree on the band and on which shape decides it, which is the thin
 
 **Machine class.** The i9-13900K under Linux, pinned, which is the only machine in the fleet whose noise floor in `MACHINES.md` sits under three percent. Ratios only, taken inside one run, which is what this claim is.
 
-**Verdict.** Not held at the span iris ships, and not decidable at any span, for two separate reasons that are worth keeping apart.
+**Verdict.** NOT-REPRODUCED at the span iris ships, and NOT-ATTEMPTABLE at a span that holds the file, for two separate reasons that are worth keeping apart.
 
 At the four mebibyte span that `iris_source::DEFAULT_SPAN` sets, a 256 mebibyte scan runs at 143.51% of the buffer path, interval 142.63% to 144.42%. At a span that holds the whole file it runs at 96.72%, interval 96.46% to 97.11%. That is a large effect and its cause is not the abstraction.
 

--- a/docs/METHODOLOGY.md
+++ b/docs/METHODOLOGY.md
@@ -84,6 +84,16 @@ The same applies to a system that answers one query two different ways across it
 
 Every claim this repository intends to test is registered before it is run, with the threshold that decides it. Rows carry a purpose field, either confirmatory or exploratory, and an exploratory row cannot be cited as a claim. A claim that was registered and not run shows in the ledger as pending, which makes quietly dropping an inconvenient result visible as a gap in a committed file.
 
+A registration is a committed file rather than a sentence asserting that one was made, so the ordering is checkable by anybody with the repository in front of them, and the tool refuses to grade a reading taken before the day its own threshold was registered. A threshold written after the number exists is not a threshold, it is a description of the number, and the two look identical on the page a reader eventually sees.
+
+The verdict is one of five words and there is no sixth: REPRODUCED, REPRODUCED-WITH-CAVEAT, NOT-REPRODUCED, NOT-ATTEMPTABLE, PENDING. The three that follow from a measurement are produced by arithmetic over the reading, the threshold and what the instrument can resolve, not chosen by somebody who has just seen how it came out. A vocabulary that can be extended grows a gentler word every time a result is disappointing, and the gentler word is the one that gets quoted.
+
+A caveat cannot rescue a failure. A reading outside the bar is NOT-REPRODUCED whatever else was true about the run, and the only thing a caveat does is turn a pass into a pass with the condition stated next to it. Softening a loss with a note about the circumstances is the exact move the fixed vocabulary exists to prevent.
+
+NOT-ATTEMPTABLE is a fact about our circumstances and is worded that way. An artifact that cannot be obtained reaches it and has to carry a citation saying where it was looked for. So does a bar narrower than what the instrument can resolve, which is why a claim settled by a comparison runs its own control in the same session: a harness that cannot put two copies of one thing closer than nine percent cannot report that two different things are three percent apart. A reading that close to its bar is recorded as undecided rather than graded, and the bar is not widened to a number the instrument happens to clear.
+
+What is not a verdict at all is a claim whose instrument nobody has written yet. That is a gap in this repository's work, and giving it a word would put a finished looking row on a page for something that was never attempted.
+
 ## What gets thrown away
 
 Only runs that failed a gate that was declared in advance. Removing an outlier after looking at it is prohibited, and so is running an experiment repeatedly and publishing the run that worked. The purpose field makes the second one mechanical rather than a matter of discipline.


### PR DESCRIPTION
Closes #22.

A claim this project intends to make is now a committed file rather than a paragraph, and `iris-bench reproduce C0002` reads that file, runs the instrument it names, and prints one of five words. The registrations live in `crates/bench-store/claims/`, one TOML file per claim, carrying the identifier, the purpose, the day and place it was registered, the threshold, and the settings the instrument is to be run with. That last part matters more than it looks: a registration that reads its numbers from whatever the tool currently defaults to is a registration whose threshold can be moved without editing it.

The vocabulary is REPRODUCED, REPRODUCED-WITH-CAVEAT, NOT-REPRODUCED, NOT-ATTEMPTABLE and PENDING, and there is no sixth. The set being closed is the only reason it is worth having, because a vocabulary somebody can extend grows a gentler word every time a result comes out badly and the gentler word is the one that gets quoted.

The three that follow from a measurement are not chosen by a person. `Bar::decide` is the only thing that produces them and it takes three numbers, the reading's distance from the target, the tolerance, and what the instrument can resolve. A caveat can turn a pass into a pass with the condition next to it and it can never turn a loss into anything softer, which is the exact move the fixed set exists to prevent.

NOT-ATTEMPTABLE is reached two ways and both are facts about our circumstances rather than criticism of anybody's work. One is an artifact that cannot be obtained or run here, which has to carry a citation saying where it was looked for, since an unsupported assertion that something was unavailable is not better than no entry. The other is a bar narrower than what the instrument can resolve, and that is why `reproduce` runs the control first and grades against its interval. A harness that cannot put two copies of one buffer closer than nine percent has no business reporting that two different things are three percent apart. The control comes first rather than after, because running it afterwards would mean grading the reading against a resolution measured on a machine that had since changed.

Run against C0002 the arithmetic lands exactly where the prose in `docs/CLAIMS.md` already had it, NOT-REPRODUCED at the four mebibyte span iris ships and NOT-ATTEMPTABLE at a span that holds the file. That was the strongest check available that the rule matches what a person reading the same numbers concluded.

Three things are errors rather than verdicts. A claim nobody registered, a reading taken before the day its own threshold was written down, and a claim whose instrument nobody has built yet. The last one is deliberate: giving unwritten work a word would put a finished looking row on a page for something that was never attempted. Everything else exits zero whichever word it lands on, because a failed reproduction is a result and not a broken build.

`resident` gained a `measure` and `report` split so that `reproduce` can take a reading without printing a gate report at the terminal. That also drops `report` from eleven arguments to two and removes the `too_many_arguments` allow that was sitting on it.

## The four CI fixes in the first commit

These are unrelated to the above and are what CI on `main` has been failing on since before #105. The local gate does not run `cargo deny`, does not cross compile for Windows, and does not resolve action tags, so all four passed locally and failed on push.

`fit` in the ClickBench tests always produced a value and wrapped it in an `Option`, which pedantic flags. It now returns the record and the four call sites wrap it, which also reads closer to what the tests are saying.

`bench-run` called `libc::geteuid` guarded by a runtime `cfg!` rather than a `cfg` attribute, so it had to compile on Windows where that function does not exist. It is now two attributed functions and the non unix one returns the same answer every non root process gets.

`libbz2-rs-sys` arrives under DataFusion's default features through `async-compression` and carries the bzip2 licence, which `cargo deny` rejected. It gets a scoped exception with the reasoning written next to it rather than a feature change, because reducing DataFusion's features to dodge a licence check would change the system under test.

OpenSSF publishes no floating major tag for `scorecard-action`, only exact versions, so `v2` resolves to nothing and the job fails when it tries to download the action. It is pinned to `v2.4.4` with a comment saying why the major version rule cannot apply there.

## Checks

The full local gate is green: fmt, clippy at `-D warnings` across all targets and features, both discipline checks, the workspace tests, the doc tests, rustdoc at `-D warnings`, and `cargo check --locked`. `bench-store` gained sixteen tests and a doc test, `bench-cli` five more.
